### PR TITLE
fix(core): Fix EndPhase deltalog

### DIFF
--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -438,7 +438,7 @@ export function Flow({
 
   function EndPhase(state: State, { arg, next, turn, automatic }: any): State {
     // End the turn first.
-    state = EndTurn(state, { turn, force: true });
+    state = EndTurn(state, { turn, force: true, automatic: true });
 
     let G = state.G;
     let ctx = state.ctx;


### PR DESCRIPTION
A side effect of calling `EndPhase()` is an automatic call to `EndTurn()`. LogEntries for `endPhase` and `endTurn` log entries are added to `deltalog`.

When the user mouses over `LogEntries` in the **Debug Panel**, the state is regenerated/reduced from the deltalogs. `EndPhase()` *again* makes an automatic call to `EndTurn()`, and then the `endTurn` in the `deltalog` is also called, resulting in
one-too-many calls to `EndTurn()`.

This issue affects games using `DEFAULT` turn order and causes playback fail when using the `Debug:Log` Panel.

This error is generated to the browser console:
```
   ERROR: disallowed move: MYMOVENAME
```
where *MYMOVENAME* is the name of the move that fails.

Appears to correct issue #810

Issue also reported:
 * [Gitter 2020-06-23 07:05](https://gitter.im/boardgame-io/General?at=5ef1f017b8152d34845bace8)
 * [Gitter 2020-07-08 02:16](https://gitter.im/boardgame-io/General?at=5f05778fc7d15f7d0f7b1e01)