### PR TITLE
feat: Add plain JS lobby client

### DIFF
--- a/docs/documentation/api/Lobby.md
+++ b/docs/documentation/api/Lobby.md
@@ -25,9 +25,9 @@ The [Server](/api/Server) hosts the Lobby REST API that can be used to create an
 authenticate clients to prove that they have the right to send
 actions on behalf of a player.
 
-Authenticated games are created with server-side tokens for each player. You can create a match with the `create` API call, and join a player to a match with the `join` API call.
+Authenticated matches are created with server-side tokens for each player. You can create a match with the `create` API call, and join a player to a match with the `join` API call.
 
-A game that is authenticated will not accept moves from a client on behalf of a player without the appropriate credential token.
+A match that is authenticated will not accept moves from a client on behalf of a player without the appropriate credential token.
 
 Use the `create` API call to create a match that requires credential tokens. When you call the `join` API, you can retrieve the credential token for a particular player.
 
@@ -42,7 +42,7 @@ server.run({ port: 8000, lobbyConfig });
 
 Options are:
 
-- `apiPort`: If specified, it runs the Lobby API in a separate Koa server on this port. Otherwise, it shares the same Koa server runnning on the default boardgame.io `port`.
+- `apiPort`: If specified, it runs the Lobby API in a separate Koa server on this port. Otherwise, it shares the same Koa server running on the default boardgame.io `port`.
 - `apiCallback`: Called when the Koa server is ready. Only applicable if `apiPort` is specified.
 
 #### Creating a match
@@ -61,7 +61,7 @@ Accepts three parameters:
 
 Returns `matchID`, which is the ID of the newly created game instance.
 
-#### Joining a game
+#### Joining a match
 
 ##### POST `/games/{name}/{id}/join`
 
@@ -69,29 +69,29 @@ Allows a player to join a particular match instance `id` of a game named `name`.
 
 Accepts three JSON body parameters:
 
-- `playerID` (required): the ordinal player in the game that is being joined (0, 1...).
+- `playerID` (required): the ordinal player in the match that is being joined (0, 1...).
 
-- `playerName` (required): the display name of the player joining the game.
+- `playerName` (required): the display name of the player joining the match.
 
-- `data` (optional): additional information associated to the player.
+- `data` (optional): additional metadata to associate with the player.
 
 Returns `playerCredentials` which is the token this player will require to authenticate their actions in the future.
 
-#### Update a player's information
+#### Updating a player’s metadata
 
 ##### POST `/games/{name}/{id}/update`
 
-Rename and/or update additional information of a user in the match instance `id` of a game named `name` previously joined by the player.
+Rename and/or update additional metadata for a player in the match instance `id` of a game named `name` previously joined by the player.
 
 Accepts four parameters, requires at least one of the two optional parameters:
 
-- `playerID` (required): the ID used by the player in the game (0,1...).
+- `playerID` (required): the ID used by the player in the match (0,1...).
 
-- `crendentials` (required): the authentication token of the player.
+- `credentials` (required): the authentication token of the player.
 
 - `newName` (optional): the new name of the player.
 
-- `data` (optional): additional information associated to the player.
+- `data` (optional): additional metadata to associate with the player.
 
 #### Leaving a match
 
@@ -101,7 +101,7 @@ Leave the match instance `id` of a game named `name` previously joined by the pl
 
 Accepts two parameters, all required:
 
-- `playerID`: the ID used by the player in the game (0, 1...).
+- `playerID`: the ID used by the player in the match (0, 1...).
 
 - `credentials`: the authentication token of the player.
 
@@ -119,7 +119,7 @@ Returns an array of `matches`. Each instance has fields:
 
 - `setupData` (optional): custom object that was passed to the game `setup` function.
 
-#### Getting specific instance of a match by its ID
+#### Getting a specific match by its ID
 
 ##### GET `/games/{name}/{id}`
 
@@ -129,13 +129,9 @@ Returns a match instance. Each instance has fields:
 
 - `matchID`: the ID of the match instance.
 
-- `players`: the list of seats and players that have joined the game, if any.
+- `players`: the list of seats and players that have joined the match, if any.
 
 - `setupData` (optional): custom object that was passed to the game `setup` function.
-
-#### Client Authentication
-
-All actions for an authenticated game require an additional payload field `credentials`, which must be the given secret associated with the player.
 
 #### Playing again
 
@@ -149,12 +145,12 @@ Given a previous match, generates a match ID where users should go if they want 
 
 Accepts these parameters:
 
-- `playerID` (required): the player ID of the player on the previous game.
+- `playerID` (required): the player ID of the player in the previous match.
 
 - `credentials` (required): player's credentials.
 
-`numPlayers` (optional): the number of players. Defaults to the `numPlayers` value of the previous room.
+- `numPlayers` (optional): the number of players. Defaults to the `numPlayers` value of the previous match.
 
