### PR TITLE
feat: Allow plugins to declare an action invalid

### DIFF
--- a/docs/documentation/plugins.md
+++ b/docs/documentation/plugins.md
@@ -47,6 +47,12 @@ A plugin is an object that contains the following fields.
   // for the master instead.
   noClient: ({ G, ctx, game, data, api }) => boolean,
 
+  // Function that allows the plugin to indicate that the
+  // current action should be declared invalid and cancelled.
+  // If `isInvalid` returns an error message, the whole update
+  // will be abandoned and an error returned to the client.
+  isInvalid: ({ G, ctx, game, data, api }) => false | string,
+
   // Function that can filter `data` to hide secret state
   // before sending it to a specific client.
   // `playerID` could also be null or undefined for spectators.

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -30,4 +30,6 @@ export enum ActionErrorType {
   ActionDisabled = 'action/action_disabled',
   // The requested action is not currently possible
   ActionInvalid = 'action/action_invalid',
+  // The requested action was declared invalid by a plugin
+  PluginActionInvalid = 'action/plugin_invalid',
 }

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -143,15 +143,13 @@ function flushAndValidatePlugins(
 ): [State, TransientState?] {
   newState = plugins.Flush(newState, pluginOpts);
   const isInvalid = plugins.IsInvalid(newState, pluginOpts);
-  if (isInvalid) {
-    const { plugin, message } = isInvalid;
-    error(`plugin declared action invalid: ${plugin} - ${message}`);
-    return [
-      newState,
-      WithError(oldState, ActionErrorType.PluginActionInvalid, isInvalid),
-    ];
-  }
-  return [newState];
+  if (!isInvalid) return [newState];
+  const { plugin, message } = isInvalid;
+  error(`plugin declared action invalid: ${plugin} - ${message}`);
+  return [
+    newState,
+    WithError(oldState, ActionErrorType.PluginActionInvalid, isInvalid),
+  ];
 }
 
 /**

--- a/src/plugins/main.test.ts
+++ b/src/plugins/main.test.ts
@@ -8,7 +8,7 @@
 
 import { Client } from '../client/client';
 import { Local } from '../client/transport/local';
-import type { Ctx, Game } from '../types';
+import type { Game } from '../types';
 
 describe('basic', () => {
   let client: ReturnType<typeof Client>;
@@ -142,6 +142,7 @@ describe('isInvalid method', () => {
   afterAll(() => (console.error = stderr));
 
   test('basic plugin', () => {
+    const goodG = { good: 'nice' };
     const game: Game = {
       plugins: [
         {
@@ -150,7 +151,7 @@ describe('isInvalid method', () => {
         },
       ],
       moves: {
-        good: () => ({ good: 'nice' }),
+        good: () => goodG,
         bad: () => ({ bad: 'not ok' }),
       },
     };
@@ -158,9 +159,9 @@ describe('isInvalid method', () => {
     const client = Client({ game, playerID: '0' });
     client.start();
     client.moves.good();
-    expect(client.getState().G).toEqual({ good: 'nice' });
+    expect(client.getState().G).toEqual(goodG);
     client.moves.bad();
-    expect(client.getState().G).toEqual({ good: 'nice' });
+    expect(client.getState().G).toEqual(goodG);
   });
 
   test('plugin with API and data', () => {

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -244,6 +244,34 @@ export const NoClient = (state: State, opts: PluginOpts): boolean => {
 };
 
 /**
+ * Allows plugins to indicate if the entire action should be thrown out
+ * as invalid. This will cancel the entire state update.
+ */
+export const IsInvalid = (
+  state: State,
+  opts: PluginOpts
+): false | { plugin: string; message: string } => {
+  const firstInvalidReturn = [...DEFAULT_PLUGINS, ...opts.game.plugins]
+    .filter((plugin) => plugin.isInvalid !== undefined)
+    .map((plugin) => {
+      const { name } = plugin;
+      const pluginState = state.plugins[name];
+
+      const message = plugin.isInvalid({
+        G: state.G,
+        ctx: state.ctx,
+        game: opts.game,
+        api: pluginState && pluginState.api,
+        data: pluginState && pluginState.data,
+      });
+
+      return message ? { plugin: name, message } : false;
+    })
+    .find((value) => value);
+  return firstInvalidReturn || false;
+};
+
+/**
  * Allows plugins to customize their data for specific players.
  * For example, a plugin may want to share no data with the client, or
  * want to keep some player data secret from opponents.

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,7 @@ export interface Plugin<
 > {
   name: string;
   noClient?: (context: PluginContext<API, Data, G>) => boolean;
+  isInvalid?: (context: PluginContext<API, Data, G>) => false | string;
   setup?: (setupCtx: { G: G; ctx: Ctx; game: Game<G, Ctx> }) => Data;
   action?: (data: Data, payload: ActionShape.Plugin['payload']) => Data;
   api?: (context: {


### PR DESCRIPTION
Closes #962

This adds support for an `isInvalid` method in boardgame.io plugins. Similar to the current `noClient` plugin method, this allows the reducer to ask plugins if everything is OK or if the current event/move is invalid from their point of view. If one or more plugins returns a truthy value from its `isInvalid` method, the reducer will fall back to its initial state, analogous to what it does when a move returns `INVALID_MOVE`.

Currently this is not in use but the intention would be to use it for the events plugin, following on from #957. It also allows for other custom use cases, like state validators.

#### Notes

- `isInvalid` should return a string if the action is invalid. This could be less strict if that seems desirable.

- The error returned to the client is of the form
    ```js
    {
      type: 'action/plugin_invalid',
      payload: {
        plugin: 'name of plugin that declared action invalid',
        message: 'string returned by plugin’s isInvalid method'
      },
    }
    ```

- If more than one plugin’s `isInvalid` method returns a string, we just error with the first of them, rather than reporting all of them.