### PR TITLE
Enforce that the debug menu is always on the top of the screen

### DIFF
--- a/src/client/debug/Debug.svelte
+++ b/src/client/debug/Debug.svelte
@@ -59,6 +59,8 @@
     font-size: 14px;
     box-sizing: border-box;
     opacity: 0.9;
+    /* we want the debug panel to be above any other elements */
+    z-index: 99999;
   }
 
   .pane {


### PR DESCRIPTION
Only change here is adding `z-index` to alter the debug-menu render height.

Fixes #778