### PR TITLE
fix(client): Expose plugin action dispatchers in React client

### DIFF
--- a/src/client/react.js
+++ b/src/client/react.js
@@ -124,6 +124,7 @@ export function Client(opts) {
           isMultiplayer: !!multiplayer,
           moves: this.client.moves,
           events: this.client.events,
+          plugins: this.client.plugins,
           gameID: this.client.gameID,
           playerID: this.client.playerID,
           reset: this.client.reset,


### PR DESCRIPTION
`client.plugins` contains dispatcher for plugin actions, but these aren’t currently exposed to the React client.

## To-do

- [ ] Expose plugin dispatchers in props. The `plugins` namespace is already used by `state.plugins`, because `state` is destructured into props, so some other API might be needed.

- [ ] Add tests for the plugin dispatchers.