### PR TITLE
feat: improve typescript typings for the player plugin and react client component

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Satana Charuwichitratana
 Pete Nykänen
 Philihp Busby
 Jason Harrison
+Brendon Roberto

--- a/packages/plugins.ts
+++ b/packages/plugins.ts
@@ -7,5 +7,6 @@
  */
 
 import PluginPlayer from '../src/plugins/plugin-player';
+import { PlayerPlugin } from '../src/plugins/plugin-player';
 
-export { PluginPlayer };
+export { PluginPlayer, PlayerPlugin };

--- a/src/client/react.tsx
+++ b/src/client/react.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Client as RawClient } from './client';
 import type { ClientOpts, ClientState, _ClientImpl } from './client';
+import type { Ctx } from '../types';
 
 type WrappedBoardDelegates = 'matchID' | 'playerID' | 'credentials';
 
@@ -40,8 +41,9 @@ export type BoardProps<G extends any = any> = ClientState<G> &
 
 type ReactClientOpts<
   G extends any = any,
-  P extends BoardProps<G> = BoardProps<G>
-> = Omit<ClientOpts<G>, WrappedBoardDelegates> & {
+  P extends BoardProps<G> = BoardProps<G>,
+  CtxWithPlugins extends Ctx = Ctx
+> = Omit<ClientOpts<G, CtxWithPlugins>, WrappedBoardDelegates> & {
   board?: React.ComponentType<P>;
   loading?: React.ComponentType;
 };
@@ -67,8 +69,9 @@ type ReactClientOpts<
  */
 export function Client<
   G extends any = any,
-  P extends BoardProps<G> = BoardProps<G>
->(opts: ReactClientOpts<G, P>) {
+  P extends BoardProps<G> = BoardProps<G>,
+  ContextWithPlugins extends Ctx = Ctx
+>(opts: ReactClientOpts<G, P, ContextWithPlugins>) {
   let { game, numPlayers, loading, board, multiplayer, enhancer, debug } = opts;
 
   // Component that is displayed before the client has synced


### PR DESCRIPTION
## Overview
This fixes the issue I brought up in #190 where the `PlayerPlugin<T>` interface was not part of the public api.

Additionally, there is a second fix for a related issue I ran into when using the React `Client` component where the `game` property used only `Ctx` in the type signature instead of the generic type constraint `ContextWithPlugins`.

This caused the code setting up the client to not compile when plugins were used.

### Steps to Reproduce

1. Create a game definition that uses `Ctx` extended with plugins:

```ts
interface CustomGameContext implements Ctx {
  // Extend the context with properties and methods
}

const CustomGameDefinition: Game<any, CustomGameContext, any> = {
  // game definition elided for brevity
};
```

2. Use the game definition with the React Client component:

```ts
const App = Client<CustomGameState, BoardProps<CustomGameState>, CustomGameContext>({ game: CustomGameDefinition });
```

Notice the following error on build:

```
Type 'Game<CustomGameState, CustomGameContext, any>' is not assignable to type 'Game<CustomGameState, Ctx, any>'.
  Types of property 'setup' are incompatible.
    Type '((ctx: CustomGameContext, setupData?: any) => any) | undefined' is not assignable to type '((ctx: Ctx, setupData?: any) => any) | undefined'.
      Type '(ctx: CustomGameContext, setupData?: any) => any' is not assignable to type '(ctx: Ctx, setupData?: any) => any'.
        Types of parameters 'ctx' and 'ctx' are incompatible.
          Type 'Ctx' is not assignable to type 'CustomGameContext'.
            Type 'Ctx' is not assignable to type 'PlayerPlugin<PlayerState>'.ts(2322)
client.d.ts(15, 5): The expected type comes from property 'game' which is declared here on type 'ReactClientOpts<CustomGameState, State<CustomGameState, Ctx> & { isActive: boolean; isConnected: boolean; log: LogEntry[]; } & Omit<...> & ExposedClientProps<...> & { ...; }, Ctx>'
```

Note, in my example I extended `Ctx` with the `PlayerPlugin<T>` interface, but all custom plugins that extend `Ctx` would have the same problem.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
