### PR TITLE
Refactor: Decouples player view calculation from Server's Master

### DIFF
--- a/docs/documentation/notable_projects.md
+++ b/docs/documentation/notable_projects.md
@@ -18,6 +18,13 @@ Fool the computer, but not your friends! Adversarial "Quick, Draw".
 [b1]: https://img.shields.io/github/stars/jayelm/bad-flamingo?label=%E2%98%85&logo=github
 [c1]: https://github.com/jayelm/bad-flamingo
 
+#### [![GitHub stars][b-bl]][c-bl]  [Battle Line][p-bl] \[[code][c-bl]\]
+&nbsp;&nbsp;
+Clone of Battle Line, a 2 player card game.
+
+[b-bl]: https://img.shields.io/github/stars/rsandzimier/battleline?label=%E2%98%85&logo=github
+[c-bl]: https://github.com/rsandzimier/battleline
+[p-bl]: https://rsandzimier.github.io/battleline/
 
 #### [![GitHub stars][b2]][c2] boardgame.io-angular \[[code][c2] | [demo][d2]\]
 &nbsp;&nbsp;

--- a/src/client/transport/local.ts
+++ b/src/client/transport/local.ts
@@ -85,7 +85,7 @@ export class LocalMaster extends Master {
     const send: TransportAPI['send'] = ({ playerID, ...data }) => {
       const callback = clientCallbacks[playerID];
       if (callback !== undefined) {
-        callback(data);
+        callback(filterPlayerView(playerID, data));
       }
     };
 
@@ -94,8 +94,7 @@ export class LocalMaster extends Master {
       send,
       sendAll: (payload) => {
         for (const playerID in clientCallbacks) {
-          const data = filterPlayerView(playerID, payload);
-          send({ playerID, ...data });
+          send({ playerID, ...payload });
         }
       },
     };

--- a/src/client/transport/local.ts
+++ b/src/client/transport/local.ts
@@ -22,6 +22,7 @@ import type {
   State,
   SyncInfo,
 } from '../../types';
+import { getFilterPlayerView } from '../../master/filter-player-view';
 
 /**
  * Returns null if it is not a bot's turn.
@@ -88,11 +89,12 @@ export class LocalMaster extends Master {
       }
     };
 
+    const filterPlayerView = getFilterPlayerView(game);
     const transportAPI: TransportAPI = {
       send,
-      sendAll: (makePlayerData) => {
+      sendAll: (payload) => {
         for (const playerID in clientCallbacks) {
-          const data = makePlayerData(playerID);
+          const data = filterPlayerView(playerID, payload);
           send({ playerID, ...data });
         }
       },

--- a/src/master/filter-player-view.test.ts
+++ b/src/master/filter-player-view.test.ts
@@ -1,0 +1,208 @@
+import { getFilterPlayerView, redactLog } from './filter-player-view';
+import * as ActionCreators from '../core/action-creators';
+import { Master } from './master';
+import { InMemory } from '../server/db/inmemory';
+
+function TransportAPI(send = jest.fn(), sendAll = jest.fn()) {
+  return { send, sendAll };
+}
+
+describe('playerView', () => {
+  const send = jest.fn();
+  const sendAll = jest.fn();
+  const game = {
+    playerView: (G, ctx, player) => {
+      return { ...G, player };
+    },
+  };
+  const master = new Master(game, new InMemory(), TransportAPI(send, sendAll));
+
+  beforeAll(async () => {
+    await master.onSync('matchID', '0', undefined, 2);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('sync', async () => {
+    await master.onSync('matchID', '0', undefined, 2);
+    expect(send.mock.calls[0][0].args[1].state).toMatchObject({
+      G: { player: '0' },
+    });
+  });
+
+  test('update', async () => {
+    const action = ActionCreators.gameEvent('endTurn');
+    await master.onSync('matchID', '0', undefined, 2);
+    await master.onUpdate(action, 0, 'matchID', '0');
+    const payload = sendAll.mock.calls[sendAll.mock.calls.length - 1][0];
+    const filterPlayerView = getFilterPlayerView(game);
+
+    const transportData0 = filterPlayerView('0', payload);
+    const G_player0 = (transportData0.args[1] as any).G;
+    const transportData1 = filterPlayerView('1', payload);
+    const G_player1 = (transportData1.args[1] as any).G;
+
+    expect(G_player0.player).toBe('0');
+    expect(G_player1.player).toBe('1');
+  });
+});
+
+describe('redactLog', () => {
+  test('no-op with undefined log', () => {
+    const result = redactLog(undefined, '0');
+    expect(result).toBeUndefined();
+  });
+
+  test('no redactedMoves', () => {
+    const logEvents = [
+      {
+        _stateID: 0,
+        turn: 0,
+        phase: '',
+        action: ActionCreators.gameEvent('endTurn'),
+      },
+    ];
+    const result = redactLog(logEvents, '0');
+    expect(result).toMatchObject(logEvents);
+  });
+
+  test('redacted move is only shown with args to the player that made the move', () => {
+    const logEvents = [
+      {
+        _stateID: 0,
+        turn: 0,
+        phase: '',
+        action: ActionCreators.makeMove('clickCell', [1, 2, 3], '0'),
+        redact: true,
+      },
+    ];
+
+    // player that made the move
+    let result = redactLog(logEvents, '0');
+    expect(result).toMatchObject(logEvents);
+
+    // other player
+    result = redactLog(logEvents, '1');
+    expect(result).toMatchObject([
+      {
+        _stateID: 0,
+        turn: 0,
+        phase: '',
+        action: {
+          type: 'MAKE_MOVE',
+          payload: {
+            credentials: undefined,
+            playerID: '0',
+            type: 'clickCell',
+          },
+        },
+      },
+    ]);
+  });
+
+  test('not redacted move is shown to all', () => {
+    const logEvents = [
+      {
+        _stateID: 0,
+        turn: 0,
+        phase: '',
+        action: ActionCreators.makeMove('unclickCell', [1, 2, 3], '0'),
+      },
+    ];
+
+    // player that made the move
+    let result = redactLog(logEvents, '0');
+    expect(result).toMatchObject(logEvents);
+    // other player
+    result = redactLog(logEvents, '1');
+    expect(result).toMatchObject(logEvents);
+  });
+
+  test('can explicitly set showing args to true', () => {
+    const logEvents = [
+      {
+        _stateID: 0,
+        turn: 0,
+        phase: '',
+        action: ActionCreators.makeMove('unclickCell', [1, 2, 3], '0'),
+      },
+    ];
+
+    // player that made the move
+    let result = redactLog(logEvents, '0');
+    expect(result).toMatchObject(logEvents);
+    // other player
+    result = redactLog(logEvents, '1');
+    expect(result).toMatchObject(logEvents);
+  });
+
+  test('events are not redacted', () => {
+    const logEvents = [
+      {
+        _stateID: 0,
+        turn: 0,
+        phase: '',
+        action: ActionCreators.gameEvent('endTurn'),
+      },
+    ];
+
+    // player that made the move
+    let result = redactLog(logEvents, '0');
+    expect(result).toMatchObject(logEvents);
+    // other player
+    result = redactLog(logEvents, '1');
+    expect(result).toMatchObject(logEvents);
+  });
+
+  test('make sure sync redacts the log', async () => {
+    const game = {
+      moves: {
+        A: (G) => G,
+        B: {
+          move: (G) => G,
+          redact: true,
+        },
+      },
+    };
+
+    const send = jest.fn();
+    const master = new Master(game, new InMemory(), TransportAPI(send));
+
+    const actionA = ActionCreators.makeMove('A', ['not redacted'], '0');
+    const actionB = ActionCreators.makeMove('B', ['redacted'], '0');
+
+    // test: ping-pong two moves, then sync and check the log
+    await master.onSync('matchID', '0', undefined, 2);
+    await master.onUpdate(actionA, 0, 'matchID', '0');
+    await master.onUpdate(actionB, 1, 'matchID', '0');
+    await master.onSync('matchID', '1', undefined, 2);
+
+    const { log } = send.mock.calls[send.mock.calls.length - 1][0].args[1];
+    expect(log).toMatchObject([
+      {
+        action: {
+          type: 'MAKE_MOVE',
+          payload: {
+            type: 'A',
+            args: ['not redacted'],
+            playerID: '0',
+          },
+        },
+        _stateID: 0,
+      },
+      {
+        action: {
+          type: 'MAKE_MOVE',
+          payload: {
+            type: 'B',
+            args: null,
+            playerID: '0',
+          },
+        },
+        _stateID: 1,
+      },
+    ]);
+  });
+});

--- a/src/master/filter-player-view.ts
+++ b/src/master/filter-player-view.ts
@@ -1,0 +1,82 @@
+import { PlayerView } from '../plugins/main';
+import { createPatch } from 'rfc6902';
+import type { Game, State, LogEntry, PlayerID } from '../types';
+import type { TransportData, IntermediateTransportData } from './master';
+
+const applyPlayerView = (
+  game: Game,
+  playerID: string,
+  state: State
+): State => ({
+  ...state,
+  G: game.playerView(state.G, state.ctx, playerID),
+  plugins: PlayerView(state, { playerID, game }),
+  deltalog: undefined,
+  _undo: [],
+  _redo: [],
+});
+
+/** Gets a function that filters the TransportData for a given player and game. */
+export const getFilterPlayerView = (game: Game) => (
+  playerID: string,
+  payload: IntermediateTransportData
+): TransportData => {
+  if (payload.type === 'patch') {
+    const [matchID, stateID, prevState, state] = payload.args;
+    const log = redactLog(state.deltalog, playerID);
+    const filteredState = applyPlayerView(game, playerID, state);
+    const newStateID = state._stateID;
+    const prevFilteredState = applyPlayerView(game, playerID, prevState);
+    const patch = createPatch(prevFilteredState, filteredState);
+    return {
+      type: 'patch',
+      args: [matchID, stateID, newStateID, patch, log],
+    };
+  } else if (payload.type === 'update') {
+    const [matchID, state] = payload.args;
+    const log = redactLog(state.deltalog, playerID);
+    const filteredState = applyPlayerView(game, playerID, state);
+    return {
+      type: 'update',
+      args: [matchID, filteredState, log],
+    };
+  } else {
+    return payload;
+  }
+};
+
+/**
+ * Redact the log.
+ *
+ * @param {Array} log - The game log (or deltalog).
+ * @param {String} playerID - The playerID that this log is
+ *                            to be sent to.
+ */
+export function redactLog(log: LogEntry[], playerID: PlayerID) {
+  if (log === undefined) {
+    return log;
+  }
+
+  return log.map((logEvent) => {
+    // filter for all other players and spectators.
+    if (playerID !== null && +playerID === +logEvent.action.payload.playerID) {
+      return logEvent;
+    }
+
+    if (logEvent.redact !== true) {
+      return logEvent;
+    }
+
+    const payload = {
+      ...logEvent.action.payload,
+      args: null,
+    };
+    const filteredEvent = {
+      ...logEvent,
+      action: { ...logEvent.action, payload },
+    };
+
+    const { redact, ...remaining } = filteredEvent;
+    return remaining;
+  });
+}

--- a/src/master/filter-player-view.ts
+++ b/src/master/filter-player-view.ts
@@ -40,6 +40,19 @@ export const getFilterPlayerView = (game: Game) => (
       type: 'update',
       args: [matchID, filteredState, log],
     };
+  } else if (payload.type === 'sync') {
+    const [matchID, syncInfo] = payload.args;
+    const filteredState = applyPlayerView(game, playerID, syncInfo.state);
+    const log = redactLog(syncInfo.log, playerID);
+    const newSyncInfo = {
+      ...syncInfo,
+      state: filteredState,
+      log,
+    };
+    return {
+      type: 'sync',
+      args: [matchID, newSyncInfo],
+    };
   } else {
     return payload;
   }

