### PR TITLE
feat(plugins): Consolidate flush and validate plugins

### DIFF
--- a/src/core/initialize.ts
+++ b/src/core/initialize.ts
@@ -60,7 +60,7 @@ export function InitializeGame({
   };
 
   initial = game.flow.init(initial);
-  [initial] = plugins.flushAndValidate(initial, { game });
+  [initial] = plugins.FlushAndValidate(initial, { game });
 
   // Initialize undo stack.
   if (!game.disableUndo) {

--- a/src/core/initialize.ts
+++ b/src/core/initialize.ts
@@ -7,9 +7,8 @@
  */
 
 import { ProcessGameConfig } from './game';
-import type { Game } from '../types';
 import * as plugins from '../plugins/main';
-import type { PartialGameState, State, Ctx } from '../types';
+import type { Ctx, Game, PartialGameState, State } from '../types';
 
 /**
  * Creates the initial game state.
@@ -61,7 +60,7 @@ export function InitializeGame({
   };
 
   initial = game.flow.init(initial);
-  initial = plugins.Flush(initial, { game });
+  [initial] = plugins.flushAndValidate(initial, { game });
 
   // Initialize undo stack.
   if (!game.disableUndo) {

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -141,7 +141,7 @@ function flushAndValidatePlugins(
   oldState: State,
   pluginOpts: { game: Game; isClient?: boolean }
 ): [State, TransientState?] {
-  const [newState, isInvalid] = plugins.flushAndValidate(state, pluginOpts);
+  const [newState, isInvalid] = plugins.FlushAndValidate(state, pluginOpts);
   if (!isInvalid) return [newState];
   return [
     newState,

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -131,7 +131,7 @@ function initializeDeltalog(
 /**
  * Update plugin state after move/event & check if plugins consider the action to be valid.
  * @param newState Latest version of state in the reducer.
- * @param oldState Initial value of state when reducer started its work.
+ * @param oldState State to revert to in case of error.
  * @param pluginOpts Plugin configuration options.
  * @returns Tuple of the new state updated after flushing plugins and the old
  * state augmented with an error if a plugin declared the action invalid.
@@ -141,13 +141,10 @@ function flushAndValidatePlugins(
   oldState: State,
   pluginOpts: { game: Game; isClient?: boolean }
 ): [State, TransientState?] {
-  newState = plugins.Flush(newState, pluginOpts);
-  const isInvalid = plugins.IsInvalid(newState, pluginOpts);
-  if (!isInvalid) return [newState];
-  const { plugin, message } = isInvalid;
-  error(`plugin declared action invalid: ${plugin} - ${message}`);
+  const [state, isInvalid] = plugins.flushAndValidate(newState, pluginOpts);
+  if (!isInvalid) return [state];
   return [
-    newState,
+    state,
     WithError(oldState, ActionErrorType.PluginActionInvalid, isInvalid),
   ];
 }

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -130,21 +130,21 @@ function initializeDeltalog(
 
 /**
  * Update plugin state after move/event & check if plugins consider the action to be valid.
- * @param newState Latest version of state in the reducer.
+ * @param state Current version of state in the reducer.
  * @param oldState State to revert to in case of error.
  * @param pluginOpts Plugin configuration options.
  * @returns Tuple of the new state updated after flushing plugins and the old
  * state augmented with an error if a plugin declared the action invalid.
  */
 function flushAndValidatePlugins(
-  newState: State,
+  state: State,
   oldState: State,
   pluginOpts: { game: Game; isClient?: boolean }
 ): [State, TransientState?] {
-  const [state, isInvalid] = plugins.flushAndValidate(newState, pluginOpts);
-  if (!isInvalid) return [state];
+  const [newState, isInvalid] = plugins.flushAndValidate(state, pluginOpts);
+  if (!isInvalid) return [newState];
   return [
-    state,
+    newState,
     WithError(oldState, ActionErrorType.PluginActionInvalid, isInvalid),
   ];
 }

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -275,7 +275,7 @@ const IsInvalid = (
  * Update plugin state after move/event & check if plugins consider the update to be valid.
  * @returns Tuple of `[updatedState]` or `[originalState, invalidError]`.
  */
-export const flushAndValidate = (state: State, opts: PluginOpts) => {
+export const FlushAndValidate = (state: State, opts: PluginOpts) => {
   const updatedState = Flush(state, opts);
   const isInvalid = IsInvalid(updatedState, opts);
   if (!isInvalid) return [updatedState] as const;

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -21,6 +21,7 @@ import type {
   ActionShape,
   PlayerID,
 } from '../types';
+import { error } from '../core/logger';
 
 interface PluginOpts {
   game: Game;
@@ -166,7 +167,7 @@ export const Enhance = (
 /**
  * Allows plugins to update their state after a move / event.
  */
-export const Flush = (state: State, opts: PluginOpts): State => {
+const Flush = (state: State, opts: PluginOpts): State => {
   // We flush the events plugin first, then custom plugins and the core plugins.
   // This means custom plugins cannot use the events API but will be available in event hooks.
   // Note that plugins are flushed in reverse, to allow custom plugins calling each other.
@@ -246,7 +247,7 @@ export const NoClient = (state: State, opts: PluginOpts): boolean => {
  * Allows plugins to indicate if the entire action should be thrown out
  * as invalid. This will cancel the entire state update.
  */
-export const IsInvalid = (
+const IsInvalid = (
   state: State,
   opts: PluginOpts
 ): false | { plugin: string; message: string } => {
@@ -268,6 +269,19 @@ export const IsInvalid = (
     })
     .find((value) => value);
   return firstInvalidReturn || false;
+};
+
+/**
+ * Update plugin state after move/event & check if plugins consider the update to be valid.
+ * @returns Tuple of `[updatedState]` or `[originalState, invalidError]`.
+ */
+export const flushAndValidate = (state: State, opts: PluginOpts) => {
+  const updatedState = Flush(state, opts);
+  const isInvalid = IsInvalid(updatedState, opts);
+  if (!isInvalid) return [updatedState] as const;
+  const { plugin, message } = isInvalid;
+  error(`${plugin} plugin declared action invalid:\n${message}`);
+  return [state, isInvalid] as const;
 };
 
 /**


### PR DESCRIPTION
#963 introduced an `isInvalid` method to the plugin API allowing plugins to declare updates invalid. #963 used this to check updates in the reducer, but didn’t handle plugins being flushed during game initialisation. This PR refactors use of plugins so that flushing and validation always happens together via a consolidated `flushAndValidate` method.

---

It’s not quite clear at the moment how game initialisation should handle errors, so I’ve left that open for now — this allows plugins to revert plugin updates and log an error, but won’t actually break games. At some point it would be good to handle game initialisation errors properly.