### PR TITLE
fix(client): Fix playerView executed twice do not strip again if is multiplayer

### DIFF
--- a/docs/documentation/notable_projects.md
+++ b/docs/documentation/notable_projects.md
@@ -2,7 +2,7 @@
 
 List of notable projects using boardgame.io. This list is not exhaustive. Feel free to send a PR to add your project to this list, but please have a demo that's accessible via a URL.
 
-- [Camelot](https://www.playcamelot.com/) - Play the Camelot board game online.
+- [Camelot](https://github.com/blunket/camelot) - [play](https://www.playcamelot.com/) - Play the Camelot board game online.
 
 - [Matchimals.fun](https://github.com/chrisheninger/matchimals.fun) - [play](https://www.matchimals.fun/) - An animal matching puzzle card game.
 

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -261,6 +261,41 @@ describe('multiplayer', () => {
   });
 });
 
+describe('strip secret only on server', () => {
+  let client0;
+  let client1;
+  let spec;
+  let initial = { secret: [1, 2, 3, 4], sum: 0 };
+  beforeAll(() => {
+    spec = {
+      game: {
+        setup: () => initial,
+        playerView: (G, ctx, playerID) => {
+          let r = { ...G };
+          r.sum = r.secret.reduce((prev, curr) => {
+            return prev + curr;
+          });
+          delete r.secret;
+          return r;
+        },
+        moves: { A: (G, ctx) => ({ A: ctx.playerID }) },
+      },
+      multiplayer: Local(),
+    };
+
+    client0 = Client({ ...spec, playerID: '0' });
+    client1 = Client({ ...spec, playerID: '1' });
+
+    client0.start();
+    client1.start();
+  });
+
+  test('secret stripped', () => {
+    expect(client0.getState().G).toEqual({ sum: 10 });
+    expect(client1.getState().G).toEqual({ sum: 10 });
+  });
+});
+
 test('accepts enhancer for store', () => {
   let spyDispatcher;
   const spyEnhancer = vanillaCreateStore => (...args) => {

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -294,6 +294,11 @@ describe('strip secret only on server', () => {
     expect(client0.getState().G).toEqual({ sum: 10 });
     expect(client1.getState().G).toEqual({ sum: 10 });
   });
+
+  afterAll(() => {
+    client0.stop();
+    client1.stop();
+  });
 });
 
 test('accepts enhancer for store', () => {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -435,14 +435,11 @@ export class _ClientImpl<G extends any = any> {
     // Secrets are normally stripped on the server,
     // but we also strip them here so that game developers
     // can see their effects while prototyping.
-    let G;
-    if (!this.multiplayer) {
-      G = this.game.playerView(state.G, state.ctx, this.playerID);
-    } else {
-      // Do not strip again if this is a multiplayer game
-      // since the server has already stripped secret info.
-      G = state.G;
-    }
+    // Do not strip again if this is a multiplayer game
+    // since the server has already stripped secret info. (issue #818)
+    const G = this.multiplayer
+      ? state.G
+      : this.game.playerView(state.G, state.ctx, this.playerID);
 
     // Combine into return value.
     return {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -435,7 +435,14 @@ export class _ClientImpl<G extends any = any> {
     // Secrets are normally stripped on the server,
     // but we also strip them here so that game developers
     // can see their effects while prototyping.
-    const G = this.game.playerView(state.G, state.ctx, this.playerID);
+    let G;
+    if (!this.multiplayer) {
+      G = this.game.playerView(state.G, state.ctx, this.playerID);
+    } else {
+      // Do not strip again if this is a multiplayer game
+      // since the server has already stripped secret info.
+      G = state.G;
+    }
 
     // Combine into return value.
     return {


### PR DESCRIPTION
Fix #818 
This fix disable strip on client if current client is multiplayer .
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
