### PR TITLE
feature(#723): Improve client error handling [Part 1]

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -14,7 +14,10 @@ import * as Actions from '../core/action-types';
 import * as ActionCreators from '../core/action-creators';
 import { ProcessGameConfig } from '../core/game';
 import type Debug from './debug/Debug.svelte';
-import { CreateGameReducer } from '../core/reducer';
+import {
+  CreateGameReducer,
+  TransientHandlingMiddleware,
+} from '../core/reducer';
 import { InitializeGame } from '../core/initialize';
 import { PlayerView } from '../plugins/main';
 import type { Transport, TransportOpts } from './transport/transport';
@@ -303,6 +306,7 @@ export class _ClientImpl<G extends any = any> {
     };
 
     const middleware = applyMiddleware(
+      TransientHandlingMiddleware,
       SubscriptionMiddleware,
       TransportMiddleware,
       LogMiddleware

--- a/src/core/action-creators.ts
+++ b/src/core/action-creators.ts
@@ -149,3 +149,11 @@ export const plugin = (
   type: Actions.PLUGIN as typeof Actions.PLUGIN,
   payload: { type, args, playerID, credentials },
 });
+
+/**
+ * Private action used to strip transient metadata (e.g. errors) from the game
+ * state.
+ */
+export const stripTransients = () => ({
+  type: Actions.STRIP_TRANSIENTS as typeof Actions.STRIP_TRANSIENTS,
+});

--- a/src/core/action-types.ts
+++ b/src/core/action-types.ts
@@ -15,3 +15,4 @@ export const UNDO = 'UNDO';
 export const UPDATE = 'UPDATE';
 export const PATCH = 'PATCH';
 export const PLUGIN = 'PLUGIN';
+export const STRIP_TRANSIENTS = 'STRIP_TRANSIENTS';

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,10 +1,18 @@
+/*
+ * Copyright 2017 The boardgame.io Authors
+ *
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
 export enum UpdateErrorType {
   // The action’s credentials were missing or invalid
   UnauthorizedAction = 'update/unauthorized_action',
   // The action’s matchID was not found
-  MatchNotFound = 'match_not_found',
+  MatchNotFound = 'update/match_not_found',
   // Could not apply Patch operation (rfc6902).
-  PatchFailed = 'patch_failed',
+  PatchFailed = 'update/patch_failed',
 }
 
 export enum ActionErrorType {

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,0 +1,23 @@
+export enum UpdateErrorType {
+  // The action’s credentials were missing or invalid
+  UnauthorizedAction = 'update/unauthorized_action',
+  // The action’s matchID was not found
+  MatchNotFound = 'match_not_found',
+  // Could not apply Patch operation (rfc6902).
+  PatchFailed = 'patch_failed',
+}
+
+export enum ActionErrorType {
+  // The action contained a stale state ID
+  StaleStateId = 'action/stale_state_id',
+  // The requested move is unknown or not currently available
+  UnavailableMove = 'action/unavailable_move',
+  // The move declared it was invalid (INVALID_MOVE constant)
+  InvalidMove = 'action/invalid_move',
+  // The player making the action is not currently active
+  InactivePlayer = 'action/inactive_player',
+  // The game has finished
+  GameOver = 'action/gameover',
+  // The requested action is disabled (e.g. undo/redo, events)
+  ActionDisabled = 'action/action_disabled',
+}

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -28,4 +28,6 @@ export enum ActionErrorType {
   GameOver = 'action/gameover',
   // The requested action is disabled (e.g. undo/redo, events)
   ActionDisabled = 'action/action_disabled',
+  // The requested action is not currently possible
+  ActionInvalid = 'action/action_invalid',
 }

--- a/src/core/reducer.test.ts
+++ b/src/core/reducer.test.ts
@@ -131,11 +131,16 @@ test('valid patch', () => {
 
 test('invalid patch', () => {
   const originalState = { _stateID: 0, G: 'patch' } as State;
-  const state = reducer(
+  const { transients, ...state } = reducer(
     originalState,
     patch(0, 1, [{ op: 'replace', path: '/_stateIDD', value: 1 }], [])
   );
   expect(state).toEqual(originalState);
+  expect(transients.error.type).toEqual('patch_failed');
+  // It's an array.
+  expect(transients.error.payload.length).toEqual(1);
+  // It looks like the standard rfc6902 error language.
+  expect(transients.error.payload[0].toString()).toContain('/_stateIDD');
 });
 
 test('reset', () => {

--- a/src/core/reducer.test.ts
+++ b/src/core/reducer.test.ts
@@ -438,7 +438,15 @@ describe('undo / redo', () => {
 
   test('redo only resets deltalog if nothing to redo', () => {
     const state = reducer(initialState, makeMove('move', 'A', '0'));
-    expect(reducer(state, redo())).toEqual({ ...state, deltalog: [] });
+    expect(reducer(state, redo())).toMatchObject({
+      ...state,
+      deltalog: [],
+      transients: {
+        error: {
+          type: 'action/action_invalid',
+        },
+      },
+    });
   });
 });
 
@@ -533,13 +541,29 @@ describe('undo stack', () => {
 
   test('can’t undo at the start of a turn', () => {
     const newState = reducer(state, undo());
-    expect(newState).toEqual({ ...state, deltalog: [] });
+    expect(newState).toMatchObject({
+      ...state,
+      deltalog: [],
+      transients: {
+        error: {
+          type: 'action/action_invalid',
+        },
+      },
+    });
   });
 
   test('can’t undo another player’s move', () => {
     state = reducer(state, makeMove('basic', null, '1'));
     const newState = reducer(state, undo('0'));
-    expect(newState).toEqual({ ...state, deltalog: [] });
+    expect(newState).toMatchObject({
+      ...state,
+      deltalog: [],
+      transients: {
+        error: {
+          type: 'action/action_invalid',
+        },
+      },
+    });
   });
 });
 
@@ -595,7 +619,15 @@ describe('redo stack', () => {
     expect(state._redo).toHaveLength(1);
     const newState = reducer(state, redo('0'));
     expect(state._redo).toHaveLength(1);
-    expect(newState).toEqual({ ...state, deltalog: [] });
+    expect(newState).toMatchObject({
+      ...state,
+      deltalog: [],
+      transients: {
+        error: {
+          type: 'action/action_invalid',
+        },
+      },
+    });
   });
 });
 

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -391,10 +391,8 @@ export function CreateGameReducer({
         const { _undo, _redo } = state;
 
         if (_undo.length < 2) {
-          // TODO(#723): Add an error case here.
-          //  error(`No moves to undo`);
-          //  return WithError(state, ActionErrorType.ActionDisabled);
-          return state;
+          error(`No moves to undo`);
+          return WithError(state, ActionErrorType.ActionInvalid);
         }
 
         const last = _undo[_undo.length - 1];
@@ -405,10 +403,8 @@ export function CreateGameReducer({
           actionHasPlayerID(action) &&
           action.payload.playerID !== last.playerID
         ) {
-          // TODO(#723): Add an error case here.
-          //  error(`Cannot undo other players' moves`);
-          //  return WithError(state, ActionErrorType.ActionDisabled);
-          return state;
+          error(`Cannot undo other players' moves`);
+          return WithError(state, ActionErrorType.ActionInvalid);
         }
 
         // If undoing a move, check it is undoable.
@@ -419,7 +415,8 @@ export function CreateGameReducer({
             last.playerID
           );
           if (!CanUndoMove(state.G, state.ctx, lastMove)) {
-            return state;
+            error(`Move cannot be undone`);
+            return WithError(state, ActionErrorType.ActionInvalid);
           }
         }
 
@@ -447,10 +444,8 @@ export function CreateGameReducer({
         const { _undo, _redo } = state;
 
         if (_redo.length == 0) {
-          // TODO(#723): Add an error case here.
-          //  error(`No moves to redo`);
-          //  return WithError(state, ActionErrorType.ActionDisabled);
-          return state;
+          error(`No moves to redo`);
+          return WithError(state, ActionErrorType.ActionInvalid);
         }
 
         const first = _redo[0];
@@ -460,10 +455,8 @@ export function CreateGameReducer({
           actionHasPlayerID(action) &&
           action.payload.playerID !== first.playerID
         ) {
-          // TODO(#723): Add an error case here.
-          //  error(`Cannot redo other players` moves`);
-          //  return WithError(state, ActionErrorType.ActionDisabled);
-          return state;
+          error(`Cannot redo other players' moves`);
+          return WithError(state, ActionErrorType.ActionInvalid);
         }
 
         state = initializeDeltalog(state, action);

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -135,7 +135,7 @@ function initializeDeltalog(
  */
 function ExtractTransients(
   transientState: TransientState | null
-): [State | null, TransientMetadata | null] {
+): [State | null, TransientMetadata | undefined] {
   if (!transientState) {
     // We preserve null for the state for legacy callers, but the transient
     // field should be undefined if not present to be consistent with the

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -6,11 +6,13 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import * as ActionCreators from '../core/action-creators';
-import { CreateGameReducer } from '../core/reducer';
+import {
+  CreateGameReducer,
+  TransientHandlingMiddleware,
+} from '../core/reducer';
 import { ProcessGameConfig, IsLongFormMove } from '../core/game';
 import { UNDO, REDO, MAKE_MOVE } from '../core/action-types';
-import { createStore } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import * as logging from '../core/logger';
 import { PlayerView } from '../plugins/main';
 import type {
@@ -203,7 +205,8 @@ export class Master {
     const reducer = CreateGameReducer({
       game: this.game,
     });
-    const store = createStore(reducer, state);
+    const middleware = applyMiddleware(TransientHandlingMiddleware);
+    const store = createStore(reducer, state, middleware);
 
     // Only allow UNDO / REDO if there is exactly one player
     // that can make moves right now and the person doing the
@@ -267,12 +270,6 @@ export class Master {
     // Update server's version of the store.
     store.dispatch(action);
     state = store.getState();
-    if ('transients' in state) {
-      // TODO(#723): Where appropriate, extract the reported error and notify
-      // the caller.
-      store.dispatch(ActionCreators.stripTransients());
-      state = store.getState();
-    }
 
     this.subscribeCallback({
       state,

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -6,6 +6,7 @@
  * https://opensource.org/licenses/MIT.
  */
 
+import * as ActionCreators from '../core/action-creators';
 import { CreateGameReducer } from '../core/reducer';
 import { ProcessGameConfig, IsLongFormMove } from '../core/game';
 import { UNDO, REDO, MAKE_MOVE } from '../core/action-types';
@@ -266,6 +267,12 @@ export class Master {
     // Update server's version of the store.
     store.dispatch(action);
     state = store.getState();
+    if ('transients' in state) {
+      // TODO(#723): Where appropriate, extract the reported error and notify
+      // the caller.
+      store.dispatch(ActionCreators.stripTransients());
+      state = store.getState();
+    }
 
     this.subscribeCallback({
       state,

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -14,6 +14,7 @@ import PluginSerializable from './plugin-serializable';
 import type {
   AnyFn,
   PartialGameState,
+  TransientState,
   State,
   Game,
   Plugin,
@@ -40,7 +41,8 @@ export const ProcessAction = (
   state: State,
   action: ActionShape.Plugin,
   opts: PluginOpts
-): State => {
+): TransientState => {
+  // TODO(#723): Extend error handling to plugins.
   opts.game.plugins
     .filter((plugin) => plugin.action !== undefined)
     .filter((plugin) => plugin.name === action.payload.type)
@@ -137,7 +139,7 @@ export const Setup = (
 export const Enhance = (
   state: State,
   opts: PluginOpts & { playerID: PlayerID }
-): State => {
+): TransientState => {
   [...DEFAULT_PLUGINS, ...opts.game.plugins]
     .filter((plugin) => plugin.api !== undefined)
     .forEach((plugin) => {
@@ -166,7 +168,7 @@ export const Enhance = (
 /**
  * Allows plugins to update their state after a move / event.
  */
-export const Flush = (state: State, opts: PluginOpts): State => {
+export const Flush = (state: State, opts: PluginOpts): TransientState => {
   // We flush the events plugin first, then custom plugins and the core plugins.
   // This means custom plugins cannot use the events API but will be available in event hooks.
   // Note that plugins are flushed in reverse, to allow custom plugins calling each other.

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -14,7 +14,6 @@ import PluginSerializable from './plugin-serializable';
 import type {
   AnyFn,
   PartialGameState,
-  TransientState,
   State,
   Game,
   Plugin,
@@ -41,7 +40,7 @@ export const ProcessAction = (
   state: State,
   action: ActionShape.Plugin,
   opts: PluginOpts
-): TransientState => {
+): State => {
   // TODO(#723): Extend error handling to plugins.
   opts.game.plugins
     .filter((plugin) => plugin.action !== undefined)
@@ -139,7 +138,7 @@ export const Setup = (
 export const Enhance = (
   state: State,
   opts: PluginOpts & { playerID: PlayerID }
-): TransientState => {
+): State => {
   [...DEFAULT_PLUGINS, ...opts.game.plugins]
     .filter((plugin) => plugin.api !== undefined)
     .forEach((plugin) => {
@@ -168,7 +167,7 @@ export const Enhance = (
 /**
  * Allows plugins to update their state after a move / event.
  */
-export const Flush = (state: State, opts: PluginOpts): TransientState => {
+export const Flush = (state: State, opts: PluginOpts): State => {
   // We flush the events plugin first, then custom plugins and the core plugins.
   // This means custom plugins cannot use the events API but will be available in event hooks.
   // Note that plugins are flushed in reverse, to allow custom plugins calling each other.

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,12 +34,15 @@ export type ErrorType = UpdateErrorType | ActionErrorType;
 export interface ActionError {
   type: ErrorType;
   // TODO(#723): Figure out if we want to strongly type payloads.
-  payload: ?any;
+  payload?: any;
 }
 
 export interface TransientMetadata {
   error?: ActionError;
 }
+
+// TODO(#732): Actually define a schema for the action dispatch results.
+export type ActionResult = any;
 
 // "Private" state that may include garbage that should be stripped before
 // being handed back to a client.


### PR DESCRIPTION
This PR sets up the initial reducer/master plumbing for error handling
by introducing a "transients" option bag containing errors.

The goal of this change is to be as backwards-compatible as possible,
with subsequent changes building on top of the API extensions added
here.

Notes:

- Previously, there was an assumption that the state resulting from a
reducer processing an action is suitable for client consumption.
- Now, transient artifacts might be appended onto the state and need to
be stripped before being sent to the client.
- To work around this change, I added some new types to help signal
the "transient" nature of State that enters and exits the reducer.
- I'm assuming the master is the single caller of the core reducer and
leaving it up to the master to do this stripping..

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
