### PR TITLE
refactor(lobby): Convert React components to Typescript

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -32,15 +32,11 @@ import {
   State,
   Store,
   Ctx,
+  DebugOpt,
 } from '../types';
 
 type ClientAction = ActionShape.Reset | ActionShape.Sync | ActionShape.Update;
 type Action = CredentialedActionShape.Any | ClientAction;
-
-interface DebugOpt {
-  target?: HTMLElement;
-  impl?: typeof Debug;
-}
 
 /**
  * Standardise the passed playerID, using currentPlayer if appropriate.

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -32,11 +32,15 @@ import {
   State,
   Store,
   Ctx,
-  DebugOpt,
 } from '../types';
 
 type ClientAction = ActionShape.Reset | ActionShape.Sync | ActionShape.Update;
 type Action = CredentialedActionShape.Any | ClientAction;
+
+interface DebugOpt {
+  target?: HTMLElement;
+  impl?: typeof Debug;
+}
 
 /**
  * Standardise the passed playerID, using currentPlayer if appropriate.

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -37,7 +37,7 @@ import {
 type ClientAction = ActionShape.Reset | ActionShape.Sync | ActionShape.Update;
 type Action = CredentialedActionShape.Any | ClientAction;
 
-interface DebugOpt {
+export interface DebugOpt {
   target?: HTMLElement;
   impl?: typeof Debug;
 }

--- a/src/lobby/connection.ts
+++ b/src/lobby/connection.ts
@@ -10,7 +10,7 @@ import React from 'react';
 import { LobbyClient } from './client';
 import { Game, LobbyAPI } from '../types';
 
-interface GameComponent {
+export interface GameComponent {
   game: Game;
   board: React.ComponentType<any>;
 }

--- a/src/lobby/create-match-form.tsx
+++ b/src/lobby/create-match-form.tsx
@@ -7,20 +7,29 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
+import { Game } from '../types';
+import { GameComponent } from './connection';
 
-class LobbyCreateMatchForm extends React.Component {
-  static propTypes = {
-    games: PropTypes.array.isRequired,
-    createMatch: PropTypes.func.isRequired,
-  };
+type CreateMatchProps = {
+  games: GameComponent[];
+  createMatch: (gameName: string, numPlayers: number) => Promise<void>;
+};
 
+type CreateMatchState = {
+  selectedGame: number;
+  numPlayers: number;
+};
+
+class LobbyCreateMatchForm extends React.Component<
+  CreateMatchProps,
+  CreateMatchState
+> {
   state = {
     selectedGame: 0,
     numPlayers: 2,
   };
 
-  constructor(props) {
+  constructor(props: CreateMatchProps) {
     super(props);
     /* fix min and max number of players */
     for (let game of props.games) {
@@ -39,7 +48,7 @@ class LobbyCreateMatchForm extends React.Component {
     };
   }
 
