### PR TITLE
Prevent TypeError: state.deltalog is not iterable

### DIFF
--- a/src/core/flow.test.ts
+++ b/src/core/flow.test.ts
@@ -713,6 +713,20 @@ describe('endIf', () => {
         .payload.type
     ).toBe('endPhase');
   });
+
+  test('during game initialization with phases', () => {
+    const flow = Flow({
+      phases: {
+        A: {
+          start: true,
+        },
+      },
+      endIf: () => 'gameover',
+    });
+
+    const state = flow.init({ G: {}, ctx: flow.ctx(2) } as State);
+    expect(state.ctx.gameover).toBe('gameover');
+  });
 });
 
 test('isPlayerActive', () => {

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -470,7 +470,7 @@ export function Flow({
       logEntry.automatic = true;
     }
 
-    const deltalog = [...state.deltalog, logEntry];
+    const deltalog = [...(state.deltalog || []), logEntry];
 
     return { ...state, G, ctx, deltalog };
   }


### PR DESCRIPTION
#788 "UnhandledPromiseRejectionWarning: TypeError: state.deltalog is not iterable"

Everywhere else that deltalog is updated, it uses this (state.deltalog || []) pattern.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [ ] Test coverage is 100% (or you have a story for why it's ok).
