### PR TITLE
build: Exclude svelte from Rollup’s external module list

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,8 +17,9 @@ import pkg from './package.json';
 import typescript from 'rollup-plugin-typescript2';
 const subpackages = require('./subpackages');
 
+const internalDeps = ['svelte'];
 const external = [
-  ...Object.keys(pkg.dependencies),
+  ...Object.keys(pkg.dependencies).filter(name => !internalDeps.includes(name)),
   'react',
   'socket.io-client',
 ];


### PR DESCRIPTION
Fixes #766

@nicolodavis I’ve found it a little tricky to test this, but looking through the bundle output, this removes the Svelte imports introduced in 0.39.15, and I could get a demo project to build. Sorry for all the false starts getting the Svelte–Typescript integration working, I’ve been learning the hard way to double check my work…