### PR TITLE
Fix: endStage event crashes debug log panel.

### DIFF
--- a/src/client/debug/log/LogEvent.svelte
+++ b/src/client/debug/log/LogEvent.svelte
@@ -10,7 +10,8 @@
 
   const dispatch = createEventDispatcher();
 
-  const args = action.payload.args || [];
+  const args = action.payload.args;
+  const renderedArgs = typeof args === 'string' ? args : (args || []).join(',');
   const playerID = action.payload.playerID;
   let actionType; 
   switch (action.type) {
@@ -132,7 +133,7 @@
   on:mouseleave={() => dispatch('mouseleave')}
   on:blur={() => dispatch('mouseleave')}
 >
-  <div>{actionType}({args.join(',')})</div>
+  <div>{actionType}({renderedArgs})</div>
 
   {#if payloadComponent}
     <svelte:component this={payloadComponent} {payload} />


### PR DESCRIPTION
Fixes #855 

As discussed in the issue, handle the case in the debug panel where `args` is a string.
I manually tested it, now `endStage` events appear in log without crash.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
