### PR TITLE
feat: Improve undo/redo

### DIFF
--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -201,34 +201,6 @@ describe('phases', () => {
 });
 
 describe('turn', () => {
-  test('onBegin with undoable feature', () => {
-    const onBegin = jest.fn(G => G);
-    const flow = Flow({
-      turn: { onBegin },
-      disableUndo: false,
-    });
-    const state = { ctx: flow.ctx(2) };
-
-    expect(onBegin).not.toHaveBeenCalled();
-    const updatedState = flow.init(state);
-    expect(onBegin).toHaveBeenCalled();
-    expect(updatedState._undo).toHaveLength(1);
-  });
-
-  test('onBegin without undoable feature', () => {
-    const onBegin = jest.fn(G => G);
-    const flow = Flow({
-      turn: { onBegin },
-      disableUndo: true,
-    });
-    const state = { ctx: flow.ctx(2) };
-
-    expect(onBegin).not.toHaveBeenCalled();
-    const updatedState = flow.init(state);
-    expect(onBegin).toHaveBeenCalled();
-    expect(updatedState._undo).toHaveLength(0);
-  });
-
   test('onEnd', () => {
     const onEnd = jest.fn(G => G);
     const flow = Flow({

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -43,7 +43,6 @@ export function Flow({
   turn,
   events,
   plugins,
-  disableUndo,
 }: Game) {
   // Attach defaults.
   if (moves === undefined) {
@@ -297,9 +296,7 @@ export function Flow({
 
     G = conf.turn.wrapped.onBegin({ ...state, G, ctx });
 
-    const _undo = disableUndo ? [] : [{ G, ctx }];
-
-    return { ...state, G, ctx, _undo, _redo: [] };
+    return { ...state, G, ctx, _undo: [], _redo: [] } as State;
   }
 
   ////////////

--- a/src/core/initialize.ts
+++ b/src/core/initialize.ts
@@ -63,5 +63,16 @@ export function InitializeGame({
   initial = game.flow.init(initial);
   initial = plugins.Flush(initial, { game });
 
+  // Initialize undo stack.
+  if (!game.disableUndo) {
+    initial._undo = [
+      {
+        G: initial.G,
+        ctx: initial.ctx,
+        plugins: initial.plugins,
+      },
+    ];
+  }
+
   return initial;
 }

--- a/src/core/reducer.test.ts
+++ b/src/core/reducer.test.ts
@@ -457,6 +457,12 @@ describe('undo stack', () => {
     const newState = reducer(state, undo());
     expect(state).toEqual(newState);
   });
+
+  test('can’t undo another player’s move', () => {
+    state = reducer(state, makeMove('basic', null, '1'));
+    const newState = reducer(state, undo('0'));
+    expect(state).toEqual(newState);
+  });
 });
 
 describe('redo stack', () => {

--- a/src/core/reducer.test.ts
+++ b/src/core/reducer.test.ts
@@ -510,6 +510,15 @@ describe('redo stack', () => {
     state = reducer(state, makeMove('endTurn'));
     expect(state._redo).toHaveLength(0);
   });
+
+  test('can’t redo another player’s undo', () => {
+    state = reducer(state, makeMove('basic', null, '1'));
+    state = reducer(state, undo('1'));
+    expect(state._redo).toHaveLength(1);
+    const newState = reducer(state, redo('0'));
+    expect(state._redo).toHaveLength(1);
+    expect(newState).toEqual(state);
+  });
 });
 
 describe('undo / redo with stages', () => {

--- a/src/core/reducer.test.ts
+++ b/src/core/reducer.test.ts
@@ -314,10 +314,10 @@ test('undo / redo', () => {
 
   let state = InitializeGame({ game });
 
-  state = reducer(state, makeMove('move', 'A'));
+  state = reducer(state, makeMove('move', 'A', '0'));
   expect(state.G).toMatchObject({ A: true });
 
-  state = reducer(state, makeMove('move', 'B'));
+  state = reducer(state, makeMove('move', 'B', '0'));
   expect(state.G).toMatchObject({ A: true, B: true });
   expect(state._undo[1].ctx.events).toBeUndefined();
   expect(state._undo[1].ctx.random).toBeUndefined();
@@ -340,7 +340,7 @@ test('undo / redo', () => {
   expect(state.G).toEqual({});
 
   state = reducer(state, redo());
-  state = reducer(state, makeMove('move', 'C'));
+  state = reducer(state, makeMove('move', 'C', '0'));
   expect(state.G).toMatchObject({ A: true, C: true });
 
   state = reducer(state, undo());
@@ -351,7 +351,7 @@ test('undo / redo', () => {
 
   state = reducer(state, undo());
   state = reducer(state, undo());
-  state = reducer(state, makeMove('roll'));
+  state = reducer(state, makeMove('roll', null, '0'));
   expect(state.G).toMatchObject({ roll: 4 });
 
   state = reducer(state, undo());
@@ -377,12 +377,12 @@ test('disable undo / redo', () => {
 
   let state = InitializeGame({ game });
 
-  state = reducer(state, makeMove('move', 'A'));
+  state = reducer(state, makeMove('move', 'A', '0'));
   expect(state.G).toMatchObject({ A: true });
   expect(state._undo).toEqual([]);
   expect(state._redo).toEqual([]);
 
-  state = reducer(state, makeMove('move', 'B'));
+  state = reducer(state, makeMove('move', 'B', '0'));
   expect(state.G).toMatchObject({ A: true, B: true });
   expect(state._undo).toEqual([]);
   expect(state._redo).toEqual([]);
@@ -423,7 +423,7 @@ describe('undo stack', () => {
   });
 
   test('grows when a move is made', () => {
-    state = reducer(state, makeMove('basic'));
+    state = reducer(state, makeMove('basic', null, '0'));
     expect(state._undo).toHaveLength(2);
     expect(state._undo[1].moveType).toBe('basic');
     expect(state._undo[1].ctx).toEqual(state.ctx);
@@ -477,7 +477,7 @@ describe('redo stack', () => {
   });
 
   test('grows when a move is undone', () => {
-    state = reducer(state, makeMove('basic'));
+    state = reducer(state, makeMove('basic', null, '0'));
     state = reducer(state, undo());
     expect(state._redo).toHaveLength(1);
     expect(state._redo[0].moveType).toBe('basic');
@@ -489,16 +489,16 @@ describe('redo stack', () => {
   });
 
   test('is reset when a move is made', () => {
-    state = reducer(state, makeMove('basic'));
+    state = reducer(state, makeMove('basic', null, '0'));
     state = reducer(state, undo());
     state = reducer(state, undo());
     expect(state._redo).toHaveLength(2);
-    state = reducer(state, makeMove('basic'));
+    state = reducer(state, makeMove('basic', null, '0'));
     expect(state._redo).toHaveLength(0);
   });
 
   test('is reset when a turn ends', () => {
-    state = reducer(state, makeMove('basic'));
+    state = reducer(state, makeMove('basic', null, '0'));
     state = reducer(state, undo());
     expect(state._redo).toHaveLength(1);
     state = reducer(state, makeMove('endTurn'));

--- a/src/core/reducer.test.ts
+++ b/src/core/reducer.test.ts
@@ -419,6 +419,7 @@ describe('undo stack', () => {
   test('contains initial state at start of game', () => {
     expect(state._undo).toHaveLength(1);
     expect(state._undo[0].ctx).toEqual(state.ctx);
+    expect(state._undo[0].plugins).toEqual(state.plugins);
   });
 
   test('grows when a move is made', () => {
@@ -426,12 +427,14 @@ describe('undo stack', () => {
     expect(state._undo).toHaveLength(2);
     expect(state._undo[1].moveType).toBe('basic');
     expect(state._undo[1].ctx).toEqual(state.ctx);
+    expect(state._undo[1].plugins).toEqual(state.plugins);
   });
 
   test('shrinks when a move is undone', () => {
     state = reducer(state, undo());
     expect(state._undo).toHaveLength(1);
     expect(state._undo[0].ctx).toEqual(state.ctx);
+    expect(state._undo[0].plugins).toEqual(state.plugins);
   });
 
   test('grows when a move is redone', () => {
@@ -439,13 +442,20 @@ describe('undo stack', () => {
     expect(state._undo).toHaveLength(2);
     expect(state._undo[1].moveType).toBe('basic');
     expect(state._undo[1].ctx).toEqual(state.ctx);
+    expect(state._undo[1].plugins).toEqual(state.plugins);
   });
 
   test('is reset when a turn ends', () => {
     state = reducer(state, makeMove('endTurn'));
     expect(state._undo).toHaveLength(1);
     expect(state._undo[0].ctx).toEqual(state.ctx);
-    expect(state._undo[0].moveType).toBeUndefined();
+    expect(state._undo[0].plugins).toEqual(state.plugins);
+    expect(state._undo[0].moveType).toBe('endTurn');
+  });
+
+  test('can’t undo at the start of a turn', () => {
+    const newState = reducer(state, undo());
+    expect(state).toEqual(newState);
   });
 });
 

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -23,6 +23,17 @@ import {
 } from '../types';
 
 /**
+ * Check if the payload for the passed action contains a playerID.
+ */
+const actionHasPlayerID = (
+  action:
+    | ActionShape.MakeMove
+    | ActionShape.GameEvent
+    | ActionShape.Undo
+    | ActionShape.Redo
+) => action.payload.playerID !== null && action.payload.playerID !== undefined;
+
+/**
  * Returns true if a move can be undone.
  */
 const CanUndoMove = (G: any, ctx: Ctx, move: Move): boolean => {
@@ -120,8 +131,7 @@ export function CreateGameReducer({
 
         // Ignore the event if the player isn't active.
         if (
-          action.payload.playerID !== null &&
-          action.payload.playerID !== undefined &&
+          actionHasPlayerID(action) &&
           !game.flow.isPlayerActive(state.G, state.ctx, action.payload.playerID)
         ) {
           error(`disallowed event: ${action.payload.type}`);
@@ -174,8 +184,7 @@ export function CreateGameReducer({
 
         // Ignore the move if the player isn't active.
         if (
-          action.payload.playerID !== null &&
-          action.payload.playerID !== undefined &&
+          actionHasPlayerID(action) &&
           !game.flow.isPlayerActive(state.G, state.ctx, action.payload.playerID)
         ) {
           error(`disallowed move: ${action.payload.type}`);
@@ -278,8 +287,7 @@ export function CreateGameReducer({
 
         // Only allow players to undo their own moves.
         if (
-          action.payload.playerID !== null &&
-          action.payload.playerID !== undefined &&
+          actionHasPlayerID(action) &&
           action.payload.playerID !== last.playerID
         ) {
           return state;
@@ -320,8 +328,7 @@ export function CreateGameReducer({
 
         // Only allow players to redo their own undos.
         if (
-          action.payload.playerID !== null &&
-          action.payload.playerID !== undefined &&
+          actionHasPlayerID(action) &&
           action.payload.playerID !== first.playerID
         ) {
           return state;

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -276,6 +276,15 @@ export function CreateGameReducer({
         const last = _undo[_undo.length - 1];
         const restore = _undo[_undo.length - 2];
 
+        // Only allow players to undo their own moves.
+        if (
+          action.payload.playerID !== null &&
+          action.payload.playerID !== undefined &&
+          action.payload.playerID !== last.playerID
+        ) {
+          return state;
+        }
+
         // Only allow undoable moves to be undone.
         const lastMove: Move = game.flow.getMove(
           restore.ctx,

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -63,6 +63,7 @@ function updateUndoRedoState(
     G: state.G,
     ctx: state.ctx,
     plugins: state.plugins,
+    playerID: opts.action.payload.playerID || state.ctx.currentPlayer,
   };
 
   if (opts.action.type === 'MAKE_MOVE') {
@@ -279,7 +280,7 @@ export function CreateGameReducer({
         const lastMove: Move = game.flow.getMove(
           restore.ctx,
           last.moveType,
-          action.payload.playerID
+          last.playerID
         );
         if (!CanUndoMove(state.G, state.ctx, lastMove)) {
           return state;

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -318,6 +318,15 @@ export function CreateGameReducer({
 
         const first = _redo[0];
 
+        // Only allow players to redo their own undos.
+        if (
+          action.payload.playerID !== null &&
+          action.payload.playerID !== undefined &&
+          action.payload.playerID !== first.playerID
+        ) {
+          return state;
+        }
+
         return {
           ...state,
           G: first.G,

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -242,9 +242,16 @@ export class Master {
     // that can make moves right now and the person doing the
     // action is that player.
     if (action.type == UNDO || action.type == REDO) {
+      const hasActivePlayers = state.ctx.activePlayers !== null;
+      const isCurrentPlayer = state.ctx.currentPlayer === playerID;
+
       if (
-        state.ctx.currentPlayer !== playerID ||
-        state.ctx.activePlayers !== null
+        // If activePlayers is empty, non-current players can’t undo.
+        (!hasActivePlayers && !isCurrentPlayer) ||
+        // If player is not active or multiple players are active, can’t undo.
+        (hasActivePlayers &&
+          (state.ctx.activePlayers[playerID] === undefined ||
+            Object.keys(state.ctx.activePlayers).length > 1))
       ) {
         logging.error(`playerID=[${playerID}] cannot undo / redo right now`);
         return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -277,6 +277,7 @@ export type Undo<G extends any = any> = {
     [pluginName: string]: PluginState;
   };
   moveType?: string;
+  playerID?: PlayerID;
 };
 
 export namespace Server {

--- a/src/types.ts
+++ b/src/types.ts
@@ -270,9 +270,12 @@ export interface Game<G extends any = any, CtxWithPlugins extends Ctx = Ctx> {
   flow?: ReturnType<typeof Flow>;
 }
 
-type Undo<G extends any = any> = {
+export type Undo<G extends any = any> = {
   G: G;
   ctx: Ctx;
+  plugins: {
+    [pluginName: string]: PluginState;
+  };
   moveType?: string;
 };
 


### PR DESCRIPTION
- Add plugins state and playerID to undo/redo entries.
- Only allow players to undo/redo their own actions.
- Improve undo/redo validity check in master (fixes #565).