-`setupData` (optional): custom object that was passed to the game `setup` function. Defaults to the `setupData` object of the previous room.
+- `setupData` (optional): custom object that was passed to the game `setup` function. Defaults to the `setupData` object of the previous room.
 
 Returns `nextMatchID`, which is the ID of the newly created match that the user should go to play again.

--- a/docs/documentation/api/Server.md
+++ b/docs/documentation/api/Server.md
@@ -69,6 +69,27 @@ server.run(8000);
 server.run(8000, () => console.log("server running..."));
 ```
 
+#### With custom Lobby settings
+
+You can pass `lobbyConfig` to configure the Lobby API during server startup:
+
+```js
+const lobbyConfig = {
+  apiPort: 8080,
+  apiCallback: () => console.log('Running Lobby API on port 8080...'),
+};
+
+server.run({ port: 8000, lobbyConfig });
+```
+
+Options are:
+
+- `apiPort`: If specified, it runs the Lobby API in a separate Koa server on
+this port. Otherwise, it shares the same Koa server running on the default
+boardgame.io `port`.
+- `apiCallback`: Called when the Koa server is ready. Only applicable if
+`apiPort` is specified.
+
 #### With HTTPS
 
 ```js

--- a/packages/client.ts
+++ b/packages/client.ts
@@ -7,5 +7,6 @@
  */
 
 import { Client } from '../src/client/client';
+import { LobbyClient } from '../src/lobby/client';
 
-export { Client };
+export { Client, LobbyClient };

--- a/src/lobby/client.test.ts
+++ b/src/lobby/client.test.ts
@@ -101,6 +101,50 @@ describe('LobbyClient', () => {
     });
 
     test('validates gameName', throwsWithInvalidGameName(client.listMatches));
