### PR TITLE
Add details to exceptions raised in LobbyClient

### DIFF
--- a/packages/client.ts
+++ b/packages/client.ts
@@ -7,6 +7,6 @@
  */
 
 import { Client } from '../src/client/client';
-import { LobbyClient } from '../src/lobby/client';
+import { LobbyClient, LobbyClientError } from '../src/lobby/client';
 
-export { Client, LobbyClient };
+export { Client, LobbyClient, LobbyClientError };

--- a/src/lobby/client.ts
+++ b/src/lobby/client.ts
@@ -24,6 +24,15 @@ const validateBody = (
   }
 };
 
+export class LobbyClientError extends Error {
+  readonly details: any;
+
+  constructor(message: string, details: any) {
+    super(message);
+    this.details = details;
+  }
+}
+
 /**
  * Create a boardgame.io Lobby API client.
  * @param server The API’s base URL, e.g. `http://localhost:8000`.
@@ -38,7 +47,23 @@ export class LobbyClient {
 
   private async request(route: string, init?: RequestInit) {
     const response = await fetch(this.server + route, init);
-    if (!response.ok) throw new Error(`HTTP status ${response.status}`);
+
+    if (!response.ok) {
+      let details: any;
+
+      try {
+        details = await response.json();
+      } catch {
+        try {
+          details = await response.text();
+        } catch (error) {
+          details = error.message;
+        }
+      }
+
+      throw new LobbyClientError(`HTTP status ${response.status}`, details);
+    }
+
     return response.json();
   }
 


### PR DESCRIPTION
This pull request customizes the error type used in `LobbyClient` to enable passing-through to callers additional details about the specific error that the client encountered. Amongst others, this behavior is useful in situations where the errors thrown by the Lobby API may contain remediation hints for the user. For example, when using custom setupData validation (see https://github.com/boardgameio/boardgame.io/pull/831), the errors returned by the API may contain instructions to the user setting up a game on what exactly is incorrect about their configuration.

An alternative implementation could also expose the `response` object directly on `LobbyClientError` which would allow more flexibility to callers but also increase coupling with the client's implementation (e.g. changing away from `fetch` would be a breaking change).

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