-  _createGameNameOption = (game, idx) => {
+  _createGameNameOption = (game: GameComponent, idx: number) => {
     return (
       <option key={'name-option-' + idx} value={idx}>
         {game.game.name}
@@ -47,7 +56,7 @@ class LobbyCreateMatchForm extends React.Component {
     );
   };
 
-  _createNumPlayersOption = idx => {
+  _createNumPlayersOption = (idx: number) => {
     return (
       <option key={'num-option-' + idx} value={idx}>
         {idx}
@@ -55,7 +64,7 @@ class LobbyCreateMatchForm extends React.Component {
     );
   };
 
-  _createNumPlayersRange = game => {
+  _createNumPlayersRange = (game: Game) => {
     return [...new Array(game.maxPlayers + 1).keys()].slice(game.minPlayers);
   };
 
@@ -84,13 +93,13 @@ class LobbyCreateMatchForm extends React.Component {
     );
   }
 
-  onChangeNumPlayers = event => {
+  onChangeNumPlayers = (event: React.ChangeEvent<HTMLSelectElement>) => {
     this.setState({
       numPlayers: Number.parseInt(event.target.value),
     });
   };
 
-  onChangeSelectedGame = event => {
+  onChangeSelectedGame = (event: React.ChangeEvent<HTMLSelectElement>) => {
     let idx = Number.parseInt(event.target.value);
     this.setState({
       selectedGame: idx,

--- a/src/lobby/login-form.tsx
+++ b/src/lobby/login-form.tsx
@@ -7,13 +7,18 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 
-class LobbyLoginForm extends React.Component {
-  static propTypes = {
-    playerName: PropTypes.string,
-    onEnter: PropTypes.func.isRequired,
-  };
+type LoginFormProps = {
+  playerName?: string;
+  onEnter: (playerName: string) => void;
+};
+
+type LoginFormState = {
+  playerName?: string;
+  nameErrorMsg: string;
+};
+
+class LobbyLoginForm extends React.Component<LoginFormProps, LoginFormState> {
   static defaultProps = {
     playerName: '',
   };
@@ -52,13 +57,13 @@ class LobbyLoginForm extends React.Component {
     this.props.onEnter(this.state.playerName);
   };
 
-  onKeyPress = event => {
+  onKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
       this.onClickEnter();
     }
   };
 
-  onChangePlayerName = event => {
+  onChangePlayerName = (event: React.ChangeEvent<HTMLInputElement>) => {
     const name = event.target.value.trim();
     this.setState({
       playerName: name,

--- a/src/lobby/match-instance.tsx
+++ b/src/lobby/match-instance.tsx
@@ -7,26 +7,34 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
+import { LobbyAPI } from '../types';
 
-class LobbyMatchInstance extends React.Component {
-  static propTypes = {
-    match: PropTypes.shape({
-      gameName: PropTypes.string.isRequired,
-      matchID: PropTypes.string.isRequired,
-      players: PropTypes.array.isRequired,
-    }),
-    playerName: PropTypes.string.isRequired,
-    onClickJoin: PropTypes.func.isRequired,
-    onClickLeave: PropTypes.func.isRequired,
-    onClickPlay: PropTypes.func.isRequired,
-  };
+export type MatchOpts = {
+  numPlayers: number;
+  matchID: string;
+  playerID?: string;
+};
 
-  _createSeat = player => {
+type Match = {
+  gameName: string;
+  matchID: string;
+  players: LobbyAPI.Match['players'];
+};
+
+type MatchInstanceProps = {
+  match: Match;
+  playerName: string;
+  onClickJoin: (gameName: string, matchID: string, playerID: string) => void;
+  onClickLeave: (gameName: string, matchID: string) => void;
+  onClickPlay: (gameName: string, matchOpts: MatchOpts) => void;
+};
+
+class LobbyMatchInstance extends React.Component<MatchInstanceProps> {
+  _createSeat = (player: { name?: string; }) => {
     return player.name || '[free]';
   };
 
-  _createButtonJoin = (inst, seatId) => (
+  _createButtonJoin = (inst: Match, seatId: number) => (
     <button
       key={'button-join-' + inst.matchID}
       onClick={() =>
@@ -37,7 +45,7 @@ class LobbyMatchInstance extends React.Component {
     </button>
   );
 
-  _createButtonLeave = inst => (
+  _createButtonLeave = (inst: Match) => (
     <button
       key={'button-leave-' + inst.matchID}
       onClick={() => this.props.onClickLeave(inst.gameName, inst.matchID)}
@@ -46,7 +54,7 @@ class LobbyMatchInstance extends React.Component {
     </button>
   );
 
-  _createButtonPlay = (inst, seatId) => (
+  _createButtonPlay = (inst: Match, seatId: number) => (
     <button
       key={'button-play-' + inst.matchID}
       onClick={() =>
@@ -61,7 +69,7 @@ class LobbyMatchInstance extends React.Component {
     </button>
   );
 
-  _createButtonSpectate = inst => (
+  _createButtonSpectate = (inst: Match) => (
     <button
       key={'button-spectate-' + inst.matchID}
       onClick={() =>
@@ -75,7 +83,7 @@ class LobbyMatchInstance extends React.Component {
     </button>
   );
 
-  _createInstanceButtons = inst => {
+  _createInstanceButtons = (inst: Match) => {
     const playerSeat = inst.players.find(
       player => player.name === this.props.playerName
     );

--- a/src/lobby/match-instance.tsx
+++ b/src/lobby/match-instance.tsx
@@ -30,7 +30,7 @@ type MatchInstanceProps = {
 };
 
 class LobbyMatchInstance extends React.Component<MatchInstanceProps> {
-  _createSeat = (player: { name?: string; }) => {
+  _createSeat = (player: { name?: string }) => {
     return player.name || '[free]';
   };
 

--- a/src/lobby/react.ssr.test.tsx
+++ b/src/lobby/react.ssr.test.tsx
@@ -13,9 +13,9 @@ global.fetch = jest
 
 describe('lobby', () => {
   test('is rendered', () => {
-    const components = [{ board: 'Board', game: { name: 'GameName' } }];
+    const components: any[] = [{ board: 'Board', game: { name: 'GameName' } }];
     const ssrRender = ReactDOMServer.renderToString(
-      <Lobby server="localhost" port={8001} gameComponents={components} />
+      <Lobby gameServer="localhost" gameComponents={components} />
     );
     expect(ssrRender).toContain('lobby-view');
   });

--- a/src/lobby/react.test.tsx
+++ b/src/lobby/react.test.tsx
@@ -27,7 +27,7 @@ Enzyme.configure({ adapter: new Adapter() });
 describe('lobby', () => {
   let lobby;
   let spy = jest.fn();
-  let components;
+  let components: any[];
 
   beforeEach(async () => {
     components = [
@@ -50,7 +50,7 @@ describe('lobby', () => {
   describe('specify servers', () => {
     test('gameServer', () => {
       const spy = jest.fn();
-      const lobby = Enzyme.mount(
+      const lobby: any = Enzyme.mount(
         <Lobby
           gameComponents={components}
           clientFactory={spy.mockReturnValue(NullComponent)}
@@ -524,7 +524,7 @@ describe('lobby', () => {
       });
 
       test('should render custom lobby with games list', () => {
-        const components = [
+        const components: any[] = [
           { game: { name: 'GameName1' } },
           { game: { name: 'GameName2' } },
         ];
@@ -553,7 +553,7 @@ describe('lobby', () => {
           <button onClick={() => onEnterLobby('Alex')}>Enter</button>
         );
 
-        const lobby = Enzyme.mount(
+        const lobby: any = Enzyme.mount(
           <Lobby
             gameComponents={[]}
             renderer={({ handleEnterLobby }) => (

--- a/src/lobby/react.tsx
+++ b/src/lobby/react.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import Cookies from 'react-cookies';
 import PropTypes from 'prop-types';
+import { DebugOpt } from '../client/client';
 import { Client } from '../client/react';
 import { MCTSBot } from '../ai/mcts-bot';
 import { Local } from '../client/transport/local';
@@ -36,7 +37,7 @@ type LobbyProps = {
   gameComponents: GameComponent[];
   lobbyServer?: string;
   gameServer?: string;
-  debug?: boolean;
+  debug?: DebugOpt | boolean;
   clientFactory?: typeof Client;
   refreshInterval?: number;
   renderer?: (args: {

--- a/src/lobby/react.tsx
+++ b/src/lobby/react.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import Cookies from 'react-cookies';
+import PropTypes from 'prop-types';
 import { Client } from '../client/react';
 import { MCTSBot } from '../ai/mcts-bot';
 import { Local } from '../client/transport/local';
@@ -87,6 +88,15 @@ type LobbyState = {
  *   spectate matches (game instances).
  */
 class Lobby extends React.Component<LobbyProps, LobbyState> {
+  static propTypes = {
+    gameComponents: PropTypes.array.isRequired,
+    lobbyServer: PropTypes.string,
+    gameServer: PropTypes.string,
+    debug: PropTypes.bool,
+    clientFactory: PropTypes.func,
+    refreshInterval: PropTypes.number,
+  };
+
   static defaultProps = {
     debug: false,
     clientFactory: Client,

--- a/src/lobby/react.tsx
+++ b/src/lobby/react.tsx
@@ -16,7 +16,7 @@ import { GameComponent, LobbyConnection } from './connection';
 import LobbyLoginForm from './login-form';
 import LobbyMatchInstance, { MatchOpts } from './match-instance';
 import LobbyCreateMatchForm from './create-match-form';
-import { LobbyAPI } from '../types';
+import { DebugOpt, LobbyAPI } from '../types';
 
 enum LobbyPhases {
   ENTER = 'enter',
@@ -35,7 +35,7 @@ type LobbyProps = {
   gameComponents: GameComponent[];
   lobbyServer?: string;
   gameServer?: string;
-  debug?: boolean;
+  debug?: DebugOpt | boolean;
   clientFactory?: typeof Client;
   refreshInterval?: number;
   renderer?: (args: {

--- a/src/lobby/react.tsx
+++ b/src/lobby/react.tsx
@@ -17,7 +17,7 @@ import { GameComponent, LobbyConnection } from './connection';
 import LobbyLoginForm from './login-form';
 import LobbyMatchInstance, { MatchOpts } from './match-instance';
 import LobbyCreateMatchForm from './create-match-form';
-import { DebugOpt, LobbyAPI } from '../types';
+import { LobbyAPI } from '../types';
 
 enum LobbyPhases {
   ENTER = 'enter',
@@ -36,7 +36,7 @@ type LobbyProps = {
   gameComponents: GameComponent[];
   lobbyServer?: string;
   gameServer?: string;
-  debug?: DebugOpt | boolean;
+  debug?: boolean;
   clientFactory?: typeof Client;
   refreshInterval?: number;
   renderer?: (args: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import { Object } from 'ts-toolbelt';
 import Koa from 'koa';
 import { Store as ReduxStore } from 'redux';
+import Debug from './client/debug/Debug.svelte';
 import * as ActionCreators from './core/action-creators';
 import { Flow } from './core/flow';
 import { CreateGameReducer } from './core/reducer';
@@ -399,4 +400,9 @@ export interface SyncInfo {
   filteredMetadata: FilteredMetadata;
   initialState: State;
   log: LogEntry[];
+}
+
+export interface DebugOpt {
+  target?: HTMLElement;
+  impl?: typeof Debug;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,6 @@
 import { Object } from 'ts-toolbelt';
 import Koa from 'koa';
 import { Store as ReduxStore } from 'redux';
-import Debug from './client/debug/Debug.svelte';
 import * as ActionCreators from './core/action-creators';
 import { Flow } from './core/flow';
 import { CreateGameReducer } from './core/reducer';
@@ -400,9 +399,4 @@ export interface SyncInfo {
   filteredMetadata: FilteredMetadata;
   initialState: State;
   log: LogEntry[];
-}
-
-export interface DebugOpt {
-  target?: HTMLElement;
-  impl?: typeof Debug;
 }


### PR DESCRIPTION
Similar to @coyotte508 in https://github.com/boardgameio/boardgame.io/issues/190#issuecomment-617446765, I recently ran into an issue importing `boardgame.io/client` due to the missing types in the Lobby React components. As such, this pull request converts the Lobby React components to Typescript which should fix the import error.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
