### PR TITLE
build: Fix installing boardgame.io as a git dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint:fix": "eslint --fix .",
     "prepublishOnly": "npm run clean",
     "proxydirs": "node scripts/proxy-dirs.js",
-    "prepack": "run-s build proxydirs",
+    "prepack": "npm i && run-s build proxydirs",
     "postpack": "npm run clean",
     "prettier": "prettier --write \"{examples,src,benchmark}/**/*.{ts,js,css,md}\"",
     "changelog": "node ./scripts/changelog.js",


### PR DESCRIPTION
When installing as a git dependency, e.g. `npm i nicolodavis/boardgame.io`, the prepack script is run but will error because development dependencies aren’t available. This PR adds an `npm install` step to the prepack pipeline, which admittedly will generally be redundant, but I don’t see a way to only run it for git dependency installs and it shouldn’t cause any unwanted behaviour in other scenarios.