### PR TITLE
feat: Improve consistency around “match” instead of “game”

### DIFF
--- a/docs/documentation/api/Client.md
+++ b/docs/documentation/api/Client.md
@@ -100,7 +100,7 @@ The following properties are available on a client instance:
 - `credentials`: Multiplayer authentication credentials for this player.
 
 
-- `matchMetadata`: An array containing the players that have joined
+- `matchData`: An array containing the players that have joined
   the current match via the [Lobby API](/api/Lobby.md).
 
   Example:
@@ -314,7 +314,7 @@ following as `props`:
 - `playerID`: The player ID associated with the client.
 
 
-- `matchMetadata`: An array containing the players that have joined
+- `matchData`: An array containing the players that have joined
   the current match via the [Lobby API](/api/Lobby.md).
 
     Example:

--- a/docs/documentation/api/Client.md
+++ b/docs/documentation/api/Client.md
@@ -53,8 +53,8 @@ const client = Client({
   // See `src/client/client.js` for details.
   multiplayer: false,
 
-  // Game to connect to (multiplayer).
-  gameID: 'gameID',
+  // Match to connect to (multiplayer).
+  matchID: 'matchID',
 
   // Associate the client with a player (multiplayer).
   playerID: 'playerID',
@@ -91,7 +91,7 @@ The following properties are available on a client instance:
 - `log`: The game log.
 
 
-- `gameID`: The game ID associated with the client.
+- `matchID`: The match ID associated with the client.
 
 
 - `playerID`: The player ID associated with the client.
@@ -101,7 +101,7 @@ The following properties are available on a client instance:
 
 
 - `matchMetadata`: An array containing the players that have joined
-  the match from a [room](/api/Lobby.md).
+  the current match via the [Lobby API](/api/Lobby.md).
 
   Example:
 
@@ -175,7 +175,7 @@ The following methods are available on a client instance:
 - `redo()`: Function that redoes the previously undone move.
 
 
-- `updateGameID(id)`: Function to update the client’s game ID.
+- `updateMatchID(id)`: Function to update the client’s match ID.
 
 
 - `updatePlayerID(id)`: Function to update the client’s player ID.
@@ -202,8 +202,8 @@ A React component that runs the client.
 
 The component supports the following `props`:
 
-1. `gameID` (_string_):
-   Connect to a particular game (multiplayer).
+1. `matchID` (_string_):
+   Connect to a particular match (multiplayer).
 
 2. `playerID` (_string_):
    Associate the client with a player (multiplayer).
@@ -308,14 +308,14 @@ following as `props`:
 - `log`: The game log.
 
 
-- `gameID`: The game ID associated with the client.
+- `matchID`: The match ID associated with the client.
 
 
 - `playerID`: The player ID associated with the client.
 
 
 - `matchMetadata`: An array containing the players that have joined
-  the game from a [room](/api/Lobby.md).
+  the current match via the [Lobby API](/api/Lobby.md).
 
     Example:
 

--- a/docs/documentation/multiplayer.md
+++ b/docs/documentation/multiplayer.md
@@ -299,35 +299,35 @@ const TicTacToe = {
 
 By default all client instances connect to a game with
 an ID `'default'`. To play a new game instance, you can pass
-`gameID` to your client. All clients that use
+`matchID` to your client. All clients that use
 this ID will now see the same game state.
 
 <!-- tabs:start -->
 
 #### **Plain JS**
 
-Pass `gameID` when creating your boardgame.io client:
+Pass `matchID` when creating your boardgame.io client:
 ```js
 const client = Client({
   game: TicTacToe,
-  gameID: 'gameid',
+  matchID: 'matchID',
   // ...
 });
 ```
 
-You an also update a `gameID` on an already instantiated client:
+You an also update a `matchID` on an already instantiated client:
 ```js
-client.updateGameID('newGameID');
+client.updateMatchID('newID');
 ```
 
 #### **React**
 
 ```
-<TicTacToeClient gameID="gameid"/>
+<TicTacToeClient matchID="match-id"/>
 ```
 <!-- tabs:end -->
 
-The `gameID`, similar to the `playerID` can again be determined
+The `matchID`, similar to the `playerID` can again be determined
 either by a URL path or a lobby implementation.
 
 ### Storage

--- a/examples/react-native/App.js
+++ b/examples/react-native/App.js
@@ -22,7 +22,7 @@ const App = Client({
 const Singleplayer = () => (
   <View style={styles.container}>
     <Image source={logo} style={styles.logo} />
-    <App gameID="single" />
+    <App matchID="single" />
   </View>
 );
 

--- a/examples/react-web/src/chess/multiplayer.js
+++ b/examples/react-web/src/chess/multiplayer.js
@@ -22,7 +22,7 @@ const App = Client({
 
 const Multiplayer = playerID => () => (
   <div style={{ padding: 50 }}>
-    <App gameID="multi" playerID={playerID} />
+    <App matchID="multi" playerID={playerID} />
     PlayerID: {playerID}
   </div>
 );

--- a/examples/react-web/src/chess/singleplayer.js
+++ b/examples/react-web/src/chess/singleplayer.js
@@ -18,7 +18,7 @@ const App = Client({
 
 const Singleplayer = () => (
   <div style={{ padding: 50 }}>
-    <App gameID="single" />
+    <App matchID="single" />
   </div>
 );
 

--- a/examples/react-web/src/random/index.js
+++ b/examples/react-web/src/random/index.js
@@ -19,7 +19,7 @@ const App = Client({
 
 const SingleView = () => (
   <div style={{ padding: 50 }}>
-    <App gameID="Random" />
+    <App matchID="Random" />
   </div>
 );
 

--- a/examples/react-web/src/redacted-move/multiview.js
+++ b/examples/react-web/src/redacted-move/multiview.js
@@ -34,15 +34,15 @@ const Multiview = () => (
     </p>
     <div className="runner">
       <div className="run">
-        <App gameID="redacted-move" playerID="0" />
+        <App matchID="redacted-move" playerID="0" />
         &lt;App playerID=&quot;0&quot;/&gt;
       </div>
       <div className="run">
-        <App gameID="redacted-move" playerID="1" />
+        <App matchID="redacted-move" playerID="1" />
         &lt;App playerID=&quot;1&quot;/&gt;
       </div>
       <div className="run">
-        <App gameID="redacted-move" />
+        <App matchID="redacted-move" />
         &lt;App/&gt;
       </div>
     </div>

--- a/examples/react-web/src/secret-state/multiview.js
+++ b/examples/react-web/src/secret-state/multiview.js
@@ -25,19 +25,19 @@ const Multiview = () => (
     <h1>Secret Info</h1>
     <div className="runner">
       <div className="run">
-        <App gameID="secret-state" playerID="0" />
+        <App matchID="secret-state" playerID="0" />
         &lt;App playerID=&quot;0&quot;/&gt;
       </div>
       <div className="run">
-        <App gameID="secret-state" playerID="1" />
+        <App matchID="secret-state" playerID="1" />
         &lt;App playerID=&quot;1&quot;/&gt;
       </div>
       <div className="run">
-        <App gameID="secret-state" playerID="2" />
+        <App matchID="secret-state" playerID="2" />
         &lt;App playerID=&quot;2&quot;/&gt;
       </div>
       <div className="run">
-        <App gameID="secret-state" />
+        <App matchID="secret-state" />
         &lt;App/&gt;
       </div>
     </div>

--- a/examples/react-web/src/simulator/simulator.js
+++ b/examples/react-web/src/simulator/simulator.js
@@ -118,7 +118,7 @@ class App extends React.Component {
 
     let players = [];
     for (let i = 0; i < 6; i++) {
-      players.push(<App key={i} gameID={this.type} playerID={i + ''} />);
+      players.push(<App key={i} matchID={this.type} playerID={i + ''} />);
     }
 
     return (
@@ -152,7 +152,7 @@ class App extends React.Component {
 
         <div className="turnorder-content">
           <div className="player-container">
-            <App gameID={this.type} />
+            <App matchID={this.type} />
             <span>{players}</span>
           </div>
           <div className="description">

--- a/examples/react-web/src/tic-tac-toe/authenticated.js
+++ b/examples/react-web/src/tic-tac-toe/authenticated.js
@@ -26,7 +26,7 @@ class AuthenticatedClient extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      gameID: 'gameID',
+      matchID: 'matchID',
       players: {
         '0': {
           credentials: 'credentials',
@@ -46,13 +46,13 @@ class AuthenticatedClient extends React.Component {
       .post(`http://${hostname}:${PORT}/games/${gameName}/create`)
       .send({ numPlayers: 2 });
 
-    const gameID = newGame.body.gameID;
+    const matchID = newGame.body.matchID;
 
     let playerCredentials = [];
 
     for (let playerID of [0, 1]) {
       const player = await request
-        .post(`http://${hostname}:${PORT}/games/${gameName}/${gameID}/join`)
+        .post(`http://${hostname}:${PORT}/games/${gameName}/${matchID}/join`)
         .send({
           gameName,
           playerID,
@@ -63,7 +63,7 @@ class AuthenticatedClient extends React.Component {
     }
 
     this.setState({
-      gameID,
+      matchID,
       players: {
         '0': {
           credentials: playerCredentials[0],
@@ -77,7 +77,7 @@ class AuthenticatedClient extends React.Component {
 
   onPlayerCredentialsChange(playerID, credentials) {
     this.setState({
-      gameID: this.state.gameID,
+      matchID: this.state.matchID,
       players: {
         ...this.state.players,
         [playerID]: {
@@ -90,7 +90,7 @@ class AuthenticatedClient extends React.Component {
   render() {
     return (
       <AuthenticatedExample
-        gameID={this.state.gameID}
+        matchID={this.state.matchID}
         players={this.state.players}
         onPlayerCredentialsChange={this.onPlayerCredentialsChange.bind(this)}
       />
@@ -100,7 +100,7 @@ class AuthenticatedClient extends React.Component {
 
 class AuthenticatedExample extends React.Component {
   static propTypes = {
-    gameID: PropTypes.string,
+    matchID: PropTypes.string,
     players: PropTypes.any,
     onPlayerCredentialsChange: PropTypes.func,
   };
@@ -118,7 +118,7 @@ class AuthenticatedExample extends React.Component {
         <div className="runner">
           <div className="run">
             <App
-              gameID={this.props.gameID}
+              matchID={this.props.matchID}
               playerID="0"
               credentials={this.props.players['0'].credentials}
             />
@@ -132,7 +132,7 @@ class AuthenticatedExample extends React.Component {
           </div>
           <div className="run">
             <App
-              gameID={this.props.gameID}
+              matchID={this.props.matchID}
               playerID="1"
               credentials={this.props.players['1'].credentials}
             />

--- a/examples/react-web/src/tic-tac-toe/multiplayer.js
+++ b/examples/react-web/src/tic-tac-toe/multiplayer.js
@@ -24,11 +24,11 @@ const Multiplayer = () => (
     <h1>Multiplayer</h1>
     <div className="runner">
       <div className="run">
-        <App gameID="multi" playerID="0" />
+        <App matchID="multi" playerID="0" />
         &lt;App playerID=&quot;0&quot;/&gt;
       </div>
       <div className="run">
-        <App gameID="multi" playerID="1" />
+        <App matchID="multi" playerID="1" />
         &lt;App playerID=&quot;1&quot;/&gt;
       </div>
     </div>

--- a/examples/react-web/src/tic-tac-toe/singleplayer.js
+++ b/examples/react-web/src/tic-tac-toe/singleplayer.js
@@ -21,7 +21,7 @@ const App = Client({
 const Singleplayer = () => (
   <div>
     <h1>Singleplayer</h1>
-    <App gameID="single" />
+    <App matchID="single" />
   </div>
 );
 

--- a/examples/react-web/src/tic-tac-toe/spectator.js
+++ b/examples/react-web/src/tic-tac-toe/spectator.js
@@ -25,15 +25,15 @@ const Spectator = () => (
     <h1>Spectator</h1>
     <div className="runner">
       <div className="run">
-        <App gameID="spectator" playerID="0" />
+        <App matchID="spectator" playerID="0" />
         &lt;App playerID=&quot;0&quot;/&gt;
       </div>
       <div className="run">
-        <App gameID="spectator" playerID="1" />
+        <App matchID="spectator" playerID="1" />
         &lt;App playerID=&quot;1&quot;/&gt;
       </div>
       <div className="run">
-        <App gameID="spectator" />
+        <App matchID="spectator" />
         Spectator
       </div>
     </div>

--- a/examples/snippets/src/phases-1/Player.svelte
+++ b/examples/snippets/src/phases-1/Player.svelte
@@ -7,7 +7,7 @@
 
   const client = Client({
     game: Game,
-    gameID: 'default',
+    matchID: 'default',
     playerID,
     debug: false,
     numPlayers: 3,

--- a/examples/snippets/src/phases-2/Player.svelte
+++ b/examples/snippets/src/phases-2/Player.svelte
@@ -7,7 +7,7 @@
 
   const client = Client({
     game: Game,
-    gameID: 'default',
+    matchID: 'default',
     playerID,
     debug: false,
     numPlayers: 3,

--- a/examples/snippets/src/stages-1/Player.svelte
+++ b/examples/snippets/src/stages-1/Player.svelte
@@ -7,7 +7,7 @@
 
   const client = Client({
     game: Game,
-    gameID: 'default',
+    matchID: 'default',
     playerID,
     debug: false,
     numPlayers: 3,

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -233,7 +233,7 @@ describe('multiplayer', () => {
         this.callback = null;
       }
 
-      subscribeMatchMetadata(fn) {
+      subscribeMatchData(fn) {
         this.callback = fn;
       }
     }
@@ -256,7 +256,7 @@ describe('multiplayer', () => {
     test('metadata callback', () => {
       const metadata = { m: true };
       client.transport.callback(metadata);
-      expect(client.matchMetadata).toEqual(metadata);
+      expect(client.matchData).toEqual(metadata);
     });
   });
 });

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -233,7 +233,7 @@ describe('multiplayer', () => {
         this.callback = null;
       }
 
-      subscribeGameMetadata(fn) {
+      subscribeMatchMetadata(fn) {
         this.callback = fn;
       }
     }
@@ -256,7 +256,7 @@ describe('multiplayer', () => {
     test('metadata callback', () => {
       const metadata = { m: true };
       client.transport.callback(metadata);
-      expect(client.gameMetadata).toEqual(metadata);
+      expect(client.matchMetadata).toEqual(metadata);
     });
   });
 });

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -115,7 +115,7 @@ export class _ClientImpl<G extends any = any> {
   matchID: string;
   playerID: PlayerID | null;
   credentials: string;
-  gameMetadata?: FilteredMetadata;
+  matchMetadata?: FilteredMetadata;
   moves: Record<string, (...args: any[]) => void>;
   events: {
     endGame?: (gameover?: any) => void;
@@ -281,7 +281,7 @@ export class _ClientImpl<G extends any = any> {
       isConnected: true,
       onAction: () => {},
       subscribe: () => {},
-      subscribeGameMetadata: () => {},
+      subscribeMatchMetadata: () => {},
       connect: () => {},
       disconnect: () => {},
       updateMatchID: () => {},
@@ -303,8 +303,8 @@ export class _ClientImpl<G extends any = any> {
 
     this.createDispatchers();
 
-    this.transport.subscribeGameMetadata(metadata => {
-      this.gameMetadata = metadata;
+    this.transport.subscribeMatchMetadata(metadata => {
+      this.matchMetadata = metadata;
     });
 
     this._debugPanel = null;

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -115,7 +115,7 @@ export class _ClientImpl<G extends any = any> {
   matchID: string;
   playerID: PlayerID | null;
   credentials: string;
-  matchMetadata?: FilteredMetadata;
+  matchData?: FilteredMetadata;
   moves: Record<string, (...args: any[]) => void>;
   events: {
     endGame?: (gameover?: any) => void;
@@ -281,7 +281,7 @@ export class _ClientImpl<G extends any = any> {
       isConnected: true,
       onAction: () => {},
       subscribe: () => {},
-      subscribeMatchMetadata: () => {},
+      subscribeMatchData: () => {},
       connect: () => {},
       disconnect: () => {},
       updateMatchID: () => {},
@@ -303,8 +303,8 @@ export class _ClientImpl<G extends any = any> {
 
     this.createDispatchers();
 
-    this.transport.subscribeMatchMetadata(metadata => {
-      this.matchMetadata = metadata;
+    this.transport.subscribeMatchData(metadata => {
+      this.matchData = metadata;
     });
 
     this._debugPanel = null;

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -90,7 +90,7 @@ export interface ClientOpts<G extends any = any> {
   debug?: DebugOpt | boolean;
   numPlayers?: number;
   multiplayer?: (opts: TransportOpts) => Transport;
-  gameID?: string;
+  matchID?: string;
   playerID?: PlayerID;
   credentials?: string;
   enhancer?: StoreEnhancer;
@@ -112,7 +112,7 @@ export class _ClientImpl<G extends any = any> {
   game: ReturnType<typeof ProcessGameConfig>;
   store: Store;
   log: State['deltalog'];
-  gameID: string;
+  matchID: string;
   playerID: PlayerID | null;
   credentials: string;
   gameMetadata?: FilteredMetadata;
@@ -136,14 +136,14 @@ export class _ClientImpl<G extends any = any> {
     debug,
     numPlayers,
     multiplayer,
-    gameID,
+    matchID: matchID,
     playerID,
     credentials,
     enhancer,
   }: ClientOpts) {
     this.game = ProcessGameConfig(game);
     this.playerID = playerID;
-    this.gameID = gameID;
+    this.matchID = matchID;
     this.credentials = credentials;
     this.multiplayer = multiplayer;
     this.debug = debug;
@@ -284,7 +284,7 @@ export class _ClientImpl<G extends any = any> {
       subscribeGameMetadata: () => {},
       connect: () => {},
       disconnect: () => {},
-      updateGameID: () => {},
+      updateMatchID: () => {},
       updatePlayerID: () => {},
     } as unknown) as Transport;
 
@@ -294,7 +294,7 @@ export class _ClientImpl<G extends any = any> {
         gameKey: game,
         game: this.game,
         store: this.store,
-        gameID,
+        matchID,
         playerID,
         gameName: this.game.name,
         numPlayers,
@@ -475,10 +475,10 @@ export class _ClientImpl<G extends any = any> {
     this.notifySubscribers();
   }
 
-  updateGameID(gameID: string) {
-    this.gameID = gameID;
+  updateMatchID(matchID: string) {
+    this.matchID = matchID;
     this.createDispatchers();
-    this.transport.updateGameID(gameID);
+    this.transport.updateMatchID(matchID);
     this.notifySubscribers();
   }
 
@@ -497,7 +497,7 @@ export class _ClientImpl<G extends any = any> {
  * @param {...object} game - The return value of `Game`.
  * @param {...object} numPlayers - The number of players.
  * @param {...object} multiplayer - Set to a falsy value or a transportFactory, e.g., SocketIO()
- * @param {...object} gameID - The gameID that you want to connect to.
+ * @param {...object} matchID - The matchID that you want to connect to.
  * @param {...object} playerID - The playerID associated with this client.
  * @param {...string} credentials - The authentication credentials associated with this client.
  *

--- a/src/client/debug/info/Info.svelte
+++ b/src/client/debug/info/Info.svelte
@@ -11,7 +11,7 @@
 </style>
 
 <section class="gameinfo">
-  <Item name="gameID" value={client.gameID} />
+  <Item name="matchID" value={client.matchID} />
   <Item name="playerID" value={client.playerID} />
   <Item name="isActive" value={$client.isActive} />
   {#if $client.isMultiplayer}

--- a/src/client/react-native.js
+++ b/src/client/react-native.js
@@ -40,7 +40,7 @@ export function Client(opts) {
     static propTypes = {
       // The ID of a game to connect to.
       // Only relevant in multiplayer.
-      gameID: PropTypes.string,
+      matchID: PropTypes.string,
       // The ID of the player associated with this client.
       // Only relevant in multiplayer.
       playerID: PropTypes.string,
@@ -50,7 +50,7 @@ export function Client(opts) {
     };
 
     static defaultProps = {
-      gameID: 'default',
+      matchID: 'default',
       playerID: null,
       credentials: null,
     };
@@ -62,7 +62,7 @@ export function Client(opts) {
         game,
         numPlayers,
         multiplayer,
-        gameID: props.gameID,
+        matchID: props.matchID,
         playerID: props.playerID,
         credentials: props.credentials,
         debug: false,
@@ -81,8 +81,8 @@ export function Client(opts) {
     }
 
     componentDidUpdate(prevProps) {
-      if (prevProps.gameID != this.props.gameID) {
-        this.client.updateGameID(this.props.gameID);
+      if (prevProps.matchID != this.props.matchID) {
+        this.client.updateMatchID(this.props.matchID);
       }
       if (prevProps.playerID != this.props.playerID) {
         this.client.updatePlayerID(this.props.playerID);
@@ -96,13 +96,13 @@ export function Client(opts) {
       let _board = null;
 
       const state = this.client.getState();
-      const { gameID, playerID, ...rest } = this.props;
+      const { matchID, playerID, ...rest } = this.props;
 
       if (board) {
         _board = React.createElement(board, {
           ...state,
           ...rest,
-          gameID,
+          matchID,
           playerID,
           isMultiplayer: !!multiplayer,
           moves: this.client.moves,

--- a/src/client/react-native.js
+++ b/src/client/react-native.js
@@ -111,7 +111,7 @@ export function Client(opts) {
           reset: this.client.reset,
           undo: this.client.undo,
           redo: this.client.redo,
-          gameMetadata: this.client.gameMetadata,
+          matchMetadata: this.client.matchMetadata,
         });
       }
 

--- a/src/client/react-native.js
+++ b/src/client/react-native.js
@@ -111,7 +111,7 @@ export function Client(opts) {
           reset: this.client.reset,
           undo: this.client.undo,
           redo: this.client.redo,
-          matchMetadata: this.client.matchMetadata,
+          matchData: this.client.matchData,
         });
       }
 

--- a/src/client/react-native.test.js
+++ b/src/client/react-native.test.js
@@ -84,7 +84,7 @@ test('move api', () => {
   expect(board.props.G).toEqual({ arg: 42 });
 });
 
-test('update gameID / playerID', () => {
+test('update matchID / playerID', () => {
   let Board = null;
   let game = null;
 
@@ -99,7 +99,7 @@ test('update gameID / playerID', () => {
     board: TestBoard,
   });
   game = Enzyme.mount(<Board />);
-  game.setProps({ gameID: 'a' });
+  game.setProps({ matchID: 'a' });
   game.setProps({ playerID: '3' });
   expect(game.instance().transport).toBe(undefined);
 
@@ -114,32 +114,32 @@ test('update gameID / playerID', () => {
     board: TestBoard,
     multiplayer: Local(),
   });
-  game = Enzyme.mount(<Board gameID="a" playerID="1" credentials="foo" />);
+  game = Enzyme.mount(<Board matchID="a" playerID="1" credentials="foo" />);
   const m = game.instance().client.transport;
   const g = game.instance().client;
 
-  const spy1 = jest.spyOn(m, 'updateGameID');
+  const spy1 = jest.spyOn(m, 'updateMatchID');
   const spy2 = jest.spyOn(m, 'updatePlayerID');
   const spy3 = jest.spyOn(g, 'updateCredentials');
 
-  expect(m.gameID).toBe('a');
+  expect(m.matchID).toBe('a');
   expect(m.playerID).toBe('1');
 
-  game.setProps({ gameID: 'a' });
+  game.setProps({ matchID: 'a' });
   game.setProps({ playerID: '1' });
   game.setProps({ credentials: 'foo' });
 
-  expect(m.gameID).toBe('a');
+  expect(m.matchID).toBe('a');
   expect(m.playerID).toBe('1');
   expect(spy1).not.toHaveBeenCalled();
   expect(spy2).not.toHaveBeenCalled();
   expect(spy3).not.toHaveBeenCalled();
 
-  game.setProps({ gameID: 'next' });
+  game.setProps({ matchID: 'next' });
   game.setProps({ playerID: 'next' });
   game.setProps({ credentials: 'bar' });
 
-  expect(m.gameID).toBe('next');
+  expect(m.matchID).toBe('next');
   expect(m.playerID).toBe('next');
   expect(spy1).toHaveBeenCalled();
   expect(spy2).toHaveBeenCalled();

--- a/src/client/react.test.tsx
+++ b/src/client/react.test.tsx
@@ -110,7 +110,7 @@ test('move api', () => {
   expect(board.props.G).toEqual({ arg: 42 });
 });
 
-test('update gameID / playerID', () => {
+test('update matchID / playerID', () => {
   let Board = null;
   let game = null;
 
@@ -125,7 +125,7 @@ test('update gameID / playerID', () => {
     board: TestBoard,
   });
   game = Enzyme.mount(<Board />);
-  game.setProps({ gameID: 'a' });
+  game.setProps({ matchID: 'a' });
   game.setProps({ playerID: '3' });
   expect(game.instance().transport).toBe(undefined);
 
@@ -140,32 +140,32 @@ test('update gameID / playerID', () => {
     board: TestBoard,
     multiplayer: Local(),
   });
-  game = Enzyme.mount(<Board gameID="a" playerID="1" credentials="foo" />);
+  game = Enzyme.mount(<Board matchID="a" playerID="1" credentials="foo" />);
   const m = game.instance().client.transport;
   const g = game.instance().client;
 
-  const spy1 = jest.spyOn(m, 'updateGameID');
+  const spy1 = jest.spyOn(m, 'updateMatchID');
   const spy2 = jest.spyOn(m, 'updatePlayerID');
   const spy3 = jest.spyOn(g, 'updateCredentials');
 
-  expect(m.gameID).toBe('a');
+  expect(m.matchID).toBe('a');
   expect(m.playerID).toBe('1');
 
-  game.setProps({ gameID: 'a' });
+  game.setProps({ matchID: 'a' });
   game.setProps({ playerID: '1' });
   game.setProps({ credentials: 'foo' });
 
-  expect(m.gameID).toBe('a');
+  expect(m.matchID).toBe('a');
   expect(m.playerID).toBe('1');
   expect(spy1).not.toHaveBeenCalled();
   expect(spy2).not.toHaveBeenCalled();
   expect(spy3).not.toHaveBeenCalled();
 
-  game.setProps({ gameID: 'next' });
+  game.setProps({ matchID: 'next' });
   game.setProps({ playerID: 'next' });
   game.setProps({ credentials: 'bar' });
 
-  expect(m.gameID).toBe('next');
+  expect(m.matchID).toBe('next');
   expect(m.playerID).toBe('next');
   expect(spy1).toHaveBeenCalled();
   expect(spy2).toHaveBeenCalled();

--- a/src/client/react.tsx
+++ b/src/client/react.tsx
@@ -29,7 +29,7 @@ export type BoardProps<G extends any = any> = State<G> &
     | 'redo'
     | 'playerID'
     | 'matchID'
-    | 'matchMetadata'
+    | 'matchData'
   > & {
     isActive: boolean;
     isMultiplayer: boolean;
@@ -173,7 +173,7 @@ export function Client<
           undo: this.client.undo,
           redo: this.client.redo,
           log: this.client.log,
-          matchMetadata: this.client.matchMetadata,
+          matchData: this.client.matchData,
         });
       }
 

--- a/src/client/react.tsx
+++ b/src/client/react.tsx
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import { Client as RawClient, ClientOpts, _ClientImpl } from './client';
 import { State } from '../types';
 
-type WrappedBoardDelegates = 'gameID' | 'playerID' | 'credentials';
+type WrappedBoardDelegates = 'matchID' | 'playerID' | 'credentials';
 
 export type WrappedBoardProps = Pick<
   ClientOpts,
@@ -28,7 +28,7 @@ export type BoardProps<G extends any = any> = State<G> &
     | 'undo'
     | 'redo'
     | 'playerID'
-    | 'gameID'
+    | 'matchID'
     | 'gameMetadata'
   > & {
     isActive: boolean;
@@ -92,7 +92,7 @@ export function Client<
     static propTypes = {
       // The ID of a game to connect to.
       // Only relevant in multiplayer.
-      gameID: PropTypes.string,
+      matchID: PropTypes.string,
       // The ID of the player associated with this client.
       // Only relevant in multiplayer.
       playerID: PropTypes.string,
@@ -104,7 +104,7 @@ export function Client<
     };
 
     static defaultProps = {
-      gameID: 'default',
+      matchID: 'default',
       playerID: null,
       credentials: null,
       debug: true,
@@ -122,7 +122,7 @@ export function Client<
         debug,
         numPlayers,
         multiplayer,
-        gameID: props.gameID,
+        matchID: props.matchID,
         playerID: props.playerID,
         credentials: props.credentials,
         enhancer,
@@ -140,8 +140,8 @@ export function Client<
     }
 
     componentDidUpdate(prevProps: WrappedBoardProps & AdditionalProps) {
-      if (this.props.gameID != prevProps.gameID) {
-        this.client.updateGameID(this.props.gameID);
+      if (this.props.matchID != prevProps.matchID) {
+        this.client.updateMatchID(this.props.matchID);
       }
       if (this.props.playerID != prevProps.playerID) {
         this.client.updatePlayerID(this.props.playerID);
@@ -167,7 +167,7 @@ export function Client<
           isMultiplayer: !!multiplayer,
           moves: this.client.moves,
           events: this.client.events,
-          gameID: this.client.gameID,
+          matchID: this.client.matchID,
           playerID: this.client.playerID,
           reset: this.client.reset,
           undo: this.client.undo,

--- a/src/client/react.tsx
+++ b/src/client/react.tsx
@@ -29,7 +29,7 @@ export type BoardProps<G extends any = any> = State<G> &
     | 'redo'
     | 'playerID'
     | 'matchID'
-    | 'gameMetadata'
+    | 'matchMetadata'
   > & {
     isActive: boolean;
     isMultiplayer: boolean;
@@ -173,7 +173,7 @@ export function Client<
           undo: this.client.undo,
           redo: this.client.redo,
           log: this.client.log,
-          gameMetadata: this.client.gameMetadata,
+          matchMetadata: this.client.matchMetadata,
         });
       }
 

--- a/src/client/transport/local.test.js
+++ b/src/client/transport/local.test.js
@@ -169,8 +169,8 @@ describe('LocalMaster', () => {
   });
 
   test('connect without callback', () => {
-    master.connect('gameID', '0', undefined);
-    master.onSync('gameID', '0');
+    master.connect('matchID', '0', undefined);
+    master.onSync('matchID', '0');
   });
 
   test('disconnect', () => {
@@ -180,7 +180,7 @@ describe('LocalMaster', () => {
 });
 
 describe('LocalTransport', () => {
-  describe('update gameID / playerID', () => {
+  describe('update matchID / playerID', () => {
     const master = { connect: jest.fn(), onSync: jest.fn() };
     const store = { dispatch: () => {} };
     const m = new LocalTransport({ master, store });
@@ -189,9 +189,9 @@ describe('LocalTransport', () => {
       jest.resetAllMocks();
     });
 
-    test('gameID', () => {
-      m.updateGameID('test');
-      expect(m.gameID).toBe('test');
+    test('matchID', () => {
+      m.updateMatchID('test');
+      expect(m.matchID).toBe('test');
       expect(master.connect).toBeCalled();
     });
 
@@ -221,7 +221,7 @@ describe('LocalTransport', () => {
     test('receive update', () => {
       const restored = { restore: true };
       expect(store.getState()).not.toMatchObject(restored);
-      m.onUpdate('unknown gameID', restored);
+      m.onUpdate('unknown matchID', restored);
       expect(store.getState()).not.toMatchObject(restored);
       m.onUpdate('default', restored);
       expect(store.getState()).not.toMatchObject(restored);
@@ -235,7 +235,7 @@ describe('LocalTransport', () => {
     test('receive sync', () => {
       const restored = { restore: true };
       expect(store.getState()).not.toMatchObject(restored);
-      m.onSync('unknown gameID', { state: restored });
+      m.onSync('unknown matchID', { state: restored });
       expect(store.getState()).not.toMatchObject(restored);
       m.onSync('default', { state: restored });
       expect(store.getState()).toMatchObject(restored);

--- a/src/client/transport/local.ts
+++ b/src/client/transport/local.ts
@@ -52,7 +52,7 @@ interface LocalMasterOpts {
  */
 export class LocalMaster extends Master {
   connect: (
-    gameID: string,
+    matchID: string,
     playerID: PlayerID,
     callback: (...args: any[]) => void
   ) => void;
@@ -91,11 +91,11 @@ export class LocalMaster extends Master {
 
     super(game, new InMemory(), transportAPI, false);
 
-    this.connect = (gameID, playerID, callback) => {
+    this.connect = (matchID, playerID, callback) => {
       clientCallbacks[playerID] = callback;
     };
 
-    this.subscribe(({ state, gameID }) => {
+    this.subscribe(({ state, matchID }) => {
       if (!bots) {
         return;
       }
@@ -109,7 +109,7 @@ export class LocalMaster extends Master {
           await this.onUpdate(
             botAction.action,
             state._stateID,
-            gameID,
+            matchID,
             botAction.action.payload.playerID
           );
         }, 100);
@@ -133,7 +133,7 @@ export class LocalTransport extends Transport {
 
   /**
    * Creates a new Mutiplayer instance.
-   * @param {string} gameID - The game ID to connect to.
+   * @param {string} matchID - The game ID to connect to.
    * @param {string} playerID - The player ID associated with this client.
    * @param {string} gameName - The game type (the `name` field in `Game`).
    * @param {string} numPlayers - The number of players.
@@ -141,12 +141,12 @@ export class LocalTransport extends Transport {
   constructor({
     master,
     store,
-    gameID,
+    matchID,
     playerID,
     gameName,
     numPlayers,
   }: LocalTransportOpts) {
-    super({ store, gameName, playerID, gameID, numPlayers });
+    super({ store, gameName, playerID, matchID, numPlayers });
     this.master = master;
     this.isConnected = true;
   }
@@ -156,10 +156,10 @@ export class LocalTransport extends Transport {
    * master broadcasts the update to other clients (including
    * this one).
    */
-  async onUpdate(gameID: string, state: State, deltalog: LogEntry[]) {
+  async onUpdate(matchID: string, state: State, deltalog: LogEntry[]) {
     const currentState = this.store.getState();
 
-    if (gameID == this.gameID && state._stateID >= currentState._stateID) {
+    if (matchID == this.matchID && state._stateID >= currentState._stateID) {
       const action = ActionCreators.update(state, deltalog);
       this.store.dispatch(action);
     }
@@ -169,8 +169,8 @@ export class LocalTransport extends Transport {
    * Called when the client first connects to the master
    * and requests the current game state.
    */
-  onSync(gameID: string, syncInfo: SyncInfo) {
-    if (gameID == this.gameID) {
+  onSync(matchID: string, syncInfo: SyncInfo) {
+    if (matchID == this.matchID) {
       const action = ActionCreators.sync(syncInfo);
       this.store.dispatch(action);
     }
@@ -181,14 +181,14 @@ export class LocalTransport extends Transport {
    * game master is made.
    */
   onAction(state: State, action: CredentialedActionShape.Any) {
-    this.master.onUpdate(action, state._stateID, this.gameID, this.playerID);
+    this.master.onUpdate(action, state._stateID, this.matchID, this.playerID);
   }
 
   /**
    * Connect to the master.
    */
   connect() {
-    this.master.connect(this.gameID, this.playerID, (type, ...args) => {
+    this.master.connect(this.matchID, this.playerID, (type, ...args) => {
       if (type == 'sync') {
         this.onSync.apply(this, args);
       }
@@ -196,7 +196,7 @@ export class LocalTransport extends Transport {
         this.onUpdate.apply(this, args);
       }
     });
-    this.master.onSync(this.gameID, this.playerID, this.numPlayers);
+    this.master.onSync(this.matchID, this.playerID, this.numPlayers);
   }
 
   /**
@@ -215,8 +215,8 @@ export class LocalTransport extends Transport {
    * Updates the game id.
    * @param {string} id - The new game id.
    */
-  updateGameID(id: string) {
-    this.gameID = id;
+  updateMatchID(id: string) {
+    this.matchID = id;
     const action = ActionCreators.reset(null);
     this.store.dispatch(action);
     this.connect();

--- a/src/client/transport/local.ts
+++ b/src/client/transport/local.ts
@@ -209,7 +209,7 @@ export class LocalTransport extends Transport {
    */
   subscribe() {}
 
-  subscribeMatchMetadata() {}
+  subscribeMatchData() {}
 
   /**
    * Updates the game id.

--- a/src/client/transport/local.ts
+++ b/src/client/transport/local.ts
@@ -209,7 +209,7 @@ export class LocalTransport extends Transport {
    */
   subscribe() {}
 
-  subscribeGameMetadata() {}
+  subscribeMatchMetadata() {}
 
   /**
    * Updates the game id.

--- a/src/client/transport/socketio.test.js
+++ b/src/client/transport/socketio.test.js
@@ -36,16 +36,16 @@ test('defaults', () => {
   m.callback();
 });
 
-describe('update gameID / playerID', () => {
+describe('update matchID / playerID', () => {
   const socket = new MockSocket();
   const m = new SocketIOTransport({ socket });
   m.store = { dispatch: () => {} };
 
   beforeEach(() => (socket.emit = jest.fn()));
 
-  test('gameID', () => {
-    m.updateGameID('test');
-    expect(m.gameID).toBe('test');
+  test('matchID', () => {
+    m.updateMatchID('test');
+    expect(m.matchID).toBe('test');
     expect(socket.emit).lastCalledWith('sync', 'test', null, 2);
   });
 
@@ -66,7 +66,7 @@ describe('connection status', () => {
     mockSocket = new MockSocket();
     m = new SocketIOTransport({
       socket: mockSocket,
-      gameID: 0,
+      matchID: 0,
       playerID: 0,
       gameName: 'foo',
       numPlayers: 2,
@@ -115,7 +115,7 @@ describe('multiplayer', () => {
   test('receive update', () => {
     const restored = { restore: true };
     expect(store.getState()).not.toMatchObject(restored);
-    mockSocket.receive('update', 'unknown gameID', restored);
+    mockSocket.receive('update', 'unknown matchID', restored);
     expect(store.getState()).not.toMatchObject(restored);
     mockSocket.receive('update', 'default', restored);
     expect(store.getState()).not.toMatchObject(restored);
@@ -129,7 +129,7 @@ describe('multiplayer', () => {
   test('receive sync', () => {
     const restored = { restore: true };
     expect(store.getState()).not.toMatchObject(restored);
-    mockSocket.receive('sync', 'unknown gameID', { state: restored });
+    mockSocket.receive('sync', 'unknown matchID', { state: restored });
     expect(store.getState()).not.toMatchObject(restored);
     mockSocket.receive('sync', 'default', { state: restored });
     expect(store.getState()).toMatchObject(restored);
@@ -195,14 +195,14 @@ describe('server option', () => {
   });
 });
 
-test('changing a gameID resets the state before resync', () => {
+test('changing a matchID resets the state before resync', () => {
   const m = new SocketIOTransport();
   const game = {};
   const store = createStore(CreateGameReducer({ game }));
   m.store = store;
   const dispatchSpy = jest.spyOn(store, 'dispatch');
 
-  m.updateGameID('foo');
+  m.updateMatchID('foo');
 
   expect(dispatchSpy).toHaveBeenCalledWith(
     expect.objectContaining({

--- a/src/client/transport/socketio.ts
+++ b/src/client/transport/socketio.ts
@@ -37,7 +37,7 @@ export class SocketIOTransport extends Transport {
   socket;
   socketOpts;
   callback: () => void;
-  matchMetadataCallback: MetadataCallback;
+  matchDataCallback: MetadataCallback;
 
   /**
    * Creates a new Mutiplayer instance.
@@ -66,7 +66,7 @@ export class SocketIOTransport extends Transport {
     this.socketOpts = socketOpts;
     this.isConnected = false;
     this.callback = () => {};
-    this.matchMetadataCallback = () => {};
+    this.matchDataCallback = () => {};
   }
 
   /**
@@ -126,7 +126,7 @@ export class SocketIOTransport extends Transport {
     this.socket.on('sync', (matchID: string, syncInfo: SyncInfo) => {
       if (matchID == this.matchID) {
         const action = ActionCreators.sync(syncInfo);
-        this.matchMetadataCallback(syncInfo.filteredMetadata);
+        this.matchDataCallback(syncInfo.filteredMetadata);
         this.store.dispatch(action);
       }
     });
@@ -161,8 +161,8 @@ export class SocketIOTransport extends Transport {
     this.callback = fn;
   }
 
-  subscribeMatchMetadata(fn: MetadataCallback) {
-    this.matchMetadataCallback = fn;
+  subscribeMatchData(fn: MetadataCallback) {
+    this.matchDataCallback = fn;
   }
 
   /**

--- a/src/client/transport/socketio.ts
+++ b/src/client/transport/socketio.ts
@@ -37,7 +37,7 @@ export class SocketIOTransport extends Transport {
   socket;
   socketOpts;
   callback: () => void;
-  gameMetadataCallback: MetadataCallback;
+  matchMetadataCallback: MetadataCallback;
 
   /**
    * Creates a new Mutiplayer instance.
@@ -66,7 +66,7 @@ export class SocketIOTransport extends Transport {
     this.socketOpts = socketOpts;
     this.isConnected = false;
     this.callback = () => {};
-    this.gameMetadataCallback = () => {};
+    this.matchMetadataCallback = () => {};
   }
 
   /**
@@ -126,7 +126,7 @@ export class SocketIOTransport extends Transport {
     this.socket.on('sync', (matchID: string, syncInfo: SyncInfo) => {
       if (matchID == this.matchID) {
         const action = ActionCreators.sync(syncInfo);
-        this.gameMetadataCallback(syncInfo.filteredMetadata);
+        this.matchMetadataCallback(syncInfo.filteredMetadata);
         this.store.dispatch(action);
       }
     });
@@ -161,8 +161,8 @@ export class SocketIOTransport extends Transport {
     this.callback = fn;
   }
 
-  subscribeGameMetadata(fn: MetadataCallback) {
-    this.gameMetadataCallback = fn;
+  subscribeMatchMetadata(fn: MetadataCallback) {
+    this.matchMetadataCallback = fn;
   }
 
   /**

--- a/src/client/transport/socketio.ts
+++ b/src/client/transport/socketio.ts
@@ -43,7 +43,7 @@ export class SocketIOTransport extends Transport {
    * Creates a new Mutiplayer instance.
    * @param {object} socket - Override for unit tests.
    * @param {object} socketOpts - Options to pass to socket.io.
-   * @param {string} gameID - The game ID to connect to.
+   * @param {string} matchID - The game ID to connect to.
    * @param {string} playerID - The player ID associated with this client.
    * @param {string} gameName - The game type (the `name` field in `Game`).
    * @param {string} numPlayers - The number of players.
@@ -53,13 +53,13 @@ export class SocketIOTransport extends Transport {
     socket,
     socketOpts,
     store,
-    gameID,
+    matchID,
     playerID,
     gameName,
     numPlayers,
     server,
   }: SocketIOTransportOpts = {}) {
-    super({ store, gameName, playerID, gameID, numPlayers });
+    super({ store, gameName, playerID, matchID, numPlayers });
 
     this.server = server;
     this.socket = socket;
@@ -78,7 +78,7 @@ export class SocketIOTransport extends Transport {
       'update',
       action,
       state._stateID,
-      this.gameID,
+      this.matchID,
       this.playerID
     );
   }
@@ -108,10 +108,13 @@ export class SocketIOTransport extends Transport {
     // this one).
     this.socket.on(
       'update',
-      (gameID: string, state: State, deltalog: LogEntry[]) => {
+      (matchID: string, state: State, deltalog: LogEntry[]) => {
         const currentState = this.store.getState();
 
-        if (gameID == this.gameID && state._stateID >= currentState._stateID) {
+        if (
+          matchID == this.matchID &&
+          state._stateID >= currentState._stateID
+        ) {
           const action = ActionCreators.update(state, deltalog);
           this.store.dispatch(action);
         }
@@ -120,8 +123,8 @@ export class SocketIOTransport extends Transport {
 
     // Called when the client first connects to the master
     // and requests the current game state.
-    this.socket.on('sync', (gameID: string, syncInfo: SyncInfo) => {
-      if (gameID == this.gameID) {
+    this.socket.on('sync', (matchID: string, syncInfo: SyncInfo) => {
+      if (matchID == this.matchID) {
         const action = ActionCreators.sync(syncInfo);
         this.gameMetadataCallback(syncInfo.filteredMetadata);
         this.store.dispatch(action);
@@ -131,7 +134,7 @@ export class SocketIOTransport extends Transport {
     // Keep track of connection status.
     this.socket.on('connect', () => {
       // Initial sync to get game state.
-      this.socket.emit('sync', this.gameID, this.playerID, this.numPlayers);
+      this.socket.emit('sync', this.matchID, this.playerID, this.numPlayers);
       this.isConnected = true;
       this.callback();
     });
@@ -166,14 +169,14 @@ export class SocketIOTransport extends Transport {
    * Updates the game id.
    * @param {string} id - The new game id.
    */
-  updateGameID(id: string) {
-    this.gameID = id;
+  updateMatchID(id: string) {
+    this.matchID = id;
 
     const action = ActionCreators.reset(null);
     this.store.dispatch(action);
 
     if (this.socket) {
-      this.socket.emit('sync', this.gameID, this.playerID, this.numPlayers);
+      this.socket.emit('sync', this.matchID, this.playerID, this.numPlayers);
     }
   }
 
@@ -188,7 +191,7 @@ export class SocketIOTransport extends Transport {
     this.store.dispatch(action);
 
     if (this.socket) {
-      this.socket.emit('sync', this.gameID, this.playerID, this.numPlayers);
+      this.socket.emit('sync', this.matchID, this.playerID, this.numPlayers);
     }
   }
 }

--- a/src/client/transport/transport.ts
+++ b/src/client/transport/transport.ts
@@ -24,7 +24,7 @@ export interface TransportOpts {
   gameKey?: Game;
   game?: ReturnType<typeof ProcessGameConfig>;
   playerID?: PlayerID;
-  gameID?: string;
+  matchID?: string;
   numPlayers?: number;
 }
 
@@ -32,7 +32,7 @@ export abstract class Transport {
   protected store: Store;
   protected gameName: string;
   protected playerID: PlayerID | null;
-  protected gameID: string;
+  protected matchID: string;
   protected numPlayers: number;
   isConnected: boolean;
 
@@ -40,13 +40,13 @@ export abstract class Transport {
     store,
     gameName,
     playerID,
-    gameID,
+    matchID,
     numPlayers,
   }: TransportOpts) {
     this.store = store;
     this.gameName = gameName || 'default';
     this.playerID = playerID || null;
-    this.gameID = gameID || 'default';
+    this.matchID = matchID || 'default';
     this.numPlayers = numPlayers || 2;
   }
 
@@ -55,6 +55,6 @@ export abstract class Transport {
   abstract disconnect(): void;
   abstract subscribe(fn: () => void): void;
   abstract subscribeGameMetadata(fn: MetadataCallback): void;
-  abstract updateGameID(id: string): void;
+  abstract updateMatchID(id: string): void;
   abstract updatePlayerID(id: PlayerID): void;
 }

--- a/src/client/transport/transport.ts
+++ b/src/client/transport/transport.ts
@@ -54,7 +54,7 @@ export abstract class Transport {
   abstract connect(): void;
   abstract disconnect(): void;
   abstract subscribe(fn: () => void): void;
-  abstract subscribeGameMetadata(fn: MetadataCallback): void;
+  abstract subscribeMatchMetadata(fn: MetadataCallback): void;
   abstract updateMatchID(id: string): void;
   abstract updatePlayerID(id: PlayerID): void;
 }

--- a/src/client/transport/transport.ts
+++ b/src/client/transport/transport.ts
@@ -54,7 +54,7 @@ export abstract class Transport {
   abstract connect(): void;
   abstract disconnect(): void;
   abstract subscribe(fn: () => void): void;
-  abstract subscribeMatchMetadata(fn: MetadataCallback): void;
+  abstract subscribeMatchData(fn: MetadataCallback): void;
   abstract updateMatchID(id: string): void;
   abstract updatePlayerID(id: PlayerID): void;
 }

--- a/src/master/master.test.ts
+++ b/src/master/master.test.ts
@@ -162,11 +162,11 @@ describe('update', () => {
     ]);
   });
 
-  test('invalid gameID', async () => {
+  test('invalid matchID', async () => {
     await master.onUpdate(action, 1, 'default:unknown', '1');
     expect(sendAll).not.toHaveBeenCalled();
     expect(error).toHaveBeenCalledWith(
-      `game not found, gameID=[default:unknown]`
+      `game not found, matchID=[default:unknown]`
     );
   });
 
@@ -193,7 +193,7 @@ describe('update', () => {
     );
   });
 
-  test('valid gameID / stateID / playerID', async () => {
+  test('valid matchID / stateID / playerID', async () => {
     await master.onUpdate(action, 1, 'gameID', '1');
     expect(sendAll).toHaveBeenCalled();
   });
@@ -213,7 +213,7 @@ describe('update', () => {
     await master.onUpdate(event, 2, 'gameID', '0');
     event = ActionCreators.gameEvent('endTurn');
     await master.onUpdate(event, 3, 'gameID', '0');
-    expect(error).toHaveBeenCalledWith(`game over - gameID=[gameID]`);
+    expect(error).toHaveBeenCalledWith(`game over - matchID=[gameID]`);
   });
 
   test('writes gameover to metadata', async () => {
@@ -340,7 +340,7 @@ describe('subscribe', () => {
   test('sync', async () => {
     master.onSync('gameID', '0');
     expect(callback).toBeCalledWith({
-      gameID: 'gameID',
+      matchID: 'gameID',
       state: expect.objectContaining({ _stateID: 0 }),
     });
   });
@@ -349,7 +349,7 @@ describe('subscribe', () => {
     const action = ActionCreators.gameEvent('endTurn');
     master.onUpdate(action, 0, 'gameID', '0');
     expect(callback).toBeCalledWith({
-      gameID: 'gameID',
+      matchID: 'gameID',
       action,
       state: expect.objectContaining({ _stateID: 1 }),
     });

--- a/src/master/master.test.ts
+++ b/src/master/master.test.ts
@@ -674,7 +674,7 @@ describe('doesMatchRequireAuthentication', () => {
 
   describe('when match has no credentials', () => {
     test('then authentication is not required', () => {
-      const matchMetadata = {
+      const matchData = {
         gameName: '',
         setupData: {},
         players: {
@@ -683,14 +683,14 @@ describe('doesMatchRequireAuthentication', () => {
         createdAt: 0,
         updatedAt: 0,
       };
-      const result = doesMatchRequireAuthentication(matchMetadata);
+      const result = doesMatchRequireAuthentication(matchData);
       expect(result).toBe(false);
     });
   });
 
   describe('when match has credentials', () => {
     test('then authentication is required', () => {
-      const matchMetadata = {
+      const matchData = {
         gameName: '',
         setupData: {},
         players: {
@@ -702,7 +702,7 @@ describe('doesMatchRequireAuthentication', () => {
         createdAt: 0,
         updatedAt: 0,
       };
-      const result = doesMatchRequireAuthentication(matchMetadata);
+      const result = doesMatchRequireAuthentication(matchData);
       expect(result).toBe(true);
     });
   });
@@ -711,7 +711,7 @@ describe('doesMatchRequireAuthentication', () => {
 describe('isActionFromAuthenticPlayer', () => {
   let action;
   let playerID;
-  let matchMetadata;
+  let matchData;
   let credentials;
   let playerMetadata;
 
@@ -722,13 +722,13 @@ describe('isActionFromAuthenticPlayer', () => {
       payload: { credentials: 'SECRET' },
     };
 
-    matchMetadata = {
+    matchData = {
       players: {
         '0': { credentials: 'SECRET' },
       },
     };
 
-    playerMetadata = matchMetadata.players[playerID];
+    playerMetadata = matchData.players[playerID];
     ({ credentials } = action.payload || {});
   });
 

--- a/src/master/master.test.ts
+++ b/src/master/master.test.ts
@@ -623,9 +623,7 @@ describe('getPlayerMetadata', () => {
 
   describe('when metadata does not contain players field', () => {
     test('then playerMetadata is undefined', () => {
-      expect(
-        getPlayerMetadata({} as Server.MatchMetadata, '0')
-      ).toBeUndefined();
+      expect(getPlayerMetadata({} as Server.MatchData, '0')).toBeUndefined();
     });
   });
 

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -26,7 +26,7 @@ import {
 import * as StorageAPI from '../server/db/base';
 
 export const getPlayerMetadata = (
-  matchData: Server.MatchMetadata,
+  matchData: Server.MatchData,
   playerID: PlayerID
 ) => {
   if (matchData && matchData.players) {
@@ -81,10 +81,10 @@ export function redactLog(log: LogEntry[], playerID: PlayerID) {
  * Verifies that the match has metadata and is using credentials.
  */
 export const doesMatchRequireAuthentication = (
-  matchData?: Server.MatchMetadata
+  matchData?: Server.MatchData
 ) => {
   if (!matchData) return false;
-  const { players } = matchData as Server.MatchMetadata;
+  const { players } = matchData as Server.MatchData;
   const hasCredentials = Object.keys(players).some(key => {
     return !!(players[key] && players[key].credentials);
   });
@@ -191,7 +191,7 @@ export class Master {
     playerID: string
   ) {
     let isActionAuthentic;
-    let metadata: Server.MatchMetadata | undefined;
+    let metadata: Server.MatchData | undefined;
     const credentials = credAction.payload.credentials;
     if (IsSynchronous(this.storageAPI)) {
       ({ metadata } = this.storageAPI.fetch(matchID, { metadata: true }));
@@ -305,7 +305,7 @@ export class Master {
 
     const { deltalog, ...stateWithoutDeltalog } = state;
 
-    let newMetadata: Server.MatchMetadata | undefined;
+    let newMetadata: Server.MatchData | undefined;
     if (metadata && !('gameover' in metadata)) {
       newMetadata = {
         ...metadata,
@@ -340,7 +340,7 @@ export class Master {
     let state: State;
     let initialState: State;
     let log: LogEntry[];
-    let matchData: Server.MatchMetadata;
+    let matchData: Server.MatchData;
     let filteredMetadata: FilteredMetadata;
     let result: StorageAPI.FetchResult<{
       state: true;

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -26,11 +26,11 @@ import {
 import * as StorageAPI from '../server/db/base';
 
 export const getPlayerMetadata = (
-  matchMetadata: Server.MatchMetadata,
+  matchData: Server.MatchMetadata,
   playerID: PlayerID
 ) => {
-  if (matchMetadata && matchMetadata.players) {
-    return matchMetadata.players[playerID];
+  if (matchData && matchData.players) {
+    return matchData.players[playerID];
   }
 };
 
@@ -81,10 +81,10 @@ export function redactLog(log: LogEntry[], playerID: PlayerID) {
  * Verifies that the match has metadata and is using credentials.
  */
 export const doesMatchRequireAuthentication = (
-  matchMetadata?: Server.MatchMetadata
+  matchData?: Server.MatchMetadata
 ) => {
-  if (!matchMetadata) return false;
-  const { players } = matchMetadata as Server.MatchMetadata;
+  if (!matchData) return false;
+  const { players } = matchData as Server.MatchMetadata;
   const hasCredentials = Object.keys(players).some(key => {
     return !!(players[key] && players[key].credentials);
   });
@@ -340,7 +340,7 @@ export class Master {
     let state: State;
     let initialState: State;
     let log: LogEntry[];
-    let matchMetadata: Server.MatchMetadata;
+    let matchData: Server.MatchMetadata;
     let filteredMetadata: FilteredMetadata;
     let result: StorageAPI.FetchResult<{
       state: true;
@@ -368,10 +368,10 @@ export class Master {
     state = result.state;
     initialState = result.initialState;
     log = result.log;
-    matchMetadata = result.metadata;
+    matchData = result.metadata;
 
-    if (matchMetadata) {
-      filteredMetadata = Object.values(matchMetadata.players).map(player => {
+    if (matchData) {
+      filteredMetadata = Object.values(matchData.players).map(player => {
         const { credentials, ...filteredData } = player;
         return filteredData;
       });

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -44,7 +44,7 @@ export const CreateMatch = async ({
 }) => {
   if (!numPlayers || typeof numPlayers !== 'number') numPlayers = 2;
 
-  const metadata: Server.MatchMetadata = {
+  const metadata: Server.MatchData = {
     gameName: game.name,
     unlisted: !!unlisted,
     players: {},
@@ -71,9 +71,9 @@ export const CreateMatch = async ({
  * @param {object} metadata - The match metadata object to strip credentials from.
  * @return - A metadata object without player credentials.
  */
-const createClientMatchMetadata = (
+const createClientMatchData = (
   matchID: string,
-  metadata: Server.MatchMetadata
+  metadata: Server.MatchData
 ): LobbyAPI.Match => {
   return {
     ...metadata,
@@ -199,7 +199,7 @@ export const createRouter = ({
         metadata: true,
       });
       if (!metadata.unlisted) {
-        matches.push(createClientMatchMetadata(matchID, metadata));
+        matches.push(createClientMatchData(matchID, metadata));
       }
     }
     const body: LobbyAPI.MatchList = { matches };
@@ -221,7 +221,7 @@ export const createRouter = ({
     if (!metadata) {
       ctx.throw(404, 'Match ' + matchID + ' not found');
     }
-    const body: LobbyAPI.Match = createClientMatchMetadata(matchID, metadata);
+    const body: LobbyAPI.Match = createClientMatchData(matchID, metadata);
     ctx.body = body;
   });
 

--- a/src/server/db/base.ts
+++ b/src/server/db/base.ts
@@ -22,7 +22,7 @@ export interface FetchOpts {
 export interface FetchFields {
   state: State;
   log: LogEntry[];
-  metadata: Server.MatchMetadata;
+  metadata: Server.MatchData;
   initialState: State;
 }
 
@@ -48,7 +48,7 @@ export interface ListGamesOpts {
  */
 export interface CreateGameOpts {
   initialState: State;
-  metadata: Server.MatchMetadata;
+  metadata: Server.MatchData;
 }
 
 export abstract class Async {
@@ -93,7 +93,7 @@ export abstract class Async {
    */
   abstract setMetadata(
     matchID: string,
-    metadata: Server.MatchMetadata
+    metadata: Server.MatchData
   ): Promise<void>;
 
   /**
@@ -151,7 +151,7 @@ export abstract class Sync {
   /**
    * Update the match metadata.
    */
-  abstract setMetadata(matchID: string, metadata: Server.MatchMetadata): void;
+  abstract setMetadata(matchID: string, metadata: Server.MatchData): void;
 
   /**
    * Fetch the game state.

--- a/src/server/db/flatfile.test.ts
+++ b/src/server/db/flatfile.test.ts
@@ -32,7 +32,7 @@ describe('FlatFile', () => {
 
     await db.createGame('gameID', {
       initialState: state as State,
-      metadata: metadata as Server.MatchMetadata,
+      metadata: metadata as Server.MatchData,
     });
 
     // Must return created game.

--- a/src/server/db/flatfile.ts
+++ b/src/server/db/flatfile.ts
@@ -78,39 +78,39 @@ export class FlatFile extends StorageAPI.Async {
   }
 
   async createGame(
-    gameID: string,
+    matchID: string,
     opts: StorageAPI.CreateGameOpts
   ): Promise<void> {
     // Store initial state separately for easy retrieval later.
-    const key = InitialStateKey(gameID);
+    const key = InitialStateKey(matchID);
 
     await this.setItem(key, opts.initialState);
-    await this.setState(gameID, opts.initialState);
-    await this.setMetadata(gameID, opts.metadata);
+    await this.setState(matchID, opts.initialState);
+    await this.setMetadata(matchID, opts.metadata);
   }
 
   async fetch<O extends StorageAPI.FetchOpts>(
-    gameID: string,
+    matchID: string,
     opts: O
   ): Promise<StorageAPI.FetchResult<O>> {
     let result = {} as StorageAPI.FetchFields;
 
     if (opts.state) {
-      result.state = (await this.getItem(gameID)) as State;
+      result.state = (await this.getItem(matchID)) as State;
     }
 
     if (opts.metadata) {
-      const key = MetadataKey(gameID);
+      const key = MetadataKey(matchID);
       result.metadata = (await this.getItem(key)) as Server.MatchMetadata;
     }
 
     if (opts.log) {
-      const key = LogKey(gameID);
+      const key = LogKey(matchID);
       result.log = (await this.getItem(key)) as LogEntry[];
     }
 
     if (opts.initialState) {
-      const key = InitialStateKey(gameID);
+      const key = InitialStateKey(matchID);
       result.initialState = (await this.getItem(key)) as State;
     }
 
@@ -157,14 +157,14 @@ export class FlatFile extends StorageAPI.Async {
   }
 }
 
-function InitialStateKey(gameID: string) {
-  return `${gameID}:initial`;
+function InitialStateKey(matchID: string) {
+  return `${matchID}:initial`;
 }
 
-function MetadataKey(gameID: string) {
-  return `${gameID}:metadata`;
+function MetadataKey(matchID: string) {
+  return `${matchID}:metadata`;
 }
 
-function LogKey(gameID: string) {
-  return `${gameID}:log`;
+function LogKey(matchID: string) {
+  return `${matchID}:log`;
 }

--- a/src/server/db/flatfile.ts
+++ b/src/server/db/flatfile.ts
@@ -16,7 +16,7 @@ export class FlatFile extends StorageAPI.Async {
   private games: {
     init: (opts: object) => Promise<void>;
     setItem: (id: string, value: any) => Promise<any>;
-    getItem: (id: string) => Promise<State | Server.MatchMetadata | LogEntry[]>;
+    getItem: (id: string) => Promise<State | Server.MatchData | LogEntry[]>;
     removeItem: (id: string) => Promise<void>;
     clear: () => {};
     keys: () => Promise<string[]>;
@@ -101,7 +101,7 @@ export class FlatFile extends StorageAPI.Async {
 
     if (opts.metadata) {
       const key = MetadataKey(matchID);
-      result.metadata = (await this.getItem(key)) as Server.MatchMetadata;
+      result.metadata = (await this.getItem(key)) as Server.MatchData;
     }
 
     if (opts.log) {
@@ -132,7 +132,7 @@ export class FlatFile extends StorageAPI.Async {
     return await this.setItem(id, state);
   }
 
-  async setMetadata(id: string, metadata: Server.MatchMetadata): Promise<void> {
+  async setMetadata(id: string, metadata: Server.MatchData): Promise<void> {
     const key = MetadataKey(id);
 
     return await this.setItem(key, metadata);

--- a/src/server/db/inmemory.test.ts
+++ b/src/server/db/inmemory.test.ts
@@ -31,7 +31,7 @@ describe('InMemory', () => {
       metadata: {
         gameName: 'tic-tac-toe',
         updatedAt: new Date(2020, 1).getTime(),
-      } as Server.MatchMetadata,
+      } as Server.MatchData,
       initialState: stateEntry as State,
     });
 
@@ -61,7 +61,7 @@ describe('InMemory', () => {
           gameName: 'tic-tac-toe',
           gameover: 'gameover',
           updatedAt: new Date(2020, 3).getTime(),
-        } as Server.MatchMetadata,
+        } as Server.MatchData,
         initialState: stateEntry as State,
       });
 
@@ -79,7 +79,7 @@ describe('InMemory', () => {
         metadata: {
           gameName: 'tic-tac-toe',
           updatedAt: new Date(2020, 5).getTime(),
-        } as Server.MatchMetadata,
+        } as Server.MatchData,
         initialState: stateEntry as State,
       });
       const timestamp = new Date(2020, 4);

--- a/src/server/db/inmemory.ts
+++ b/src/server/db/inmemory.ts
@@ -32,53 +32,53 @@ export class InMemory extends StorageAPI.Sync {
   /**
    * Create a new game.
    */
-  createGame(gameID: string, opts: StorageAPI.CreateGameOpts) {
-    this.initial.set(gameID, opts.initialState);
-    this.setState(gameID, opts.initialState);
-    this.setMetadata(gameID, opts.metadata);
+  createGame(matchID: string, opts: StorageAPI.CreateGameOpts) {
+    this.initial.set(matchID, opts.initialState);
+    this.setState(matchID, opts.initialState);
+    this.setMetadata(matchID, opts.metadata);
   }
 
   /**
    * Write the game metadata to the in-memory object.
    */
-  setMetadata(gameID: string, metadata: Server.MatchMetadata) {
-    this.metadata.set(gameID, metadata);
+  setMetadata(matchID: string, metadata: Server.MatchMetadata) {
+    this.metadata.set(matchID, metadata);
   }
 
   /**
    * Write the game state to the in-memory object.
    */
-  setState(gameID: string, state: State, deltalog?: LogEntry[]): void {
+  setState(matchID: string, state: State, deltalog?: LogEntry[]): void {
     if (deltalog && deltalog.length > 0) {
-      const log = this.log.get(gameID) || [];
-      this.log.set(gameID, log.concat(deltalog));
+      const log = this.log.get(matchID) || [];
+      this.log.set(matchID, log.concat(deltalog));
     }
-    this.state.set(gameID, state);
+    this.state.set(matchID, state);
   }
 
   /**
-   * Fetches state for a particular gameID.
+   * Fetches state for a particular matchID.
    */
   fetch<O extends StorageAPI.FetchOpts>(
-    gameID: string,
+    matchID: string,
     opts: O
   ): StorageAPI.FetchResult<O> {
     let result = {} as StorageAPI.FetchFields;
 
     if (opts.state) {
-      result.state = this.state.get(gameID);
+      result.state = this.state.get(matchID);
     }
 
     if (opts.metadata) {
-      result.metadata = this.metadata.get(gameID);
+      result.metadata = this.metadata.get(matchID);
     }
 
     if (opts.log) {
-      result.log = this.log.get(gameID) || [];
+      result.log = this.log.get(matchID) || [];
     }
 
     if (opts.initialState) {
-      result.initialState = this.initial.get(gameID);
+      result.initialState = this.initial.get(matchID);
     }
 
     return result as StorageAPI.FetchResult<O>;
@@ -87,9 +87,9 @@ export class InMemory extends StorageAPI.Sync {
   /**
    * Remove the game state from the in-memory object.
    */
-  wipe(gameID: string) {
-    this.state.delete(gameID);
-    this.metadata.delete(gameID);
+  wipe(matchID: string) {
+    this.state.delete(matchID);
+    this.metadata.delete(matchID);
   }
 
   /**

--- a/src/server/db/inmemory.ts
+++ b/src/server/db/inmemory.ts
@@ -15,7 +15,7 @@ import * as StorageAPI from './base';
 export class InMemory extends StorageAPI.Sync {
   private state: Map<string, State>;
   private initial: Map<string, State>;
-  private metadata: Map<string, Server.MatchMetadata>;
+  private metadata: Map<string, Server.MatchData>;
   private log: Map<string, LogEntry[]>;
 
   /**
@@ -41,7 +41,7 @@ export class InMemory extends StorageAPI.Sync {
   /**
    * Write the game metadata to the in-memory object.
    */
-  setMetadata(matchID: string, metadata: Server.MatchMetadata) {
+  setMetadata(matchID: string, metadata: Server.MatchData) {
     this.metadata.set(matchID, metadata);
   }
 

--- a/src/server/transport/socketio.test.ts
+++ b/src/server/transport/socketio.test.ts
@@ -223,11 +223,11 @@ describe('connect / disconnect', () => {
     await io.socket.receive('sync', 'gameID', '1', 2);
 
     expect(toObj(clientInfo)['0']).toMatchObject({
-      gameID: 'gameID',
+      matchID: 'gameID',
       playerID: '0',
     });
     expect(toObj(clientInfo)['1']).toMatchObject({
-      gameID: 'gameID',
+      matchID: 'gameID',
       playerID: '1',
     });
   });
@@ -238,7 +238,7 @@ describe('connect / disconnect', () => {
 
     expect(toObj(clientInfo)['0']).toBeUndefined();
     expect(toObj(clientInfo)['1']).toMatchObject({
-      gameID: 'gameID',
+      matchID: 'gameID',
       playerID: '1',
     });
     expect(toObj(roomInfo.get('gameID'))).toEqual({ '1': '1' });
@@ -250,7 +250,7 @@ describe('connect / disconnect', () => {
 
     expect(toObj(clientInfo)['0']).toBeUndefined();
     expect(toObj(clientInfo)['1']).toMatchObject({
-      gameID: 'gameID',
+      matchID: 'gameID',
       playerID: '1',
     });
     expect(toObj(roomInfo.get('gameID'))).toEqual({ '1': '1' });

--- a/src/server/transport/socketio.ts
+++ b/src/server/transport/socketio.ts
@@ -24,7 +24,7 @@ const PING_INTERVAL = 10 * 1e3;
  * information to the clients.
  */
 export function TransportAPI(
-  gameID: string,
+  matchID: string,
   socket,
   clientInfo: Map<any, any>,
   roomInfo: Map<any, any>
@@ -33,7 +33,7 @@ export function TransportAPI(
    * Send a message to a specific client.
    */
   const send: MasterTransport['send'] = ({ type, playerID, args }) => {
-    const clients = roomInfo.get(gameID).values();
+    const clients = roomInfo.get(matchID).values();
     for (const client of clients) {
       const info = clientInfo.get(client);
       if (info.playerID == playerID) {
@@ -50,7 +50,7 @@ export function TransportAPI(
    * Send a message to all clients.
    */
   const sendAll: MasterTransport['sendAll'] = makePlayerData => {
-    roomInfo.get(gameID).forEach(c => {
+    roomInfo.get(matchID).forEach(c => {
       const playerID: PlayerID = clientInfo.get(c).playerID;
       const data = makePlayerData(playerID);
       send({ playerID, ...data });
@@ -112,47 +112,47 @@ export class SocketIO {
       const nsp = app._io.of(game.name);
 
       nsp.on('connection', socket => {
-        socket.on('update', async (action, stateID, gameID, playerID) => {
+        socket.on('update', async (action, stateID, matchID, playerID) => {
           const master = new Master(
             game,
             app.context.db,
-            TransportAPI(gameID, socket, this.clientInfo, this.roomInfo),
+            TransportAPI(matchID, socket, this.clientInfo, this.roomInfo),
             this.auth
           );
-          await master.onUpdate(action, stateID, gameID, playerID);
+          await master.onUpdate(action, stateID, matchID, playerID);
         });
 
-        socket.on('sync', async (gameID, playerID, numPlayers) => {
-          socket.join(gameID);
+        socket.on('sync', async (matchID, playerID, numPlayers) => {
+          socket.join(matchID);
 
           // Remove client from any previous game that it was a part of.
           if (this.clientInfo.has(socket.id)) {
-            const { gameID: oldGameID } = this.clientInfo.get(socket.id);
-            this.roomInfo.get(oldGameID).delete(socket.id);
+            const { matchID: oldMatchID } = this.clientInfo.get(socket.id);
+            this.roomInfo.get(oldMatchID).delete(socket.id);
           }
 
-          let roomClients = this.roomInfo.get(gameID);
+          let roomClients = this.roomInfo.get(matchID);
           if (roomClients === undefined) {
             roomClients = new Set();
-            this.roomInfo.set(gameID, roomClients);
+            this.roomInfo.set(matchID, roomClients);
           }
           roomClients.add(socket.id);
 
-          this.clientInfo.set(socket.id, { gameID, playerID, socket });
+          this.clientInfo.set(socket.id, { matchID, playerID, socket });
 
           const master = new Master(
             game,
             app.context.db,
-            TransportAPI(gameID, socket, this.clientInfo, this.roomInfo),
+            TransportAPI(matchID, socket, this.clientInfo, this.roomInfo),
             this.auth
           );
-          await master.onSync(gameID, playerID, numPlayers);
+          await master.onSync(matchID, playerID, numPlayers);
         });
 
         socket.on('disconnect', () => {
           if (this.clientInfo.has(socket.id)) {
-            const { gameID } = this.clientInfo.get(socket.id);
-            this.roomInfo.get(gameID).delete(socket.id);
+            const { matchID } = this.clientInfo.get(socket.id);
+            this.roomInfo.get(matchID).delete(socket.id);
             this.clientInfo.delete(socket.id);
           }
         });

--- a/src/types.ts
+++ b/src/types.ts
@@ -294,7 +294,7 @@ export namespace Server {
     data?: any;
   };
 
-  export interface MatchMetadata {
+  export interface MatchData {
     gameName: string;
     players: { [id: number]: PlayerMetadata };
     setupData?: any;
@@ -309,7 +309,7 @@ export namespace Server {
 export namespace LobbyAPI {
   export type GameList = string[];
   type PublicPlayerMetadata = Omit<Server.PlayerMetadata, 'credentials'>;
-  export type Match = Omit<Server.MatchMetadata, 'players'> & {
+  export type Match = Omit<Server.MatchData, 'players'> & {
     matchID: string;
     players: PublicPlayerMetadata[];
   };


### PR DESCRIPTION
This PR addresses #763, updating client and transport implementations to use `matchID`, `matchData`, `updateMatchID`, `subscribeMatchData`, etc. instead of using “game”.

So far I didn’t include the refactoring of the Storage API as that might require some further consideration, so I’ll await feedback before doing anything about that.

### Breaking changes

#### Clients should now be passed a `matchID` instead of `gameID`

```js
import { Client } from 'boardgame.io/react';

const App = Client({ game });

export default () => <App matchID="xyz" />;
```

```js
import { Client } from 'boardgame.io/client';

const client = Client({
  matchID: 'xyz',
  // ...
});

client.updateMatchID('abc');
```

#### React board components will receive `matchData` instead of `gameMetadata`

```js
const Board = ({ matchData }) => {
  return <div>{matchData}</div>
};
```