### PR TITLE
Add https://cantstop.fun to notable projects

### DIFF
--- a/docs/documentation/notable_projects.md
+++ b/docs/documentation/notable_projects.md
@@ -12,6 +12,8 @@ List of notable projects using boardgame.io. This list is not exhaustive. Feel f
 
 - [boardgame.io-angular](https://github.com/turn-based/boardgame.io-angular) - [demo](https://turn-based-209306.firebaseapp.com/) - Unofficial Angular client for boardgame.io.
 
+- [Can't Stop!](https://github.com/simlmx/cantstop) - [play](https://cantstop.fun) - The classic "push your luck" dice game.
+
 - [Cardman Multiplayer](https://github.com/VengelStudio/cardman-multiplayer) - [play](http://cardman-multiplayer.herokuapp.com) - A cross between Hangman and a card game.
 
 - [Elevation of Privilege](https://github.com/dehydr8/elevation-of-privilege) - [play](https://elevation-of-privilege.herokuapp.com/) - An online multiplayer version of the threat modeling card game.


### PR DESCRIPTION
Adding [cantstop.fun][1] to the notable projects list.

I wasn't exactly sure where to put it in the list: I followed the almost alphabetical order.
I'm happy to create a following PR sorting everything in alphabetical order if you folks think it's a good idea.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).

[1]: https://cantstop.fun