### PR TITLE
docs: Add Thinktank to notable_projects.md

### DIFF
--- a/docs/documentation/notable_projects.md
+++ b/docs/documentation/notable_projects.md
@@ -31,3 +31,5 @@ List of notable projects using boardgame.io. This list is not exhaustive. Feel f
 - [Multibuzzer](https://github.com/wsun/multibuzzer) - [play](https://multibuzz.app) - Simple multiplayer buzzer system for trivia night or quiz bowl.
 
 - [Udaipur](https://github.com/skvrahul/UdaipurGame) - [play](https://udaipur-game.herokuapp.com/) - Clone of Jaipur, a 2 Player Card game, with online multiplayer support.
+
+- [Thinktank](https://github.com/averycrespi/thinktank) - [play](https://thinktank.crespi.dev) - A 2-player strategy game inspired by Conundrum.


### PR DESCRIPTION
I developed a 2-player strategy game called Thinktank using boardgame.io. It's an online adaptation of a board game called Conundrum, which was designed by some alumni at my university.

It would be awesome to have Thinktank added to the notable projects list!

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
