### PR TITLE
feat: Centralise lobby API and master authentication logic

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -489,6 +489,7 @@ export class _ClientImpl<G extends any = any> {
   updateCredentials(credentials: string) {
     this.credentials = credentials;
     this.createDispatchers();
+    this.transport.updateCredentials(credentials);
     this.notifySubscribers();
   }
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -335,6 +335,7 @@ export class _ClientImpl<G extends any = any> {
         store: this.store,
         matchID,
         playerID,
+        credentials,
         gameName: this.game.name,
         numPlayers,
       });

--- a/src/client/transport/local.ts
+++ b/src/client/transport/local.ts
@@ -203,7 +203,12 @@ export class LocalTransport extends Transport {
         this.onUpdate.apply(this, args);
       }
     });
-    this.master.onSync(this.matchID, this.playerID, this.numPlayers);
+    this.master.onSync(
+      this.matchID,
+      this.playerID,
+      this.credentials,
+      this.numPlayers
+    );
   }
 
   /**

--- a/src/client/transport/local.ts
+++ b/src/client/transport/local.ts
@@ -218,14 +218,21 @@ export class LocalTransport extends Transport {
   subscribeMatchData() {}
 
   /**
+   * Dispatches a reset action, then requests a fresh sync from the master.
+   */
+  private resetAndSync() {
+    const action = ActionCreators.reset(null);
+    this.store.dispatch(action);
+    this.connect();
+  }
+
+  /**
    * Updates the game id.
    * @param {string} id - The new game id.
    */
   updateMatchID(id: string) {
     this.matchID = id;
-    const action = ActionCreators.reset(null);
-    this.store.dispatch(action);
-    this.connect();
+    this.resetAndSync();
   }
 
   /**
@@ -234,9 +241,7 @@ export class LocalTransport extends Transport {
    */
   updatePlayerID(id: PlayerID) {
     this.playerID = id;
-    const action = ActionCreators.reset(null);
-    this.store.dispatch(action);
-    this.connect();
+    this.resetAndSync();
   }
 }
 

--- a/src/client/transport/local.ts
+++ b/src/client/transport/local.ts
@@ -149,10 +149,11 @@ export class LocalTransport extends Transport {
     store,
     matchID,
     playerID,
+    credentials,
     gameName,
     numPlayers,
   }: LocalTransportOpts) {
-    super({ store, gameName, playerID, matchID, numPlayers });
+    super({ store, gameName, playerID, matchID, credentials, numPlayers });
     this.master = master;
     this.isConnected = true;
   }
@@ -241,6 +242,15 @@ export class LocalTransport extends Transport {
    */
   updatePlayerID(id: PlayerID) {
     this.playerID = id;
+    this.resetAndSync();
+  }
+
+  /**
+   * Updates the credentials associated with this client.
+   * @param {string|undefined} credentials - The new credentials to use.
+   */
+  updateCredentials(credentials?: string) {
+    this.credentials = credentials;
     this.resetAndSync();
   }
 }

--- a/src/client/transport/local.ts
+++ b/src/client/transport/local.ts
@@ -95,7 +95,7 @@ export class LocalMaster extends Master {
       },
     };
     const storage = persist ? new LocalStorage(storageKey) : new InMemory();
