### PR TITLE
Fix custom plugins not available in events hooks. Add test.

### DIFF
--- a/src/plugins/main.test.ts
+++ b/src/plugins/main.test.ts
@@ -180,14 +180,34 @@ describe('actions', () => {
 });
 
 describe('plugins are accessible in events triggered from moves', () => {
+  const plugins = [
+    {
+      name: 'test',
+
+      setup: () => ({
+        initial: true,
+      }),
+
+      flush: () => ({ initial: true }),
+
+      api: ({ data }) => {
+        return {
+          get: () => data.initial,
+        };
+      },
+    },
+  ];
+
   test('turn/onBegin', () => {
     const game = {
+      plugins,
       moves: {
         stop: (G, ctx) => ctx.events.endTurn(),
       },
       turn: {
         onBegin: (G, ctx) => {
           G.onBegin = ctx.random.Die(1);
+          G.test = ctx.test.get();
         },
       },
     };
@@ -196,17 +216,20 @@ describe('plugins are accessible in events triggered from moves', () => {
     client.moves.stop();
     expect(client.getState().G).toEqual({
       onBegin: 1,
+      test: true,
     });
   });
 
   test('turn/onEnd', () => {
     const game = {
+      plugins,
       moves: {
         stop: (G, ctx) => ctx.events.endTurn(),
       },
       turn: {
         onEnd: (G, ctx) => {
           G.onEnd = ctx.random.Die(1);
+          G.test = ctx.test.get();
         },
       },
     };
@@ -215,11 +238,13 @@ describe('plugins are accessible in events triggered from moves', () => {
     client.moves.stop();
     expect(client.getState().G).toEqual({
       onEnd: 1,
+      test: true,
     });
   });
 
   test('phase/onBegin', () => {
     const game = {
+      plugins,
       moves: {
         stop: (G, ctx) => ctx.events.setPhase('second'),
       },
@@ -229,7 +254,8 @@ describe('plugins are accessible in events triggered from moves', () => {
         },
         second: {
           onBegin: (G, ctx) => {
-            G.onEnd = ctx.random.Die(1);
+            G.onBegin = ctx.random.Die(1);
+            G.test = ctx.test.get();
           },
         },
       },
@@ -238,12 +264,14 @@ describe('plugins are accessible in events triggered from moves', () => {
     const client = Client({ game });
     client.moves.stop();
     expect(client.getState().G).toEqual({
-      onEnd: 1,
+      onBegin: 1,
+      test: true,
     });
   });
 
   test('phase/onEnd', () => {
     const game = {
+      plugins,
       moves: {
         stop: (G, ctx) => ctx.events.endPhase(),
       },
@@ -252,6 +280,7 @@ describe('plugins are accessible in events triggered from moves', () => {
           start: true,
           onEnd: (G, ctx) => {
             G.onEnd = ctx.random.Die(1);
+            G.test = ctx.test.get();
           },
         },
       },
@@ -261,6 +290,7 @@ describe('plugins are accessible in events triggered from moves', () => {
     client.moves.stop();
     expect(client.getState().G).toEqual({
       onEnd: 1,
+      test: true,
     });
   });
 });

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -30,13 +30,8 @@ interface PluginOpts {
 /**
  * List of plugins that are always added.
  */
-const DEFAULT_PLUGINS = [
-  PluginImmer,
-  PluginRandom,
-  PluginEvents,
-  PluginLog,
-  PluginSerializable,
-];
+const CORE_PLUGINS = [PluginImmer, PluginRandom, PluginLog, PluginSerializable];
+const DEFAULT_PLUGINS = [...CORE_PLUGINS, PluginEvents];
 
 /**
  * Allow plugins to intercept actions and process them.
@@ -172,9 +167,9 @@ export const Enhance = (
  * Allows plugins to update their state after a move / event.
  */
 export const Flush = (state: State, opts: PluginOpts): State => {
-  // Note that we flush plugins in reverse order, to make sure that plugins
-  // that come before in the chain are still available.
-  [...DEFAULT_PLUGINS, ...opts.game.plugins].reverse().forEach((plugin) => {
+  // We flush the events plugin first, then custom plugins and the core plugins
+  // This means custom plugins cannot use the events API but will be available in event hooks
+  [PluginEvents, ...opts.game.plugins, ...CORE_PLUGINS].forEach((plugin) => {
     const name = plugin.name;
     const pluginState = state.plugins[name] || { data: {} };
 


### PR DESCRIPTION
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).

This changes the order the plugins are flushed in to fix the problem mentioned in #910. It also adds a test to make sure it works.

This removes the additional reverse as it seemed necessary to separate PluginEvents from the rest (hence CORE_PLUGINS and DEFAULT_PLUGINS) to execute everything in the right order.