+
+    describe('builds filter queries', () => {
+      test('kitchen sink', async () => {
+        await client.listMatches('chess', {
+          isGameover: false,
+          updatedBefore: 3000,
+          updatedAfter: 1000,
+        });
+        expect(fetch).toBeCalledWith(
+          '/games/chess?isGameover=false&updatedBefore=3000&updatedAfter=1000',
+          undefined
+        );
+      });
+
+      test('isGameover', async () => {
+        await client.listMatches('chess', { isGameover: undefined });
+        expect(fetch).toBeCalledWith('/games/chess', undefined);
+        await client.listMatches('chess', { isGameover: false });
+        expect(fetch).toBeCalledWith(
+          '/games/chess?isGameover=false',
+          undefined
+        );
+        await client.listMatches('chess', { isGameover: true });
+        expect(fetch).toBeCalledWith('/games/chess?isGameover=true', undefined);
+      });
+
+      test('updatedBefore', async () => {
+        const updatedBefore = 1989;
+        await client.listMatches('chess', { updatedBefore });
+        expect(fetch).toBeCalledWith(
+          '/games/chess?updatedBefore=1989',
+          undefined
+        );
+      });
+
+      test('updatedAfter', async () => {
+        const updatedAfter = 1970;
+        await client.listMatches('chess', { updatedAfter });
+        expect(fetch).toBeCalledWith(
+          '/games/chess?updatedAfter=1970',
+          undefined
+        );
+      });
+    });
   });
 
   describe('getMatch', () => {

--- a/src/lobby/client.test.ts
+++ b/src/lobby/client.test.ts
@@ -1,0 +1,271 @@
+import { LobbyClient } from './client';
+
+const throwsWithoutBody = (fn: (...args: any) => Promise<any>) => async () => {
+  await expect(fn('tic-tac-toe')).rejects.toThrow(
+    `Expected body, got “undefined”.`
+  );
+};
+
+const testStringValidation = (
+  fn: (arg: any) => Promise<any>,
+  label: string
+) => async () => {
+  await expect(fn(undefined)).rejects.toThrow(
+    `Expected ${label} string, got "undefined".`
+  );
+  await expect(fn(2)).rejects.toThrow(`Expected ${label} string, got "2".`);
+  await expect(fn('')).rejects.toThrow(`Expected ${label} string, got "".`);
+};
+
+const throwsWithInvalidGameName = (fn: (...args: any) => Promise<any>) =>
+  testStringValidation(fn, 'game name');
+
+const throwsWithInvalidMatchID = (fn: (...args: any) => Promise<any>) =>
+  testStringValidation((matchID: string) => fn('chess', matchID), 'match ID');
+
+const testBasicBody = (fn: (...args: any) => Promise<any>) => async () => {
+  await expect(
+    fn('chess', '1', { playerID: undefined, credentials: 'pwd' })
+  ).rejects.toThrow(
+    'Expected body.playerID to be of type string, got “undefined”.'
+  );
+
+  await expect(
+    fn('chess', '2', { playerID: '0', credentials: (0 as unknown) as string })
+  ).rejects.toThrow('Expected body.credentials to be of type string, got “0”.');
+};
+
+describe('LobbyClient', () => {
+  let client = new LobbyClient();
+
+  beforeEach(async () => {
+    (global as any).fetch = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => {},
+    }));
+  });
+
+  describe('construction', () => {
+    test('basic', async () => {
+      await client.listGames();
+      expect(fetch).toBeCalledWith(`/games`, undefined);
+    });
+
+    test('with server address', async () => {
+      const client = new LobbyClient({ server: 'http://api.io' });
+      await client.listGames();
+      expect(fetch).toBeCalledWith(`http://api.io/games`, undefined);
+    });
+
+    test('with server address with trailing slash', async () => {
+      const client = new LobbyClient({ server: 'http://api.io/' });
+      await client.listGames();
+      expect(fetch).toBeCalledWith(`http://api.io/games`, undefined);
+    });
+  });
+
+  describe('status errors', () => {
+    beforeEach(async () => {
+      (global as any).fetch = jest.fn(async () => ({
+        ok: false,
+        status: 404,
+        json: async () => {},
+      }));
+      client = new LobbyClient();
+    });
+
+    test('404 throws an error', async () => {
+      await expect(client.listGames()).rejects.toThrow('HTTP status 404');
+    });
+  });
+
+  describe('listGames', () => {
+    test('calls `/games`', async () => {
+      await client.listGames();
+      expect(fetch).toBeCalledWith('/games', undefined);
+    });
+
+    test('init can be customized', async () => {
+      await client.listGames({ headers: { Authorization: 'pwd' } });
+      expect(fetch).toBeCalledWith('/games', {
+        headers: { Authorization: 'pwd' },
+      });
+    });
+  });
+
+  describe('listMatches', () => {
+    test('calls `/games/:name`', async () => {
+      await client.listMatches('tic-tac-toe');
+      expect(fetch).toBeCalledWith(`/games/tic-tac-toe`, undefined);
+    });
+
+    test('validates gameName', throwsWithInvalidGameName(client.listMatches));
+  });
+
+  describe('getMatch', () => {
+    test('calls `/games/:name/:id`', async () => {
+      await client.getMatch('tic-tac-toe', 'xyz');
+      expect(fetch).toBeCalledWith(`/games/tic-tac-toe/xyz`, undefined);
+    });
+
+    test('validates gameName', throwsWithInvalidGameName(client.getMatch));
+    test('validates matchID', throwsWithInvalidMatchID(client.getMatch));
+  });
+
+  describe('createMatch', () => {
+    test('calls `/games/:name/create`', async () => {
+      await client.createMatch('tic-tac-toe', { numPlayers: 2 });
+      expect(fetch).toBeCalledWith(`/games/tic-tac-toe/create`, {
+        method: 'post',
+        body: '{"numPlayers":2}',
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    test('validates gameName', throwsWithInvalidGameName(client.createMatch));
+
+    test('throws without body', throwsWithoutBody(client.createMatch));
+
+    test('validates body', async () => {
+      await expect(
+        client.createMatch('tic-tac-toe', {
+          numPlayers: ('12' as unknown) as number,
+        })
+      ).rejects.toThrow(
+        'Expected body.numPlayers to be of type number, got “12”.'
+      );
+    });
+
+    test('init can be customized', async () => {
+      await client.createMatch(
+        'chess',
+        { numPlayers: 2 },
+        { headers: { Authorization: 'pwd' } }
+      );
+      expect(fetch).toBeCalledWith(`/games/chess/create`, {
+        method: 'post',
+        body: '{"numPlayers":2}',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'pwd',
+        },
+      });
+    });
+  });
+
+  describe('joinMatch', () => {
+    test('calls `/games/:name/:id/join`', async () => {
+      await client.joinMatch('tic-tac-toe', 'xyz', {
+        playerID: '0',
+        playerName: 'Alice',
+      });
+      expect(fetch).toBeCalledWith(`/games/tic-tac-toe/xyz/join`, {
+        method: 'post',
+        body: '{"playerID":"0","playerName":"Alice"}',
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    test('validates gameName', throwsWithInvalidGameName(client.joinMatch));
+    test('validates matchID', throwsWithInvalidMatchID(client.joinMatch));
+
+    test(
+      'throws without body',
+      throwsWithoutBody(() => client.joinMatch('chess', 'id', undefined))
+    );
+
+    test('validates body', async () => {
+      await expect(
+        client.joinMatch('tic-tac-toe', 'xyz', {
+          playerID: (0 as unknown) as string,
+          playerName: 'Bob',
+        })
+      ).rejects.toThrow(
+        'Expected body.playerID to be of type string, got “0”.'
+      );
+
+      await expect(
+        client.joinMatch('tic-tac-toe', 'xyz', {
+          playerID: '0',
+          playerName: undefined,
+        })
+      ).rejects.toThrow(
+        'Expected body.playerName to be of type string, got “undefined”.'
+      );
+    });
+  });
+
+  describe('leaveMatch', () => {
+    test('calls `/games/:name/:id/leave`', async () => {
+      await client.leaveMatch('tic-tac-toe', 'xyz', {
+        playerID: '0',
+        credentials: 'pwd',
+      });
+      expect(fetch).toBeCalledWith(`/games/tic-tac-toe/xyz/leave`, {
+        method: 'post',
+        body: '{"playerID":"0","credentials":"pwd"}',
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    test('validates gameName', throwsWithInvalidGameName(client.leaveMatch));
+    test('validates matchID', throwsWithInvalidMatchID(client.leaveMatch));
+
+    test(
+      'throws without body',
+      throwsWithoutBody(() => client.leaveMatch('chess', 'id', undefined))
+    );
+
+    test('validates body', testBasicBody(client.leaveMatch));
+  });
+
+  describe('updatePlayer', () => {
+    test('calls `/games/:name/:id/update`', async () => {
+      await client.updatePlayer('tic-tac-toe', 'xyz', {
+        playerID: '0',
+        credentials: 'pwd',
+        newName: 'Al',
+      });
+      expect(fetch).toBeCalledWith(`/games/tic-tac-toe/xyz/update`, {
+        method: 'post',
+        body: '{"playerID":"0","credentials":"pwd","newName":"Al"}',
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    test('validates gameName', throwsWithInvalidGameName(client.updatePlayer));
+    test('validates matchID', throwsWithInvalidMatchID(client.updatePlayer));
+
+    test(
+      'throws without body',
+      throwsWithoutBody(() => client.updatePlayer('chess', 'id', undefined))
+    );
+
+    test('validates body', testBasicBody(client.updatePlayer));
+  });
+
+  describe('playAgain', () => {
+    test('calls `/games/:name/:id/playAgain`', async () => {
+      await client.playAgain('tic-tac-toe', 'xyz', {
+        playerID: '0',
+        credentials: 'pwd',
+      });
+      expect(fetch).toBeCalledWith(`/games/tic-tac-toe/xyz/playAgain`, {
+        method: 'post',
+        body: '{"playerID":"0","credentials":"pwd"}',
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    test('validates gameName', throwsWithInvalidGameName(client.playAgain));
+    test('validates matchID', throwsWithInvalidMatchID(client.playAgain));
+
+    test(
+      'throws without body',
+      throwsWithoutBody(() => client.playAgain('chess', 'id', undefined))
+    );
+
+    test('validates body', testBasicBody(client.playAgain));
+  });
+});

--- a/src/lobby/client.ts
+++ b/src/lobby/client.ts
@@ -76,11 +76,12 @@ export class LobbyClient {
   /**
    * Get a list of the matches for a specific game type on the server.
    * @param  gameName The game to list for, e.g. 'tic-tac-toe'.
+   * @param  where    Options to filter matches by update time or gameover state
    * @param  init     Optional RequestInit interface to override defaults.
    * @return Array of match metadata objects.
    *
    * @example
-   * lobbyClient.listMatches('tic-tac-toe')
+   * lobbyClient.listMatches('tic-tac-toe', where: { isGameover: false })
    *   .then(data => console.log(data.matches));
    * // => [
    * //   {
@@ -93,10 +94,37 @@ export class LobbyClient {
    */
   async listMatches(
     gameName: string,
+    where?: {
+      /**
+       * If true, only games that have ended will be returned.
+       * If false, only games that have not yet ended will be returned.
+       * Leave undefined to receive both finished and unfinished games.
+       */
+      isGameover?: boolean;
+      /**
+       * List matches last updated before a specific time.
+       * Value should be a timestamp in milliseconds after January 1, 1970.
+       */
+      updatedBefore?: number;
+      /**
+       * List matches last updated after a specific time.
+       * Value should be a timestamp in milliseconds after January 1, 1970.
+       */
+      updatedAfter?: number;
+    },
     init?: RequestInit
   ): Promise<LobbyAPI.MatchList> {
     assertGameName(gameName);
-    return this.request(`/games/${gameName}`, init);
+    let query = '';
+    if (where) {
+      const queries = [];
+      const { isGameover, updatedBefore, updatedAfter } = where;
+      if (isGameover !== undefined) queries.push(`isGameover=${isGameover}`);
+      if (updatedBefore) queries.push(`updatedBefore=${updatedBefore}`);
+      if (updatedAfter) queries.push(`updatedAfter=${updatedAfter}`);
+      if (queries.length) query = '?' + queries.join('&');
+    }
+    return this.request(`/games/${gameName}${query}`, init);
   }
 
   /**

--- a/src/lobby/client.ts
+++ b/src/lobby/client.ts
@@ -1,0 +1,292 @@
+import { LobbyAPI } from '../types';
+
+const assertString = (str: unknown, label: string) => {
+  if (!str || typeof str !== 'string') {
+    throw new Error(`Expected ${label} string, got "${str}".`);
+  }
+};
+const assertGameName = (name?: string) => assertString(name, 'game name');
+const assertMatchID = (id?: string) => assertString(id, 'match ID');
+
+const validateBody = (
+  body: { [key: string]: any } | undefined,
+  schema: { [key: string]: 'string' | 'number' | 'object' | 'boolean' }
+) => {
+  if (!body) throw new Error(`Expected body, got “${body}”.`);
+  for (const key in schema) {
+    const type = schema[key];
+    const received = body[key];
+    if (typeof received !== type) {
+      throw new Error(
+        `Expected body.${key} to be of type ${type}, got “${received}”.`
+      );
+    }
+  }
+};
+
+/**
+ * Create a boardgame.io Lobby API client.
+ * @param server The API’s base URL, e.g. `http://localhost:8000`.
+ */
+export class LobbyClient {
+  private server: string;
+
+  constructor({ server = '' }: { server?: string } = {}) {
+    // strip trailing slash if passed
+    this.server = server.replace(/\/$/, '');
+  }
+
+  private async request(route: string, init?: RequestInit) {
+    const response = await fetch(this.server + route, init);
+    if (!response.ok) throw new Error(`HTTP status ${response.status}`);
+    return response.json();
+  }
+
+  private async post(
+    route: string,
+    opts: { body?: object; init?: RequestInit }
+  ) {
+    let init: RequestInit = {
+      method: 'post',
+      body: JSON.stringify(opts.body),
+      headers: { 'Content-Type': 'application/json' },
+    };
+    if (opts.init)
+      init = {
+        ...init,
+        ...opts.init,
+        headers: { ...init.headers, ...opts.init.headers },
+      };
+    return this.request(route, init);
+  }
+
+  /**
+   * Get a list of the game names available on this server.
+   * @param  init Optional RequestInit interface to override defaults.
+   * @return Array of game names.
+   *
+   * @example
+   * lobbyClient.listGames()
+   *   .then(console.log); // => ['chess', 'tic-tac-toe']
+   */
+  async listGames(init?: RequestInit): Promise<string[]> {
+    return this.request('/games', init);
+  }
+
+  /**
+   * Get a list of the matches for a specific game type on the server.
+   * @param  gameName The game to list for, e.g. 'tic-tac-toe'.
+   * @param  init     Optional RequestInit interface to override defaults.
+   * @return Array of match metadata objects.
+   *
+   * @example
+   * lobbyClient.listMatches('tic-tac-toe').then(console.log);
+   * // => [
+   * //   {
+   * //     matchID: 'xyz',
+   * //     gameName: 'tic-tac-toe',
+   * //     players: [{ id: 0, name: 'Alice' }, { id: 1 }]
+   * //   },
+   * //   ...
+   * // ]
+   */
+  async listMatches(
+    gameName: string,
+    init?: RequestInit
+  ): Promise<LobbyAPI.MatchList> {
+    assertGameName(gameName);
+    return this.request(`/games/${gameName}`, init);
+  }
+
+  /**
+   * Get metadata for a specific match.
+   * @param  gameName The match’s game type, e.g. 'tic-tac-toe'.
+   * @param  matchID  Match ID for the match to fetch.
+   * @param  init     Optional RequestInit interface to override defaults.
+   * @return A match metadata object.
+   *
+   * @example
+   * lobbyClient.getMatch('tic-tac-toe', 'xyz').then(console.log);
+   * // => {
+   * //   matchID: 'xyz',
+   * //   gameName: 'tic-tac-toe',
+   * //   players: [{ id: 0, name: 'Alice' }, { id: 1 }]
+   * // }
+   */
+  async getMatch(
+    gameName: string,
+    matchID: string,
+    init?: RequestInit
+  ): Promise<LobbyAPI.Match> {
+    assertGameName(gameName);
+    assertMatchID(matchID);
+    return this.request(`/games/${gameName}/${matchID}`, init);
+  }
+
+  /**
+   * Create a new match for a specific game type.
+   * @param  gameName The game to create a match for, e.g. 'tic-tac-toe'.
+   * @param  body     Options required to configure match creation.
+   * @param  init     Optional RequestInit interface to override defaults.
+   * @return An object containing the created `matchID`.
+   *
+   * @example
+   * lobbyClient.createMatch('tic-tac-toe', { numPlayers: 2 })
+   *   .then(console.log);
+   * // => { matchID: 'xyz' }
+   */
+  async createMatch(
+    gameName: string,
+    body: {
+      numPlayers: number;
+      setupData?: any;
+      unlisted?: boolean;
+      [key: string]: any;
+    },
+    init?: RequestInit
+  ): Promise<LobbyAPI.CreatedMatch> {
+    assertGameName(gameName);
+    validateBody(body, { numPlayers: 'number' });
+    return this.post(`/games/${gameName}/create`, { body, init });
+  }
+
+  /**
+   * Join a match using its matchID.
+   * @param  gameName The match’s game type, e.g. 'tic-tac-toe'.
+   * @param  matchID  Match ID for the match to join.
+   * @param  body     Options required to join match.
+   * @param  init     Optional RequestInit interface to override defaults.
+   * @return Object containing `playerCredentials` for the player who joined.
+   *
+   * @example
+   * lobbyClient.joinMatch('tic-tac-toe', 'xyz', {
+   *   playerID: '1',
+   *   playerName: 'Bob',
+   * }).then(console.log);
+   * // => { playerCredentials: 'random-string' }
+   */
+  async joinMatch(
+    gameName: string,
+    matchID: string,
+    body: {
+      playerID: string;
+      playerName: string;
+      data?: any;
+      [key: string]: any;
+    },
+    init?: RequestInit
+  ): Promise<LobbyAPI.JoinedMatch> {
+    assertGameName(gameName);
+    assertMatchID(matchID);
+    validateBody(body, { playerID: 'string', playerName: 'string' });
+    return this.post(`/games/${gameName}/${matchID}/join`, { body, init });
+  }
+
+  /**
+   * Leave a previously joined match.
+   * @param  gameName The match’s game type, e.g. 'tic-tac-toe'.
+   * @param  matchID  Match ID for the match to leave.
+   * @param  body     Options required to leave match.
+   * @param  init     Optional RequestInit interface to override defaults.
+   * @return Promise resolves if successful.
+   *
+   * @example
+   * lobbyClient.leaveMatch('tic-tac-toe', 'xyz', {
+   *   playerID: '1',
+   *   credentials: 'credentials-returned-when-joining',
+   * })
+   *   .then(() => console.log('Left match.'))
+   *   .catch(error => console.error('Error leaving match', error));
+   */
+  async leaveMatch(
+    gameName: string,
+    matchID: string,
+    body: {
+      playerID: string;
+      credentials: string;
+      [key: string]: any;
+    },
+    init?: RequestInit
+  ): Promise<void> {
+    assertGameName(gameName);
+    assertMatchID(matchID);
+    validateBody(body, { playerID: 'string', credentials: 'string' });
+    await this.post(`/games/${gameName}/${matchID}/leave`, { body, init });
+  }
+
+  /**
+   * Update a player’s name or custom metadata.
+   * @param  gameName The match’s game type, e.g. 'tic-tac-toe'.
+   * @param  matchID  Match ID for the match to update.
+   * @param  body     Options required to update player.
+   * @param  init     Optional RequestInit interface to override defaults.
+   * @return Promise resolves if successful.
+   *
+   * @example
+   * lobbyClient.updatePlayer('tic-tac-toe', 'xyz', {
+   *   playerID: '0',
+   *   credentials: 'credentials-returned-when-joining',
+   *   newName: 'Al',
+   * })
+   *   .then(() => console.log('Updated player data.'))
+   *   .catch(error => console.error('Error updating data', error));
+   */
+  async updatePlayer(
+    gameName: string,
+    matchID: string,
+    body: {
+      playerID: string;
+      credentials: string;
+      newName?: string;
+      data?: any;
+      [key: string]: any;
+    },
+    init?: RequestInit
+  ): Promise<void> {
+    assertGameName(gameName);
+    assertMatchID(matchID);
+    validateBody(body, { playerID: 'string', credentials: 'string' });
+    await this.post(`/games/${gameName}/${matchID}/update`, { body, init });
+  }
+
+  /**
+   * Create a new match based on the configuration of the current match.
+   * @param  gameName The match’s game type, e.g. 'tic-tac-toe'.
+   * @param  matchID  Match ID for the match to play again.
+   * @param  body     Options required to configure match.
+   * @param  init     Optional RequestInit interface to override defaults.
+   * @return Object containing `nextMatchID`.
+   *
+   * @example
+   * lobbyClient.playAgain('tic-tac-toe', 'xyz', {
+   *   playerID: '0',
+   *   credentials: 'credentials-returned-when-joining',
+   * })
+   *   .then(({ nextMatchID }) => {
+   *     return lobbyClient.joinMatch('tic-tac-toe', nextMatchID, {
+   *       playerID: '0',
+   *       playerName: 'Al',
+   *     })
+   *   })
+   *   .then({ playerCredentials } => {
+   *     console.log(playerCredentials);
+   *   })
+   *   .catch(console.error);
+   */
+  async playAgain(
+    gameName: string,
+    matchID: string,
+    body: {
+      playerID: string;
+      credentials: string;
+      unlisted?: boolean;
+      [key: string]: any;
+    },
+    init?: RequestInit
+  ): Promise<LobbyAPI.NextMatch> {
+    assertGameName(gameName);
+    assertMatchID(matchID);
+    validateBody(body, { playerID: 'string', credentials: 'string' });
+    return this.post(`/games/${gameName}/${matchID}/playAgain`, { body, init });
+  }
+}

--- a/src/lobby/client.ts
+++ b/src/lobby/client.ts
@@ -80,7 +80,8 @@ export class LobbyClient {
    * @return Array of match metadata objects.
    *
    * @example
-   * lobbyClient.listMatches('tic-tac-toe').then(console.log);
+   * lobbyClient.listMatches('tic-tac-toe')
+   *   .then(data => console.log(data.matches));
    * // => [
    * //   {
    * //     matchID: 'xyz',

--- a/src/lobby/connection.test.js
+++ b/src/lobby/connection.test.js
@@ -6,7 +6,7 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { LobbyConnection } from './connection.js';
+import { LobbyConnection } from './connection';
 
 describe('lobby', () => {
   let lobby;

--- a/src/lobby/connection.ts
+++ b/src/lobby/connection.ts
@@ -6,6 +6,7 @@
  * https://opensource.org/licenses/MIT.
  */
 
+import React from 'react';
 import { LobbyClient } from './client';
 import { Game, LobbyAPI } from '../types';
 

--- a/src/lobby/connection.ts
+++ b/src/lobby/connection.ts
@@ -6,8 +6,33 @@
  * https://opensource.org/licenses/MIT.
  */
 
+import { Game, LobbyAPI } from '../types';
+
+interface GameComponent {
+  game: Game;
+  board: React.ComponentType<any>;
+}
+
+interface LobbyConnectionOpts {
+  server: string;
+  playerName: string;
+  playerCredentials: string;
+  gameComponents: GameComponent[];
+}
+
 class _LobbyConnectionImpl {
-  constructor({ server, gameComponents, playerName, playerCredentials }) {
+  gameComponents: GameComponent[];
+  playerName: string;
+  playerCredentials: string;
+  server: string;
+  matches: LobbyAPI.MatchList['matches'];
+
+  constructor({
+    server,
+    gameComponents,
+    playerName,
+    playerCredentials,
+  }: LobbyConnectionOpts) {
     this.gameComponents = gameComponents;
     this.playerName = playerName || 'Visitor';
     this.playerCredentials = playerCredentials;
@@ -41,25 +66,25 @@ class _LobbyConnectionImpl {
     }
   }
 
-  _getMatchInstance(matchID) {
+  _getMatchInstance(matchID: string) {
     for (let inst of this.matches) {
       if (inst['matchID'] === matchID) return inst;
     }
   }
 
-  _getGameComponents(gameName) {
+  _getGameComponents(gameName: string) {
     for (let comp of this.gameComponents) {
       if (comp.game.name === gameName) return comp;
     }
   }
 
-  _findPlayer(playerName) {
+  _findPlayer(playerName: string) {
     for (let inst of this.matches) {
       if (inst.players.some(player => player.name === playerName)) return inst;
     }
   }
 
-  async join(gameName, matchID, playerID) {
+  async join(gameName: string, matchID: string, playerID: string) {
     try {
       let inst = this._findPlayer(this.playerName);
       if (inst) {
@@ -89,7 +114,7 @@ class _LobbyConnectionImpl {
     }
   }
 
-  async leave(gameName, matchID) {
+  async leave(gameName: string, matchID: string) {
     try {
       let inst = this._getMatchInstance(matchID);
       if (!inst) throw new Error('match instance not found');
@@ -129,7 +154,7 @@ class _LobbyConnectionImpl {
     this.playerName = 'Visitor';
   }
 
-  async create(gameName, numPlayers) {
+  async create(gameName: string, numPlayers: number) {
     try {
       const comp = this._getGameComponents(gameName);
       if (!comp) throw new Error('game not found');
@@ -167,6 +192,6 @@ class _LobbyConnectionImpl {
  * Returns:
  *   A JS object that synchronizes the list of running game instances with the server and provides an API to create/join/start instances.
  */
-export function LobbyConnection(opts) {
+export function LobbyConnection(opts: LobbyConnectionOpts) {
   return new _LobbyConnectionImpl(opts);
 }

--- a/src/lobby/react.ssr.test.js
+++ b/src/lobby/react.ssr.test.js
@@ -7,7 +7,9 @@ import Lobby from './react';
 import ReactDOMServer from 'react-dom/server';
 
 /* mock server requests */
-global.fetch = jest.fn().mockReturnValue({ status: 200, json: () => [] });
+global.fetch = jest
+  .fn()
+  .mockReturnValue({ ok: true, status: 200, json: () => [] });
 
 describe('lobby', () => {
   test('is rendered', () => {

--- a/src/lobby/react.test.js
+++ b/src/lobby/react.test.js
@@ -13,7 +13,9 @@ import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 /* mock server requests */
-global.fetch = jest.fn().mockReturnValue({ status: 200, json: () => [] });
+global.fetch = jest
+  .fn()
+  .mockReturnValue({ ok: true, status: 200, json: () => [] });
 
 /* mock 'Client' component */
 function NullComponent() {

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -14,7 +14,7 @@ import cors from '@koa/cors';
 
 import { InitializeGame } from '../core/initialize';
 import * as StorageAPI from './db/base';
-import { Server, Game } from '../types';
+import { Server, LobbyAPI, Game } from '../types';
 
 /**
  * Creates a new match.
@@ -72,7 +72,7 @@ export const CreateMatch = async ({
 const createClientMatchMetadata = (
   matchID: string,
   metadata: Server.MatchMetadata
-) => {
+): LobbyAPI.Match => {
   return {
     ...metadata,
     matchID,
@@ -105,7 +105,8 @@ export const createRouter = ({
    * @return - Array of game names as string.
    */
   router.get('/games', async ctx => {
-    ctx.body = games.map(game => game.name);
+    const body: LobbyAPI.GameList = games.map(game => game.name);
+    ctx.body = body;
   });
 
   /**
@@ -140,9 +141,8 @@ export const createRouter = ({
       unlisted,
     });
 
-    ctx.body = {
-      matchID,
-    };
+    const body: LobbyAPI.CreatedMatch = { matchID };
+    ctx.body = body;
   });
 
   /**
@@ -165,9 +165,8 @@ export const createRouter = ({
         matches.push(createClientMatchMetadata(matchID, metadata));
       }
     }
-    ctx.body = {
-      matches,
-    };
+    const body: LobbyAPI.MatchList = { matches };
+    ctx.body = body;
   });
 
   /**
@@ -185,7 +184,8 @@ export const createRouter = ({
     if (!metadata) {
       ctx.throw(404, 'Match ' + matchID + ' not found');
     }
-    ctx.body = createClientMatchMetadata(matchID, metadata);
+    const body: LobbyAPI.Match = createClientMatchMetadata(matchID, metadata);
+    ctx.body = body;
   });
 
   /**
@@ -231,9 +231,8 @@ export const createRouter = ({
 
     await db.setMetadata(matchID, metadata);
 
-    ctx.body = {
-      playerCredentials,
-    };
+    const body: LobbyAPI.JoinedMatch = { playerCredentials };
+    ctx.body = body;
   });
 
   /**
@@ -334,9 +333,8 @@ export const createRouter = ({
 
     await db.setMetadata(matchID, metadata);
 
-    ctx.body = {
-      nextMatchID,
-    };
+    const body: LobbyAPI.NextMatch = { nextMatchID };
+    ctx.body = body;
   });
 
   const updatePlayerMetadata = async (ctx: Koa.Context) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -229,6 +229,8 @@ interface PhaseMap<G extends any = any, CtxWithPlugins extends Ctx = Ctx> {
 
 export interface Game<G extends any = any, CtxWithPlugins extends Ctx = Ctx> {
   name?: string;
+  minPlayers?: number;
+  maxPlayers?: number;
   seed?: string | number;
   setup?: (ctx: CtxWithPlugins, setupData?: any) => any;
   moves?: MoveMap<G, CtxWithPlugins>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -291,6 +291,27 @@ export namespace Server {
   }
 }
 
+export namespace LobbyAPI {
+  export type GameList = string[];
+  type PublicPlayerMetadata = Omit<Server.PlayerMetadata, 'credentials'>;
+  export type Match = Omit<Server.MatchMetadata, 'players'> & {
+    matchID: string;
+    players: PublicPlayerMetadata[];
+  };
+  export interface MatchList {
+    matches: Match[];
+  }
+  export interface CreatedMatch {
+    matchID: string;
+  }
+  export interface JoinedMatch {
+    playerCredentials: string;
+  }
+  export interface NextMatch {
+    nextMatchID: string;
+  }
+}
+
 export type Reducer = ReturnType<typeof CreateGameReducer>;
 export type Store = ReduxStore<State, ActionShape.Any>;
 


### PR DESCRIPTION
This PR adds:

- Types for the data returned by the Lobby API, closing #707
- A new plain JS lobby client class that is a lightweight wrapper around `fetch` and provides end-to-end typing for TS users
- It also refactors the React Lobby’s connection class to use the new plain client, which makes that class a little easier to understand.