--- a/src/master/master.test.ts
+++ b/src/master/master.test.ts
@@ -9,7 +9,7 @@
 import * as ActionCreators from '../core/action-creators';
 import { InitializeGame } from '../core/initialize';
 import { InMemory } from '../server/db/inmemory';
-import { Master, redactLog } from './master';
+import { Master } from './master';
 import { error } from '../core/logger';
 import type { Game, Server, State, Ctx, LogEntry } from '../types';
 import { Auth } from '../server/auth';
@@ -171,12 +171,8 @@ describe('sync', () => {
 });
 
 describe('update', () => {
-  let sendAllReturn;
-
   const send = jest.fn();
-  const sendAll = jest.fn((arg) => {
-    sendAllReturn = arg;
-  });
+  const sendAll = jest.fn();
   const game = {
     moves: {
       A: (G) => G,
@@ -190,24 +186,18 @@ describe('update', () => {
     db = new InMemory();
     master = new Master(game, db, TransportAPI(send, sendAll));
     await master.onSync('matchID', '0', undefined, 2);
-    sendAllReturn = undefined;
     jest.clearAllMocks();
   });
 
   test('basic', async () => {
     await master.onUpdate(action, 0, 'matchID', '0');
     expect(sendAll).toBeCalled();
-    expect(sendAllReturn).not.toBeUndefined();
-
-    const value = sendAllReturn('0');
+    const value = sendAll.mock.calls[0][0];
     expect(value.type).toBe('update');
     expect(value.args[0]).toBe('matchID');
     expect(value.args[1]).toMatchObject({
       G: {},
-      deltalog: undefined,
-      _redo: [],
       _stateID: 1,
-      _undo: [],
       ctx: {
         currentPlayer: '1',
         numPlayers: 2,
@@ -217,20 +207,6 @@ describe('update', () => {
         turn: 2,
       },
     });
-
-    expect(value.args[2]).toMatchObject([
-      {
-        action: {
-          payload: {
-            args: undefined,
-            credentials: undefined,
-            playerID: undefined,
-            type: 'endTurn',
-          },
-          type: 'GAME_EVENT',
-        },
-      },
-    ]);
   });
 
   test('invalid matchID', async () => {
@@ -340,22 +316,12 @@ describe('update', () => {
       master.onSync('matchID', '1', undefined, 2),
     ]);
 
-    const G_player0 = sendAllReturn('0').args[1].G;
-    const G_player1 = sendAllReturn('1').args[1].G;
+    const G = sendAll.mock.calls[sendAll.mock.calls.length - 1][0].args[1].G;
 
-    expect(G_player0).toMatchObject({
+    expect(G).toMatchObject({
       players: {
         '0': {
           cards: ['card1'],
-        },
-      },
-      cards: ['card0'],
-      discardedCards: ['card3'],
-    });
-    expect(G_player1).toMatchObject({
-      players: {
-        '1': {
-          cards: ['card2'],
         },
       },
       cards: ['card0'],
@@ -524,12 +490,8 @@ describe('update', () => {
 });
 
 describe('patch', () => {
-  let sendAllReturn;
-
   const send = jest.fn();
-  const sendAll = jest.fn((arg) => {
-    sendAllReturn = arg;
-  });
+  const sendAll = jest.fn();
   const db = new InMemory();
   const master = new Master(
     {
@@ -592,39 +554,21 @@ describe('patch', () => {
   });
 
   beforeEach(() => {
-    sendAllReturn = undefined;
     jest.clearAllMocks();
   });
 
   test('basic', async () => {
     await master.onUpdate(move, 0, 'matchID', '0');
     expect(sendAll).toBeCalled();
-    expect(sendAllReturn).not.toBeUndefined();
 
-    const value = sendAllReturn('0');
+    const value = sendAll.mock.calls[0][0];
     expect(value.type).toBe('patch');
     expect(value.args[0]).toBe('matchID');
     expect(value.args[1]).toBe(0);
-    expect(value.args[2]).toBe(1);
-    expect(value.args[3]).toMatchObject([
-      { op: 'remove', path: '/G/players/0/cards/0' },
-      { op: 'add', path: '/G/discardedCards/-', value: 'card3' },
-      { op: 'replace', path: '/ctx/numMoves', value: 1 },
-      { op: 'replace', path: '/_stateID', value: 1 },
-    ]);
-
-    expect(value.args[4]).toMatchObject([
-      {
-        action: {
-          payload: {
-            args: null,
-            playerID: '0',
-            type: 'A',
-          },
-          type: 'MAKE_MOVE',
-        },
-      },
-    ]);
+    // prevState -- had a card
+    expect(value.args[2].G.players[0].cards).toEqual(['card3']);
+    // state -- doesnt have a card anymore
+    expect(value.args[3].G.players[0].cards).toEqual([]);
   });
 
   test('invalid matchID', async () => {
@@ -728,12 +672,8 @@ describe('patch', () => {
 });
 
 describe('connectionChange', () => {
-  let sendAllReturn;
-
   const send = jest.fn();
-  const sendAll = jest.fn((arg) => {
-    sendAllReturn = arg;
-  });
+  const sendAll = jest.fn();
 
   const db = new InMemory();
   const master = new Master(game, db, TransportAPI(send, sendAll));
@@ -760,7 +700,6 @@ describe('connectionChange', () => {
   db.createMatch('matchID', { metadata, initialState: {} as State });
 
   beforeEach(() => {
-    sendAllReturn = undefined;
     master.subscribe(({ state }) => {
       validateNotTransientState(state);
     });
@@ -783,7 +722,7 @@ describe('connectionChange', () => {
       { id: 0, name: 'Alice', isConnected: true },
       { id: 1, name: 'Bob', isConnected: false },
     ];
-    const sentMessage = sendAllReturn('0');
+    const sentMessage = sendAll.mock.calls[0][0];
     expect(sentMessage.type).toEqual('matchData');
     expect(sentMessage.args[1]).toMatchObject(expectedMetadata);
   });
@@ -829,53 +768,6 @@ describe('connectionChange', () => {
     await masterWithAsyncDb.onConnectionChange('matchID', '0', undefined, true);
 
     expect(sendAll).toHaveBeenCalled();
-  });
-});
-
-describe('playerView', () => {
-  let sendAllReturn;
-  let sendReturn;
-
-  const send = jest.fn((arg) => {
-    sendReturn = arg;
-  });
-  const sendAll = jest.fn((arg) => {
-    sendAllReturn = arg;
-  });
-  const game = {
-    playerView: (G, ctx, player) => {
-      return { ...G, player };
-    },
-  };
-  const master = new Master(game, new InMemory(), TransportAPI(send, sendAll));
-
-  beforeAll(async () => {
-    await master.onSync('matchID', '0', undefined, 2);
-  });
-
-  beforeEach(() => {
-    sendReturn = undefined;
-    sendAllReturn = undefined;
-    jest.clearAllMocks();
-  });
-
-  test('sync', async () => {
-    await master.onSync('matchID', '0', undefined, 2);
-    expect(sendReturn.args[1].state).toMatchObject({
-      G: { player: '0' },
-    });
-  });
-
-  test('update', async () => {
-    const action = ActionCreators.gameEvent('endTurn');
-    await master.onSync('matchID', '0', undefined, 2);
-    await master.onUpdate(action, 0, 'matchID', '0');
-
-    const G_player0 = sendAllReturn('0').args[1].G;
-    const G_player1 = sendAllReturn('1').args[1].G;
-
-    expect(G_player0.player).toBe('0');
-    expect(G_player1.player).toBe('1');
   });
 });
 
@@ -1102,170 +994,9 @@ describe('authentication', () => {
   });
 });
 
-describe('redactLog', () => {
-  test('no-op with undefined log', () => {
-    const result = redactLog(undefined, '0');
-    expect(result).toBeUndefined();
-  });
-
-  test('no redactedMoves', () => {
-    const logEvents = [
-      {
-        _stateID: 0,
-        turn: 0,
-        phase: '',
-        action: ActionCreators.gameEvent('endTurn'),
-      },
-    ];
-    const result = redactLog(logEvents, '0');
-    expect(result).toMatchObject(logEvents);
-  });
-
-  test('redacted move is only shown with args to the player that made the move', () => {
-    const logEvents = [
-      {
-        _stateID: 0,
-        turn: 0,
-        phase: '',
-        action: ActionCreators.makeMove('clickCell', [1, 2, 3], '0'),
-        redact: true,
-      },
-    ];
-
-    // player that made the move
-    let result = redactLog(logEvents, '0');
-    expect(result).toMatchObject(logEvents);
-
-    // other player
-    result = redactLog(logEvents, '1');
-    expect(result).toMatchObject([
-      {
-        _stateID: 0,
-        turn: 0,
-        phase: '',
-        action: {
-          type: 'MAKE_MOVE',
-          payload: {
-            credentials: undefined,
-            playerID: '0',
-            type: 'clickCell',
-          },
-        },
-      },
-    ]);
-  });
-
-  test('not redacted move is shown to all', () => {
-    const logEvents = [
-      {
-        _stateID: 0,
-        turn: 0,
-        phase: '',
-        action: ActionCreators.makeMove('unclickCell', [1, 2, 3], '0'),
-      },
-    ];
-
-    // player that made the move
-    let result = redactLog(logEvents, '0');
-    expect(result).toMatchObject(logEvents);
-    // other player
-    result = redactLog(logEvents, '1');
-    expect(result).toMatchObject(logEvents);
-  });
-
-  test('can explicitly set showing args to true', () => {
-    const logEvents = [
-      {
-        _stateID: 0,
-        turn: 0,
-        phase: '',
-        action: ActionCreators.makeMove('unclickCell', [1, 2, 3], '0'),
-      },
-    ];
-
-    // player that made the move
-    let result = redactLog(logEvents, '0');
-    expect(result).toMatchObject(logEvents);
-    // other player
-    result = redactLog(logEvents, '1');
-    expect(result).toMatchObject(logEvents);
-  });
-
-  test('events are not redacted', () => {
-    const logEvents = [
-      {
-        _stateID: 0,
-        turn: 0,
-        phase: '',
-        action: ActionCreators.gameEvent('endTurn'),
-      },
-    ];
-
-    // player that made the move
-    let result = redactLog(logEvents, '0');
-    expect(result).toMatchObject(logEvents);
-    // other player
-    result = redactLog(logEvents, '1');
-    expect(result).toMatchObject(logEvents);
-  });
-
-  test('make sure sync redacts the log', async () => {
-    const game = {
-      moves: {
-        A: (G) => G,
-        B: {
-          move: (G) => G,
-          redact: true,
-        },
-      },
-    };
-
-    const send = jest.fn();
-    const master = new Master(game, new InMemory(), TransportAPI(send));
-
-    const actionA = ActionCreators.makeMove('A', ['not redacted'], '0');
-    const actionB = ActionCreators.makeMove('B', ['redacted'], '0');
-
-    // test: ping-pong two moves, then sync and check the log
-    await master.onSync('matchID', '0', undefined, 2);
-    await master.onUpdate(actionA, 0, 'matchID', '0');
-    await master.onUpdate(actionB, 1, 'matchID', '0');
-    await master.onSync('matchID', '1', undefined, 2);
-
-    const { log } = send.mock.calls[send.mock.calls.length - 1][0].args[1];
-    expect(log).toMatchObject([
-      {
-        action: {
-          type: 'MAKE_MOVE',
-          payload: {
-            type: 'A',
-            args: ['not redacted'],
-            playerID: '0',
-          },
-        },
-        _stateID: 0,
-      },
-      {
-        action: {
-          type: 'MAKE_MOVE',
-          payload: {
-            type: 'B',
-            args: null,
-            playerID: '0',
-          },
-        },
-        _stateID: 1,
-      },
-    ]);
-  });
-});
-
 describe('chat', () => {
-  let sendAllReturn;
   const send = jest.fn();
-  const sendAll = jest.fn((arg) => {
-    sendAllReturn = arg;
-  });
+  const sendAll = jest.fn();
   const db = new InMemory();
   const master = new Master(game, db, TransportAPI(send, sendAll));
 
@@ -1279,7 +1010,7 @@ describe('chat', () => {
       { id: 'uuid', sender: '0', payload: { message: 'foo' } },
       undefined
     );
-    expect(sendAllReturn('0')).toEqual({
+    expect(sendAll.mock.calls[0][0]).toEqual({
       type: 'chat',
       args: [
         'matchID',

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -54,15 +54,7 @@ type CallbackFn = (arg: {
   action?: ActionShape.Any | CredentialedActionShape.Any;
 }) => void;
 
-export type TransportData =
-  | {
-      type: 'update';
-      args: [string, State, LogEntry[]];
-    }
-  | {
-      type: 'patch';
-      args: [string, number, number, Operation[], LogEntry[]];
-    }
+type CommonTransportData =
   | {
       type: 'sync';
       args: [string, SyncInfo];
@@ -76,6 +68,17 @@ export type TransportData =
       args: [string, ChatMessage];
     };
 
+export type TransportData =
+  | {
+      type: 'update';
+      args: [string, State, LogEntry[]];
+    }
+  | {
+      type: 'patch';
+      args: [string, number, number, Operation[], LogEntry[]];
+    }
+  | CommonTransportData;
+
 export type IntermediateTransportData =
   | {
       type: 'update';
@@ -85,18 +88,7 @@ export type IntermediateTransportData =
       type: 'patch';
       args: [string, number, State, State];
     }
-  | {
-      type: 'sync';
-      args: [string, SyncInfo];
-    }
-  | {
-      type: 'matchData';
-      args: [string, FilteredMetadata];
-    }
-  | {
-      type: 'chat';
-      args: [string, ChatMessage];
-    };
+  | CommonTransportData;
 
 export interface TransportAPI {
   send: (

--- a/src/server/transport/socketio.test.ts
+++ b/src/server/transport/socketio.test.ts
@@ -12,6 +12,7 @@ import { Auth } from '../auth';
 import { ProcessGameConfig } from '../../core/game';
 import type { Master } from '../../master/master';
 import { error } from '../../core/logger';
+import { getFilterPlayerView } from '../../master/filter-player-view';
 
 jest.mock('../../core/logger', () => ({
   info: jest.fn(),
@@ -165,7 +166,14 @@ describe('TransportAPI', () => {
     const transport = new SocketIOTestAdapter({ clientInfo, roomInfo });
     transport.init(app, games);
     io = app.context.io;
-    api = TransportAPI('matchID', io.socket, clientInfo, roomInfo);
+    const filterPlayerView = getFilterPlayerView(games[0]);
+    api = TransportAPI(
+      'matchID',
+      io.socket,
+      clientInfo,
+      roomInfo,
+      filterPlayerView
+    );
   });
 
   beforeEach(async () => {
@@ -191,9 +199,9 @@ describe('TransportAPI', () => {
   });
 
   test('sendAll - function', () => {
-    api.sendAll((playerID) => ({ type: 'A', args: [playerID] }));
-    expect(io.socket.emit).toHaveBeenCalledWith('A', '0');
-    expect(io.socket.emit).toHaveBeenCalledWith('A', '1');
+    api.sendAll({ type: 'A', args: [] });
+    expect(io.socket.emit).toHaveBeenCalledTimes(2);
+    expect(io.socket.emit).toHaveBeenCalledWith('A');
   });
 });
 

--- a/src/server/transport/socketio.ts
+++ b/src/server/transport/socketio.ts
@@ -65,7 +65,8 @@ export function TransportAPI(
    */
   const send: MasterTransport['send'] = ({ playerID, ...data }) => {
     forEachClient((client) => {
-      if (client.playerID === playerID) emit(client.socket.id, data);
+      if (client.playerID === playerID)
+        emit(client.socket.id, filterPlayerView(playerID, data));
     });
   };
 


### PR DESCRIPTION
In this PR I refactor the interface between Master and Transport, so the Master will only send a single message to the transport, and then the transport will calculate the player view for each player. 

This will allow us to use a pub/sub to propagate the Master message, allowing us to scale the bgio server horizontally.

#### Checklist

- [x] Use a separate branch in your local repo (not `main`).
- [x] Test coverage is 100% (or you have a story for why it's ok).
