### PR TITLE
fix(master): Use `createMatch` for implicit match creation

### DIFF
--- a/src/master/master.test.ts
+++ b/src/master/master.test.ts
@@ -61,9 +61,9 @@ describe('sync', () => {
   });
 
   test('sync a second time does not create a game', async () => {
-    const fetchResult = db.fetch('gameID', { metadata: true });
-    await master.onSync('gameID', '0', 2);
-    expect(db.fetch('gameID', { metadata: true })).toMatchObject(fetchResult);
+    const fetchResult = db.fetch('matchID', { metadata: true });
+    await master.onSync('matchID', '0', 2);
+    expect(db.fetch('matchID', { metadata: true })).toMatchObject(fetchResult);
   });
 
   test('should not have metadata', async () => {
@@ -93,7 +93,7 @@ describe('sync', () => {
       createdAt: 0,
       updatedAt: 0,
     };
-    db.createGame('gameID', { metadata, initialState: {} as State });
+    db.createMatch('matchID', { metadata, initialState: {} as State });
     const masterWithMetadata = new Master(game, db, TransportAPI(send));
     await masterWithMetadata.onSync('matchID', '0', 2);
 

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -334,7 +334,7 @@ export class Master {
    * Called when the client connects / reconnects.
    * Returns the latest game state and the entire log.
    */
-  async onSync(matchID: string, playerID: string, numPlayers: number) {
+  async onSync(matchID: string, playerID: string, numPlayers = 2) {
     const key = matchID;
 
     let state: State;

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -366,9 +366,9 @@ export class Master {
       this.subscribeCallback({ state, matchID });
 
       if (IsSynchronous(this.storageAPI)) {
-        this.storageAPI.createGame(key, { initialState, metadata });
+        this.storageAPI.createMatch(key, { initialState, metadata });
       } else {
-        await this.storageAPI.createGame(key, { initialState, metadata });
+        await this.storageAPI.createMatch(key, { initialState, metadata });
       }
     }
 

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -23,6 +23,7 @@ import {
   LogEntry,
   PlayerID,
 } from '../types';
+import { createMetadata } from '../server/util';
 import * as StorageAPI from '../server/db/base';
 
 export const getPlayerMetadata = (
@@ -387,10 +388,16 @@ export class Master {
         matchID,
       });
 
+      const metadata: Server.MatchData = createMetadata({
+        game: this.game,
+        unlisted: true,
+        numPlayers,
+      });
+
       if (IsSynchronous(this.storageAPI)) {
-        this.storageAPI.setState(key, state);
+        this.storageAPI.createGame(key, { initialState, metadata });
       } else {
-        await this.storageAPI.setState(key, state);
+        await this.storageAPI.createGame(key, { initialState, metadata });
       }
     }
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -15,6 +15,7 @@ import cors from '@koa/cors';
 import { InitializeGame } from '../core/initialize';
 import * as StorageAPI from './db/base';
 import { Server, LobbyAPI, Game } from '../types';
+import { createMetadata } from './util';
 
 /**
  * Creates a new match.
@@ -44,18 +45,7 @@ export const CreateMatch = async ({
 }) => {
   if (!numPlayers || typeof numPlayers !== 'number') numPlayers = 2;
 
-  const metadata: Server.MatchData = {
-    gameName: game.name,
-    unlisted: !!unlisted,
-    players: {},
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
-  };
-  if (setupData !== undefined) metadata.setupData = setupData;
-  for (let playerIndex = 0; playerIndex < numPlayers; playerIndex++) {
-    metadata.players[playerIndex] = { id: playerIndex };
-  }
-
+  const metadata = createMetadata({ game, numPlayers, setupData, unlisted });
   const matchID = uuid();
   const initialState = InitializeGame({ game, numPlayers, setupData });
 

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -1,0 +1,32 @@
+import { Server, Game } from '../types';
+
+/**
+ * Creates a new match metadata object.
+ */
+export const createMetadata = ({
+  game,
+  unlisted,
+  setupData,
+  numPlayers,
+}: {
+  game: Game;
+  numPlayers: number;
+  setupData?: any;
+  unlisted?: boolean;
+}): Server.MatchData => {
+  const metadata: Server.MatchData = {
+    gameName: game.name,
+    unlisted: !!unlisted,
+    players: {},
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+
+  if (setupData !== undefined) metadata.setupData = setupData;
+
+  for (let playerIndex = 0; playerIndex < numPlayers; playerIndex++) {
+    metadata.players[playerIndex] = { id: playerIndex };
+  }
+
+  return metadata;
+};


### PR DESCRIPTION
Closes #722 

This makes implicit match creation in the master consistent with match creation via the Lobby API by using the Storage API’s `createMatch` method and creating basic match metadata even for these implicitly created matches. (It helps that we can now mark these matches as unlisted just in case someone was mixing the Lobby API & implicit match creation.)

Apart from the consistency, this also fixes a bug by ensuring that `initialState` is stored for implicitly created matches. Previously, by only using `setState`, clients couldn’t retrieve `initialState` for matches that had been initialised in this way, because it was never stored.