### PR TITLE
ci(Github): Add npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,17 +25,17 @@ jobs:
           npm run test
 
       - name: Publish to NPM
-        id: npm_publish
+        id: publish
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
 
       - name: Version already published
-        if: steps.npm_publish.outputs.type == 'none'
+        if: steps.publish.outputs.type == 'none'
         run: |
-          echo "Version ${{ steps.npm_publish.outputs.old-version }} already exists."
+          echo "Version ${{ steps.publish.outputs.old-version }} already exists."
 
       - name: New version published
-        if: steps.npm_publish.outputs.type != 'none'
+        if: steps.publish.outputs.type != 'none'
         run: |
-          echo "New ${{ steps.npm_publish.outputs.type }} version ${{ steps.publish.outputs.version }} published. Was ${{ steps.npm_publish.outputs.old-version }}."
+          echo "New ${{ steps.publish.outputs.type }} version ${{ steps.publish.outputs.version }} published. Was ${{ steps.publish.outputs.old-version }}."

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,31 +10,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Use Node v12
         uses: actions/setup-node@v1
         with:
           node-version: 12
-      
+
       - name: Install Dependencies
         run: npm ci
-      
+
       - name: Run Tests
         run: |
           npm run lint
           npm run test
-      
+
       - name: Publish to NPM
         id: npm_publish
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          
+
       - name: Version already published
         if: steps.npm_publish.outputs.type == 'none'
         run: |
           echo "Version ${{ steps.npm_publish.outputs.old-version }} already exists."
-          
+
       - name: New version published
         if: steps.npm_publish.outputs.type != 'none'
         run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,41 @@
+name: Publish
+
+on:
+  push:
+    branches: [ master ]
+    tags: [ 'v0.[0-9]+.[0-9]+' ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Use Node v12
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      
+      - name: Install Dependencies
+        run: npm ci
+      
+      - name: Run Tests
+        run: |
+          npm run lint
+          npm run test
+      
+      - name: Publish to NPM
+        id: npm_publish
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          
+      - name: Version already published
+        if: steps.npm_publish.outputs.type == 'none'
+        run: |
+          echo "Version ${{ steps.npm_publish.outputs.old-version }} already exists."
+          
+      - name: New version published
+        if: steps.npm_publish.outputs.type != 'none'
+        run: |
+          echo "New ${{ steps.npm_publish.outputs.type }} version ${{ steps.publish.outputs.version }} published. Was ${{ steps.npm_publish.outputs.old-version }}."


### PR DESCRIPTION
This PR adds a GitHub workflow file that will run for new git tags on the master branch that have the form `v0.x.x`.

The workflow will:

  1. Run unit tests as a safety check.

  2. Try to publish to npm, using [this GitHub Action](https://github.com/marketplace/actions/npm-publish?version=v1).

If desirable, we could set `dry-run: true` on the publish step to test out the command before running it for real.

This workflow is only responsible for publishing to npm. Tagging a new release, updating the changelog etc. must still be done locally.