### PR TITLE
feat(server): Enable game setup to perform validation

### DIFF
--- a/docs/documentation/api/Game.md
+++ b/docs/documentation/api/Game.md
@@ -10,6 +10,12 @@
   // passed through the Game Creation API.
   setup: (ctx, setupData) => G,
 
+  // Optional function to validate the setupData before
+  // matches are created. If this returns a value,
+  // an error will be reported to the user and match
+  // creation is aborted.
+  validateSetupData: (setupData, numPlayers) => 'setupData is not valid!',
+
   moves: {
     // short-form move.
     A: (G, ctx) => {},

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -102,6 +102,19 @@ describe('.createRouter', () => {
                 }
               : {},
         },
+        {
+          name: 'validate',
+          setup: (_, setupData) =>
+            setupData
+              ? {
+                  numTokens: setupData.tokens,
+                }
+              : {},
+          validateSetupData: (setupData, numPlayers) =>
+            numPlayers == 2 && setupData.tokens !== 2
+              ? 'Two player games must use two tokens'
+              : undefined,
+        },
       ];
     });
 
@@ -223,6 +236,34 @@ describe('.createRouter', () => {
               }),
             })
           );
+        });
+      });
+
+      describe('with setupData validation', () => {
+        test('creates game if validation passes', async () => {
+          response = await request(app.callback())
+            .post('/games/validate/create')
+            .send({
+              numPlayers: 2,
+              setupData: {
+                tokens: 2,
+              },
+            });
+
+          expect(response.status).toEqual(200);
+        });
+
+        test('returns error if validation fails', async () => {
+          response = await request(app.callback())
+            .post('/games/validate/create')
+            .send({
+              numPlayers: 2,
+              setupData: {
+                tokens: 3,
+              },
+            });
+
+          expect(response.status).toEqual(400);
         });
       });
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -124,6 +124,10 @@ export const createRouter = ({
     const game = games.find(g => g.name === gameName);
     if (!game) ctx.throw(404, 'Game ' + gameName + ' not found');
 
+    const setupDataError =
+      game.validateSetupData && game.validateSetupData(setupData, numPlayers);
+    if (setupDataError !== undefined) ctx.throw(400, setupDataError);
+
     const matchID = await CreateMatch({
       db,
       game,

--- a/src/types.ts
+++ b/src/types.ts
@@ -231,13 +231,21 @@ interface PhaseMap<G extends any = any, CtxWithPlugins extends Ctx = Ctx> {
   [phaseName: string]: PhaseConfig<G, CtxWithPlugins>;
 }
 
-export interface Game<G extends any = any, CtxWithPlugins extends Ctx = Ctx> {
+export interface Game<
+  G extends any = any,
+  CtxWithPlugins extends Ctx = Ctx,
+  SetupData extends any = any
+> {
   name?: string;
   minPlayers?: number;
   maxPlayers?: number;
   disableUndo?: boolean;
   seed?: string | number;
-  setup?: (ctx: CtxWithPlugins, setupData?: any) => any;
+  setup?: (ctx: CtxWithPlugins, setupData?: SetupData) => any;
+  validateSetupData?: (
+    setupData: SetupData | undefined,
+    numPlayers: number
+  ) => string | undefined;
   moves?: MoveMap<G, CtxWithPlugins>;
   phases?: PhaseMap<G, CtxWithPlugins>;
   turn?: TurnConfig<G, CtxWithPlugins>;


### PR DESCRIPTION
Many games have complex rules which affect configuration or setup options. For example, Sushi Go Party ([see rules](https://gamewright.com/pdfs/Rules/SushiGoPartyTM-RULES.pdf)) allows the Edamame card to only be used when there are 3 or more players in the game or the Menu card when there are 6 or fewer players in the game. To enable games to feed back these sorts of validation results to the client, this pull request introduces a new exception type `GameSetupError` which game setup code can throw to indicate an incompatible configuration. If thrown, the exception is communicated back to the client as a HTTP 400 error.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