-    super(game, storage, transportAPI, false);
+    super(game, storage, transportAPI);
 
     this.connect = (matchID, playerID, callback) => {
       clientCallbacks[playerID] = callback;

--- a/src/client/transport/socketio.ts
+++ b/src/client/transport/socketio.ts
@@ -58,11 +58,12 @@ export class SocketIOTransport extends Transport {
     store,
     matchID,
     playerID,
+    credentials,
     gameName,
     numPlayers,
     server,
   }: SocketIOTransportOpts = {}) {
-    super({ store, gameName, playerID, matchID, numPlayers });
+    super({ store, gameName, playerID, matchID, credentials, numPlayers });
 
     this.server = server;
     this.socket = socket;
@@ -206,6 +207,15 @@ export class SocketIOTransport extends Transport {
    */
   updatePlayerID(id: PlayerID) {
     this.playerID = id;
+    this.resetAndSync();
+  }
+
+  /**
+   * Updates the credentials associated with this client.
+   * @param {string|undefined} credentials - The new credentials to use.
+   */
+  updateCredentials(credentials?: string) {
+    this.credentials = credentials;
     this.resetAndSync();
   }
 }

--- a/src/client/transport/socketio.ts
+++ b/src/client/transport/socketio.ts
@@ -180,12 +180,9 @@ export class SocketIOTransport extends Transport {
   }
 
   /**
-   * Updates the game id.
-   * @param {string} id - The new game id.
+   * Dispatches a reset action, then requests a fresh sync from the server.
    */
-  updateMatchID(id: string) {
-    this.matchID = id;
-
+  private resetAndSync() {
     const action = ActionCreators.reset(null);
     this.store.dispatch(action);
 
@@ -195,18 +192,21 @@ export class SocketIOTransport extends Transport {
   }
 
   /**
+   * Updates the game id.
+   * @param {string} id - The new game id.
+   */
+  updateMatchID(id: string) {
+    this.matchID = id;
+    this.resetAndSync();
+  }
+
+  /**
    * Updates the player associated with this client.
    * @param {string} id - The new player id.
    */
   updatePlayerID(id: PlayerID) {
     this.playerID = id;
-
-    const action = ActionCreators.reset(null);
-    this.store.dispatch(action);
-
-    if (this.socket) {
-      this.socket.emit('sync', this.matchID, this.playerID, this.numPlayers);
-    }
+    this.resetAndSync();
   }
 }
 

--- a/src/client/transport/socketio.ts
+++ b/src/client/transport/socketio.ts
@@ -22,7 +22,7 @@ import {
 
 interface SocketIOOpts {
   server?: string;
-  socketOpts?;
+  socketOpts?: SocketIOClient.ConnectOpts;
 }
 
 type SocketIOTransportOpts = TransportOpts &
@@ -38,7 +38,7 @@ type SocketIOTransportOpts = TransportOpts &
 export class SocketIOTransport extends Transport {
   server: string;
   socket: SocketIOClient.Socket;
-  socketOpts;
+  socketOpts: SocketIOClient.ConnectOpts;
   callback: () => void;
   matchDataCallback: MetadataCallback;
 

--- a/src/client/transport/transport.ts
+++ b/src/client/transport/transport.ts
@@ -25,6 +25,7 @@ export interface TransportOpts {
   game?: ReturnType<typeof ProcessGameConfig>;
   playerID?: PlayerID;
   matchID?: string;
+  credentials?: string;
   numPlayers?: number;
 }
 
@@ -33,6 +34,7 @@ export abstract class Transport {
   protected gameName: string;
   protected playerID: PlayerID | null;
   protected matchID: string;
+  protected credentials?: string;
   protected numPlayers: number;
   isConnected: boolean;
 
@@ -41,12 +43,14 @@ export abstract class Transport {
     gameName,
     playerID,
     matchID,
+    credentials,
     numPlayers,
   }: TransportOpts) {
     this.store = store;
     this.gameName = gameName || 'default';
     this.playerID = playerID || null;
     this.matchID = matchID || 'default';
+    this.credentials = credentials;
     this.numPlayers = numPlayers || 2;
   }
 
@@ -57,4 +61,5 @@ export abstract class Transport {
   abstract subscribeMatchData(fn: MetadataCallback): void;
   abstract updateMatchID(id: string): void;
   abstract updatePlayerID(id: PlayerID): void;
+  abstract updateCredentials(credentials?: string): void;
 }

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -44,12 +44,6 @@ const filterMatchData = (matchData: Server.MatchData): FilteredMetadata =>
     return filteredData;
   });
 
-function IsSynchronous(
-  storageAPI: StorageAPI.Sync | StorageAPI.Async
-): storageAPI is StorageAPI.Sync {
-  return storageAPI.type() === StorageAPI.Type.SYNC;
-}
-
 /**
  * Redact the log.
  *
@@ -207,7 +201,7 @@ export class Master {
     let isActionAuthentic;
     let metadata: Server.MatchData | undefined;
     const credentials = credAction.payload.credentials;
-    if (IsSynchronous(this.storageAPI)) {
+    if (StorageAPI.isSynchronous(this.storageAPI)) {
       ({ metadata } = this.storageAPI.fetch(matchID, { metadata: true }));
       const playerMetadata = getPlayerMetadata(metadata, playerID);
       isActionAuthentic = this.shouldAuth(metadata)
@@ -230,7 +224,7 @@ export class Master {
     const key = matchID;
 
     let state: State;
-    if (IsSynchronous(this.storageAPI)) {
+    if (StorageAPI.isSynchronous(this.storageAPI)) {
       ({ state } = this.storageAPI.fetch(key, { state: true }));
     } else {
       ({ state } = await this.storageAPI.fetch(key, { state: true }));
@@ -351,7 +345,7 @@ export class Master {
       }
     }
 
-    if (IsSynchronous(this.storageAPI)) {
+    if (StorageAPI.isSynchronous(this.storageAPI)) {
       this.storageAPI.setState(key, stateWithoutDeltalog, deltalog);
       if (newMetadata) this.storageAPI.setMetadata(key, newMetadata);
     } else {
@@ -381,7 +375,7 @@ export class Master {
 
     let fetchResult: StorageAPI.FetchResult<typeof fetchOpts>;
 
-    if (IsSynchronous(this.storageAPI)) {
+    if (StorageAPI.isSynchronous(this.storageAPI)) {
       fetchResult = this.storageAPI.fetch(key, fetchOpts);
     } else {
       fetchResult = await this.storageAPI.fetch(key, fetchOpts);
@@ -401,7 +395,7 @@ export class Master {
 
       this.subscribeCallback({ state, matchID });
 
-      if (IsSynchronous(this.storageAPI)) {
+      if (StorageAPI.isSynchronous(this.storageAPI)) {
         this.storageAPI.createMatch(key, { initialState, metadata });
       } else {
         await this.storageAPI.createMatch(key, { initialState, metadata });
@@ -448,7 +442,7 @@ export class Master {
     const key = matchID;
 
     let metadata: Server.MatchData | undefined;
-    if (IsSynchronous(this.storageAPI)) {
+    if (StorageAPI.isSynchronous(this.storageAPI)) {
       ({ metadata } = this.storageAPI.fetch(matchID, { metadata: true }));
     } else {
       ({ metadata } = await this.storageAPI.fetch(matchID, {
@@ -477,7 +471,7 @@ export class Master {
       args: [matchID, filteredMetadata],
     }));
 
-    if (IsSynchronous(this.storageAPI)) {
+    if (StorageAPI.isSynchronous(this.storageAPI)) {
       this.storageAPI.setMetadata(key, metadata);
     } else {
       await this.storageAPI.setMetadata(key, metadata);

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -148,7 +148,7 @@ export class Master {
     stateID: number,
     matchID: string,
     playerID: string
-  ) {
+  ): Promise<void | { error: string }> {
     let metadata: Server.MatchData | undefined;
     if (StorageAPI.isSynchronous(this.storageAPI)) {
       ({ metadata } = this.storageAPI.fetch(matchID, { metadata: true }));
@@ -315,7 +315,7 @@ export class Master {
     playerID: string | null | undefined,
     credentials?: string,
     numPlayers = 2
-  ) {
+  ): Promise<void | { error: string }> {
     const key = matchID;
 
     const fetchOpts = {

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -86,10 +86,10 @@ export const createRouter = ({
   uuid?: () => string;
   generateCredentials?: Server.GenerateCredentials;
   db: StorageAPI.Sync | StorageAPI.Async;
-}): Router => {
+}): Router<any, Server.AppCtx> => {
   uuid = uuid || shortid;
   generateCredentials = generateCredentials || uuid;
-  const router = new Router();
+  const router = new Router<any, Server.AppCtx>();
 
   /**
    * List available games.
@@ -442,7 +442,10 @@ export const createRouter = ({
   return router;
 };
 
-export const configureApp = (app: Koa, router: Router): void => {
+export const configureApp = (
+  app: Server.App,
+  router: Router<any, Server.AppCtx>
+): void => {
   app.use(cors());
 
   // If API_SECRET is set, then require that requests set an

--- a/src/server/auth.test.ts
+++ b/src/server/auth.test.ts
@@ -1,0 +1,275 @@
+import {
+  extractPlayerMetadata,
+  doesMatchRequireAuthentication,
+  areCredentialsAuthentic,
+  Auth,
+} from './auth';
+
+import { Server } from '../types';
+
+describe('extractPlayerMetadata', () => {
+  describe('when metadata is not found', () => {
+    test('then playerMetadata is undefined', () => {
+      expect(extractPlayerMetadata(undefined, '0')).toBeUndefined();
+    });
+  });
+
+  describe('when metadata does not contain players field', () => {
+    test('then playerMetadata is undefined', () => {
+      expect(
+        extractPlayerMetadata({} as Server.MatchData, '0')
+      ).toBeUndefined();
+    });
+  });
+
+  describe('when metadata does not contain playerID', () => {
+    test('then playerMetadata is undefined', () => {
+      expect(
+        extractPlayerMetadata(
+          {
+            gameName: '',
+            setupData: {},
+            players: { '1': { id: 1 } },
+            createdAt: 0,
+            updatedAt: 0,
+          },
+          '0'
+        )
+      ).toBeUndefined();
+    });
+  });
+
+  describe('when metadata contains playerID', () => {
+    test('then playerMetadata is returned', () => {
+      const playerMetadata = { id: 0, credentials: 'SECRET' };
+      const result = extractPlayerMetadata(
+        {
+          gameName: '',
+          setupData: {},
+          players: { '0': playerMetadata },
+          createdAt: 0,
+          updatedAt: 0,
+        },
+        '0'
+      );
+      expect(result).toBe(playerMetadata);
+    });
+  });
+});
+
+describe('doesMatchRequireAuthentication', () => {
+  describe('when game metadata is not found', () => {
+    test('then authentication is not required', () => {
+      const result = doesMatchRequireAuthentication();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('when match has no credentials', () => {
+    test('then authentication is not required', () => {
+      const matchData = {
+        gameName: '',
+        setupData: {},
+        players: {
+          '0': { id: 1 },
+        },
+        createdAt: 0,
+        updatedAt: 0,
+      };
+      const result = doesMatchRequireAuthentication(matchData);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('when match has credentials', () => {
+    test('then authentication is required', () => {
+      const matchData = {
+        gameName: '',
+        setupData: {},
+        players: {
+          '0': {
+            id: 0,
+            credentials: 'SECRET',
+          },
+        },
+        createdAt: 0,
+        updatedAt: 0,
+      };
+      const result = doesMatchRequireAuthentication(matchData);
+      expect(result).toBe(true);
+    });
+  });
+});
+
+describe('areCredentialsAuthentic', () => {
+  let action;
+  let playerID;
+  let matchData;
+  let credentials;
+  let playerMetadata;
+
+  beforeEach(() => {
+    playerID = '0';
+
+    action = {
+      payload: { credentials: 'SECRET' },
+    };
+
+    matchData = {
+      players: {
+        '0': { credentials: 'SECRET' },
+      },
+    };
+
+    playerMetadata = matchData.players[playerID];
+    ({ credentials } = action.payload || {});
+  });
+
+  describe('when game has credentials', () => {
+    describe('when action contains no payload', () => {
+      beforeEach(() => {
+        action = {};
+        ({ credentials } = action.payload || {});
+      });
+
+      test('the action is not authentic', async () => {
+        const result = areCredentialsAuthentic(credentials, playerMetadata);
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('when action contains no credentials', () => {
+      beforeEach(() => {
+        action = {
+          payload: { someStuff: 'foo' },
+        };
+        ({ credentials } = action.payload || {});
+      });
+
+      test('then action is not authentic', async () => {
+        const result = areCredentialsAuthentic(credentials, playerMetadata);
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('when action credentials do not match game credentials', () => {
+      beforeEach(() => {
+        action = {
+          payload: { credentials: 'WRONG' },
+        };
+        ({ credentials } = action.payload || {});
+      });
+      test('then action is not authentic', async () => {
+        const result = areCredentialsAuthentic(credentials, playerMetadata);
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('when playerMetadata is not found', () => {
+      test('then action is not authentic', () => {
+        const result = areCredentialsAuthentic(credentials, undefined);
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('when action credentials do match game credentials', () => {
+      test('then action is authentic', async () => {
+        const result = areCredentialsAuthentic(credentials, playerMetadata);
+        expect(result).toBe(true);
+      });
+    });
+  });
+});
+
+describe('Auth', () => {
+  const credentials = 'credentials';
+  const playerData = { id: 0, credentials };
+  const metadata = {
+    gameName: '',
+    players: { '0': playerData },
+    createdAt: 0,
+    updatedAt: 0,
+  };
+
+  describe('defaults', () => {
+    const auth = new Auth();
+
+    test('generateCredentials', () => {
+      expect(typeof auth.generateCredentials({})).toBe('string');
+    });
+
+    test('authenticateCredentials', () => {
+      expect(
+        auth.authenticateCredentials({ playerID: '0', metadata, credentials })
+      ).toBe(true);
+    });
+  });
+
+  describe('ignores bad options', () => {
+    const auth = new Auth({
+      generateCredentials: 'foo',
+      authenticateCredentials: 'bar',
+    } as any);
+
+    test('generateCredentials', () => {
+      expect(typeof auth.generateCredentials({})).toBe('string');
+    });
+
+    test('authenticateCredentials', () => {
+      expect(
+        auth.authenticateCredentials({ playerID: '0', metadata, credentials })
+      ).toBe(true);
+    });
+  });
+
+  describe('custom methods', () => {
+    const generateCredentials = jest.fn(() => credentials);
+    const authenticateCredentials = jest.fn(() => true);
+    const auth = new Auth({ generateCredentials, authenticateCredentials });
+
+    test('generateCredentials', () => {
+      const ctx = {};
+      expect(auth.generateCredentials(ctx)).toBe(credentials);
+      expect(generateCredentials).toHaveBeenCalledWith(ctx);
+    });
+
+    test('authenticateCredentials', () => {
+      expect(
+        auth.authenticateCredentials({ playerID: '0', metadata, credentials })
+      ).toBe(true);
+      expect(authenticateCredentials).toHaveBeenCalledWith(
+        credentials,
+        playerData
+      );
+    });
+  });
+
+  describe('async', () => {
+    const generateCredentials = jest.fn(async () => credentials);
+    const authenticateCredentials = jest.fn(async () => true);
+    const auth = new Auth({ generateCredentials, authenticateCredentials });
+
+    test('generateCredentials', async () => {
+      const ctx = {};
+      const promise = auth.generateCredentials(ctx);
+      expect(promise).toBeInstanceOf(Promise);
+      expect(generateCredentials).toHaveBeenCalledWith(ctx);
+      expect(await promise).toBe(credentials);
+    });
+
+    test('authenticateCredentials', async () => {
+      const promise = auth.authenticateCredentials({
+        playerID: '0',
+        metadata,
+        credentials,
+      });
+
+      expect(promise).toBeInstanceOf(Promise);
+      expect(authenticateCredentials).toHaveBeenCalledWith(
+        credentials,
+        playerData
+      );
+      expect(await promise).toBe(true);
+    });
+  });
+});

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,0 +1,88 @@
+import { generate as shortid } from 'shortid';
+import { Server, PlayerID } from '../types';
+
+/**
+ * Verifies that a match has metadata and is using credentials.
+ */
+export const doesMatchRequireAuthentication = (
+  matchData?: Server.MatchData
+) => {
+  if (!matchData) return false;
+  const { players } = matchData;
+  const hasCredentials = Object.keys(players).some(key => {
+    return !!(players[key] && players[key].credentials);
+  });
+  return hasCredentials;
+};
+
+/**
+ * The default `authenticateCredentials` method.
+ * Verifies that the provided credentials match the player’s metadata.
+ */
+export const areCredentialsAuthentic: Server.AuthenticateCredentials = (
+  actionCredentials: string,
+  playerMetadata?: Server.PlayerMetadata
+) => {
+  if (!actionCredentials) return false;
+  if (!playerMetadata) return false;
+  return actionCredentials === playerMetadata.credentials;
+};
+
+/**
+ * Extracts a player’s metadata from the match data object.
+ */
+export const extractPlayerMetadata = (
+  matchData: Server.MatchData,
+  playerID: PlayerID
+): Server.PlayerMetadata => {
+  if (matchData && matchData.players) {
+    return matchData.players[playerID];
+  }
+};
+
+/**
+ * Class that provides authentication methods to the lobby server & transport.
+ */
+export class Auth {
+  private readonly shouldAuthenticate = doesMatchRequireAuthentication;
+  private readonly authenticate = areCredentialsAuthentic;
+
+  /**
+   * Generate credentials string from the Koa context.
+   */
+  public readonly generateCredentials: Server.GenerateCredentials = shortid;
+
+  constructor(
+    opts: {
+      authenticateCredentials?: Server.AuthenticateCredentials;
+      generateCredentials?: Server.GenerateCredentials;
+    } = {}
+  ) {
+    if (typeof opts.authenticateCredentials === 'function') {
+      this.authenticate = opts.authenticateCredentials;
+      this.shouldAuthenticate = () => true;
+    }
+    if (typeof opts.generateCredentials === 'function') {
+      this.generateCredentials = opts.generateCredentials;
+    }
+  }
+
+  /**
+   * Resolves to true if the provided credentials are valid for the given
+   * metadata and player IDs, or if the match does not require authentication.
+   */
+  public authenticateCredentials({
+    playerID,
+    credentials,
+    metadata,
+  }: {
+    playerID: string;
+    credentials: string | undefined;
+    metadata: Server.MatchData;
+  }) {
+    const playerMetadata = extractPlayerMetadata(metadata, playerID);
+    return this.shouldAuthenticate(metadata)
+      ? this.authenticate(credentials, playerMetadata)
+      : true;
+  }
+}

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -9,9 +9,9 @@ export const doesMatchRequireAuthentication = (
 ) => {
   if (!matchData) return false;
   const { players } = matchData;
-  const hasCredentials = Object.keys(players).some(key => {
-    return !!(players[key] && players[key].credentials);
-  });
+  const hasCredentials = Object.values(players).some(
+    player => !!(player && player.credentials)
+  );
   return hasCredentials;
 };
 

--- a/src/server/db/base.ts
+++ b/src/server/db/base.ts
@@ -7,6 +7,13 @@ export enum Type {
 }
 
 /**
+ * Type guard that checks if a storage implementation is synchronous.
+ */
+export function isSynchronous(storageAPI: Sync | Async): storageAPI is Sync {
+  return storageAPI.type() === Type.SYNC;
+}
+
+/**
  * Indicates which fields the fetch operation should return.
  */
 export interface FetchOpts {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -87,7 +87,7 @@ export function Server({
   https,
   uuid,
 }: ServerOpts) {
-  const app = new Koa();
+  const app: ServerTypes.App = new Koa();
 
   games = games.map(ProcessGameConfig);
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -127,7 +127,9 @@ export function Server({
         configureApp(app, router);
       } else {
         // Run API in a separate Koa app.
-        const api = new Koa();
+        const api: ServerTypes.App = new Koa();
+        api.context.db = db;
+        api.context.auth = auth;
         configureApp(api, router);
         await new Promise(resolve => {
           apiServer = api.listen(lobbyConfig.apiPort, resolve);

--- a/src/server/transport/socketio-simultaneous.test.ts
+++ b/src/server/transport/socketio-simultaneous.test.ts
@@ -8,6 +8,7 @@
 
 import IO from 'koa-socket-2';
 import { SocketIO, SocketOpts } from './socketio';
+import { Auth } from '../auth';
 import { InMemory } from '../db';
 import { createMetadata } from '../util';
 import { ProcessGameConfig } from '../../core/game';
@@ -15,7 +16,11 @@ import * as ActionCreators from '../../core/action-creators';
 import { InitializeGame } from '../../core/initialize';
 import { PlayerView } from '../../core/player-view';
 import { _ClientImpl } from '../../client/client';
+import { Master } from '../../master/master';
 import { Ctx, LogEntry, Server, State, StorageAPI } from '../../types';
+
+type SyncArgs = Parameters<Master['onSync']>;
+type UpdateArgs = Parameters<Master['onUpdate']>;
 
 type SocketIOTestAdapterOpts = SocketOpts & {
   clientInfo?: Map<any, any>;
@@ -92,20 +97,19 @@ class SocketIOTestAdapter extends SocketIO {
 jest.mock('koa-socket-2', () => {
   class MockSocket {
     id: string;
-    callbacks: {};
+    callbacks: Record<string, (...args: any[]) => Promise<void>>;
     emit: jest.Mock<any, any>;
     broadcast: { emit: jest.Mock<any, any> };
 
-    constructor() {
-      this.id = 'id';
+    constructor({ id }: { id: string }) {
+      this.id = id;
       this.callbacks = {};
       this.emit = jest.fn();
       this.broadcast = { emit: jest.fn() };
     }
 
     async receive(type, ...args) {
-      await this.callbacks[type](args[0], args[1], args[2], args[3], args[4]);
-      return;
+      await this.callbacks[type](...args);
     }
 
     on(type, callback) {
@@ -123,11 +127,13 @@ jest.mock('koa-socket-2', () => {
   }
 
   class MockIO {
-    socket: MockSocket;
+    sockets: Map<string, MockSocket>;
     socketAdapter: any;
 
     constructor() {
-      this.socket = new MockSocket();
+      this.sockets = new Map(
+        ['0', '1'].map(id => [id, new MockSocket({ id })])
+      );
     }
 
     adapter(socketAdapter) {
@@ -142,8 +148,8 @@ jest.mock('koa-socket-2', () => {
       return this;
     }
 
-    on(type, callback) {
-      callback(this.socket);
+    on(_event, callback) {
+      this.sockets.forEach(socket => void callback(socket));
     }
   }
 
@@ -208,14 +214,16 @@ describe('simultaneous moves on server game', () => {
 
   test('two clients playing using sync storage', async () => {
     let db = new InMemory();
-    app = { context: { db: db } };
+    let auth = new Auth();
+    app = { context: { db, auth } };
     transport = new SocketIOTestAdapter({
       clientInfo,
       roomInfo,
-      auth: () => true,
     });
     transport.init(app, [ProcessGameConfig(game)]);
     io = app.context.io;
+    const socket0 = io.sockets.get('0');
+    const socket1 = io.sockets.get('1');
     let fetchResult;
 
     const spyGetMatchQueue = jest.spyOn(
@@ -239,58 +247,57 @@ describe('simultaneous moves on server game', () => {
     // Call sync for both players
     await Promise.all([
       (async () => {
-        io.socket.id = '0';
-        await io.socket.receive('sync', 'matchID', '0', 2);
+        const args0: SyncArgs = ['matchID', '0', undefined, 2];
+        await socket0.receive('sync', ...args0);
       })(),
       (async () => {
-        io.socket.id = '1';
-        await io.socket.receive('sync', 'matchID', '1', 2);
+        const args1: SyncArgs = ['matchID', '1', undefined, 2];
+        await socket1.receive('sync', ...args1);
       })(),
     ]);
 
-    // Call normal move
-    io.socket.id = '0';
-    await io.socket.receive(
-      'update',
+    const moveAArgs: UpdateArgs = [
       ActionCreators.makeMove('A', null, '0'),
       0,
       'matchID',
-      '0'
-    );
+      '0',
+    ];
+
+    // Call normal move
+    await socket0.receive('update', ...moveAArgs);
 
     // Assertions for match queue creation
     expect(spyGetMatchQueue).toHaveBeenCalledWith('matchID');
 
-    // Set all players active
-    await io.socket.receive(
-      'update',
+    const activePlayersArgs: UpdateArgs = [
       ActionCreators.gameEvent('setActivePlayers', [{ all: 'A' }], '0'),
       1,
       'matchID',
-      '0'
-    );
+      '0',
+    ];
+
+    // Set all players active
+    await socket0.receive('update', ...activePlayersArgs);
 
     // Call actions simultaeously
     await Promise.all([
       (async () => {
-        io.socket.id = '1';
-        await io.socket.receive(
-          'update',
+        const moveBArgs: UpdateArgs = [
           ActionCreators.makeMove('B', null, '1'),
           2,
           'matchID',
-          '1'
-        );
+          '1',
+        ];
+        await socket1.receive('update', ...moveBArgs);
       })(),
       (async () => {
-        io.socket.id = '0';
-        await io.socket.receive(
-          'update',
+        const moveBArgs: UpdateArgs = [
           ActionCreators.makeMove('B', null, '0'),
           2,
           'matchID',
-          '0'
-        );
+          '0',
+        ];
+        await socket0.receive('update', ...moveBArgs);
       })(),
     ]);
 
@@ -316,12 +323,10 @@ describe('simultaneous moves on server game', () => {
     // Call disconnect for both players
     await Promise.all([
       (async () => {
-        io.socket.id = '0';
-        await io.socket.receive('disconnect', 'matchID', '0', 2);
+        await socket0.receive('disconnect');
       })(),
       (async () => {
-        io.socket.id = '1';
-        await io.socket.receive('disconnect', 'matchID', '1', 2);
+        await socket1.receive('disconnect');
       })(),
     ]);
 
@@ -333,15 +338,17 @@ describe('simultaneous moves on server game', () => {
   test('two clients playing using async storage', async () => {
     let db = new InMemoryAsync();
     await db.connect();
+    let auth = new Auth();
 
-    app = { context: { db: db } };
+    app = { context: { db, auth } };
     transport = new SocketIOTestAdapter({
       clientInfo,
       roomInfo,
-      auth: () => true,
     });
     transport.init(app, [ProcessGameConfig(game)]);
     io = app.context.io;
+    const socket0 = io.sockets.get('0');
+    const socket1 = io.sockets.get('1');
     let fetchResult;
 
     const spyGetMatchQueue = jest.spyOn(
@@ -365,58 +372,55 @@ describe('simultaneous moves on server game', () => {
     // Call sync for both players
     await Promise.all([
       (async () => {
-        io.socket.id = '0';
-        await io.socket.receive('sync', 'matchID', '0', 2);
+        await socket0.receive('sync', 'matchID', '0', 2);
       })(),
       (async () => {
-        io.socket.id = '1';
-        await io.socket.receive('sync', 'matchID', '1', 2);
+        await socket1.receive('sync', 'matchID', '1', 2);
       })(),
     ]);
 
-    // Call normal move
-    io.socket.id = '0';
-    await io.socket.receive(
-      'update',
+    const moveAArgs: UpdateArgs = [
       ActionCreators.makeMove('A', null, '0'),
       0,
       'matchID',
-      '0'
-    );
+      '0',
+    ];
+
+    // Call normal move
+    await socket0.receive('update', ...moveAArgs);
 
     // Assertions for match queue creation
     expect(spyGetMatchQueue).toHaveBeenCalledWith('matchID');
 
-    // Set all players active
-    await io.socket.receive(
-      'update',
+    const activePlayersArgs: UpdateArgs = [
       ActionCreators.gameEvent('setActivePlayers', [{ all: 'A' }], '0'),
       1,
       'matchID',
-      '0'
-    );
+      '0',
+    ];
+
+    // Set all players active
+    await socket0.receive('update', ...activePlayersArgs);
 
     // Call actions simultaeously
     await Promise.all([
       (async () => {
-        io.socket.id = '1';
-        await io.socket.receive(
-          'update',
+        const moveBArgs: UpdateArgs = [
           ActionCreators.makeMove('B', null, '1'),
           2,
           'matchID',
-          '1'
-        );
+          '1',
+        ];
+        await socket1.receive('update', ...moveBArgs);
       })(),
       (async () => {
-        io.socket.id = '0';
-        await io.socket.receive(
-          'update',
+        const moveBArgs: UpdateArgs = [
           ActionCreators.makeMove('B', null, '0'),
           2,
           'matchID',
-          '0'
-        );
+          '0',
+        ];
+        await socket0.receive('update', ...moveBArgs);
       })(),
     ]);
 
@@ -442,12 +446,10 @@ describe('simultaneous moves on server game', () => {
     // Call disconnect for both players
     await Promise.all([
       (async () => {
-        io.socket.id = '0';
-        await io.socket.receive('disconnect', 'matchID', '0', 2);
+        await socket0.receive('disconnect');
       })(),
       (async () => {
-        io.socket.id = '1';
-        await io.socket.receive('disconnect', 'matchID', '1', 2);
+        await socket1.receive('disconnect');
       })(),
     ]);
 

--- a/src/server/transport/socketio.test.ts
+++ b/src/server/transport/socketio.test.ts
@@ -8,6 +8,9 @@
 
 import { TransportAPI, SocketIO, SocketOpts } from './socketio';
 import { ProcessGameConfig } from '../../core/game';
+import { Master } from '../../master/master';
+
+type SyncArgs = Parameters<Master['onSync']>;
 
 type SocketIOTestAdapterOpts = SocketOpts & {
   clientInfo?: Map<any, any>;
@@ -155,9 +158,11 @@ describe('TransportAPI', () => {
   beforeEach(async () => {
     io.socket.emit = jest.fn();
     io.socket.id = '0';
-    await io.socket.receive('sync', 'matchID', '0', 2);
+    const args0: SyncArgs = ['matchID', '0', undefined, 2];
+    await io.socket.receive('sync', ...args0);
     io.socket.id = '1';
-    await io.socket.receive('sync', 'matchID', '1', 2);
+    const args1: SyncArgs = ['matchID', '1', undefined, 2];
+    await io.socket.receive('sync', ...args1);
   });
 
   test('send', () => {
@@ -220,9 +225,11 @@ describe('connect / disconnect', () => {
 
   test('0 and 1 connect', async () => {
     io.socket.id = '0';
-    await io.socket.receive('sync', 'matchID', '0', 2);
+    const args0: SyncArgs = ['matchID', '0', undefined, 2];
+    await io.socket.receive('sync', ...args0);
     io.socket.id = '1';
-    await io.socket.receive('sync', 'matchID', '1', 2);
+    const args1: SyncArgs = ['matchID', '1', undefined, 2];
+    await io.socket.receive('sync', ...args1);
 
     expect(toObj(clientInfo)['0']).toMatchObject({
       matchID: 'matchID',

--- a/src/server/transport/socketio.test.ts
+++ b/src/server/transport/socketio.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { TransportAPI, SocketIO, SocketOpts } from './socketio';
+import { Auth } from '../auth';
 import { ProcessGameConfig } from '../../core/game';
 import { Master } from '../../master/master';
 
@@ -23,7 +24,7 @@ class SocketIOTestAdapter extends SocketIO {
     roomInfo = new Map(),
     ...args
   }: SocketIOTestAdapterOpts = {}) {
-    super(Object.keys(args).length ? args : undefined);
+    super(Object.keys(args).length > 0 ? args : undefined);
     this.clientInfo = clientInfo;
     this.roomInfo = roomInfo;
   }
@@ -107,7 +108,8 @@ jest.mock('koa-socket-2', () => {
 });
 
 describe('basic', () => {
-  const app: any = { context: {} };
+  const auth = new Auth({ authenticateCredentials: () => true });
+  const app: any = { context: { auth } };
   const games = [ProcessGameConfig({ seed: 0 })];
   let clientInfo;
   let roomInfo;
@@ -125,7 +127,8 @@ describe('basic', () => {
 });
 
 describe('socketAdapter', () => {
-  const app: any = { context: {} };
+  const auth = new Auth({ authenticateCredentials: () => true });
+  const app: any = { context: { auth } };
   const games = [ProcessGameConfig({ seed: 0 })];
 
   let socketAdapter = jest.fn();
@@ -145,7 +148,8 @@ describe('TransportAPI', () => {
   let api;
 
   beforeAll(() => {
-    const app: any = { context: {} };
+    const auth = new Auth({ authenticateCredentials: () => true });
+    const app: any = { context: { auth } };
     const games = [ProcessGameConfig({ seed: 0 })];
     const clientInfo = new Map();
     const roomInfo = new Map();
@@ -185,7 +189,8 @@ describe('TransportAPI', () => {
 });
 
 describe('sync / update', () => {
-  const app: any = { context: {} };
+  const auth = new Auth({ authenticateCredentials: () => true });
+  const app: any = { context: { auth } };
   const games = [ProcessGameConfig({ seed: 0 })];
   const transport = new SocketIOTestAdapter();
   transport.init(app, games);
@@ -201,7 +206,8 @@ describe('sync / update', () => {
 });
 
 describe('connect / disconnect', () => {
-  const app: any = { context: {} };
+  const auth = new Auth({ authenticateCredentials: () => true });
+  const app: any = { context: { auth } };
   const games = [ProcessGameConfig({ seed: 0 })];
   let clientInfo;
   let roomInfo;

--- a/src/server/transport/socketio.ts
+++ b/src/server/transport/socketio.ts
@@ -67,6 +67,7 @@ interface Client {
   matchID: string;
   playerID: string;
   socket: IOTypes.Socket;
+  credentials: string | undefined;
 }
 
 /**
@@ -141,7 +142,12 @@ export class SocketIO {
           }
           roomClients.add(socket.id);
 
-          this.clientInfo.set(socket.id, { matchID, playerID, socket });
+          this.clientInfo.set(socket.id, {
+            matchID,
+            playerID,
+            socket,
+            credentials,
+          });
 
           const master = new Master(
             game,

--- a/src/server/transport/socketio.ts
+++ b/src/server/transport/socketio.ts
@@ -7,7 +7,7 @@
  */
 
 import IO from 'koa-socket-2';
-import { Socket, ServerOptions as SocketOptions } from 'socket.io';
+import IOTypes from 'socket.io';
 import { ServerOptions as HttpsOptions } from 'https';
 import PQueue from 'p-queue';
 import {
@@ -26,7 +26,7 @@ const PING_INTERVAL = 10 * 1e3;
  */
 export function TransportAPI(
   matchID: string,
-  socket: Socket,
+  socket: IOTypes.Socket,
   clientInfo: SocketIO['clientInfo'],
   roomInfo: SocketIO['roomInfo']
 ): MasterTransport {
@@ -64,14 +64,14 @@ export function TransportAPI(
 export interface SocketOpts {
   auth?: boolean | AuthFn;
   https?: HttpsOptions;
-  socketOpts?: SocketOptions;
+  socketOpts?: IOTypes.ServerOptions;
   socketAdapter?: any;
 }
 
 interface Client {
   matchID: string;
   playerID: string;
-  socket: Socket;
+  socket: IOTypes.Socket;
 }
 
 /**
@@ -84,7 +84,7 @@ export class SocketIO {
   private auth: boolean | AuthFn;
   private https: HttpsOptions;
   private socketAdapter: any;
-  private socketOpts: SocketOptions;
+  private socketOpts: IOTypes.ServerOptions;
 
   constructor({
     auth = true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import * as ActionCreators from './core/action-creators';
 import { Flow } from './core/flow';
 import { CreateGameReducer } from './core/reducer';
 import { INVALID_MOVE } from './core/constants';
+import { Auth } from './server/auth';
 import * as StorageAPI from './server/db/base';
 import { EventsAPI } from './plugins/plugin-events';
 import { RandomAPI } from './plugins/random/random';
@@ -321,6 +322,13 @@ export namespace Server {
     createdAt: number;
     updatedAt: number;
   }
+
+  export type AppCtx = Koa.DefaultContext & {
+    db: StorageAPI.Async | StorageAPI.Sync;
+    auth: Auth;
+  };
+
+  export type App = Koa<Koa.DefaultState, AppCtx>;
 }
 
 export namespace LobbyAPI {


### PR DESCRIPTION
This is some fairly hefty refactoring, but it should have minimal user impact. Here’s the summary:

- This PR creates a new `Auth` class to hold credential generation & authentication logic. This is instantiated when creating a server instance and can be customised via the server options as was already possible.

- The `Auth` instance is passed to the lobby API replacing existing equality checks, allowing for custom authentication in the `leave`, `playAgain` and `update` endpoints. Closes #693.

- The `Auth` instance is passed to master instances that run on the server and is used to authenticate all methods rather than only authenticating `onUpdate`. Closes #840.

- Additional refactoring was necessary in the transport layers to send credentials for the `sync` event.

For most users, these changes should preserve the current behaviour. The default authentication has only been centralised, not changed. However, custom transport implementations or direct uses of `Master` might be impacted.

---

@flamecoals You [mentioned on Gitter](https://gitter.im/boardgame-io/General?at=5fc1d5869cdc3e0d7546f6cc) that FBG is using some custom authentication logic. How do these changes sound to you?