### PR TITLE
fix(master): Don’t crash on missing chatMessage

### DIFF
--- a/src/master/master.test.ts
+++ b/src/master/master.test.ts
@@ -966,6 +966,19 @@ describe('authentication', () => {
 
     beforeEach(resetTestEnvironment);
 
+    test('auth success', async () => {
+      const authenticateCredentials = () => true;
+      const master = new Master(
+        game,
+        storage,
+        TransportAPI(send, sendAll),
+        new Auth({ authenticateCredentials })
+      );
+      const ret = await master.onChatMessage(matchID, chatMessage, undefined);
+      expect(ret).toBeUndefined();
+      expect(sendAll).toHaveBeenCalled();
+    });
+
     test('auth failure', async () => {
       const authenticateCredentials = () => false;
       const master = new Master(
@@ -979,7 +992,7 @@ describe('authentication', () => {
       expect(sendAll).not.toHaveBeenCalled();
     });
 
-    test('auth success', async () => {
+    test('invalid packet', async () => {
       const authenticateCredentials = () => true;
       const master = new Master(
         game,
@@ -987,9 +1000,9 @@ describe('authentication', () => {
         TransportAPI(send, sendAll),
         new Auth({ authenticateCredentials })
       );
-      const ret = await master.onChatMessage(matchID, chatMessage, undefined);
-      expect(ret).toBeUndefined();
-      expect(sendAll).toHaveBeenCalled();
+      const ret = await master.onChatMessage(matchID, undefined, undefined);
+      expect(ret && ret.error).toBe('unauthorized');
+      expect(sendAll).not.toHaveBeenCalled();
     });
 
     test('default', async () => {

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -456,7 +456,7 @@ export class Master {
           metadata: true,
         }
       );
-      const isAuthentic = await this.auth.authenticateCredentials({
+      const isAuthentic = !!(chatMessage?.sender) && await this.auth.authenticateCredentials({
         playerID: chatMessage.sender,
         credentials,
         metadata,

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -456,11 +456,13 @@ export class Master {
           metadata: true,
         }
       );
-      const isAuthentic = !!(chatMessage?.sender) && await this.auth.authenticateCredentials({
-        playerID: chatMessage.sender,
-        credentials,
-        metadata,
-      });
+      const isAuthentic =
+        !!chatMessage?.sender &&
+        (await this.auth.authenticateCredentials({
+          playerID: chatMessage.sender,
+          credentials,
+          metadata,
+        }));
       if (!isAuthentic) {
         return { error: 'unauthorized' };
       }

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -456,13 +456,14 @@ export class Master {
           metadata: true,
         }
       );
-      const isAuthentic =
-        !!chatMessage?.sender &&
-        (await this.auth.authenticateCredentials({
-          playerID: chatMessage.sender,
-          credentials,
-          metadata,
-        }));
+      if (!(chatMessage && typeof chatMessage.sender === 'string')) {
+        return { error: 'unauthorized' };
+      }
+      const isAuthentic = await this.auth.authenticateCredentials({
+        playerID: chatMessage.sender,
+        credentials,
+        metadata,
+      });
       if (!isAuthentic) {
         return { error: 'unauthorized' };
       }


### PR DESCRIPTION
This line was throwing unhandled promise rejections when I was testing invalid packets

#### Checklist

- [ this was edited in github] Use a separate branch in your local repo (not `main`).
- [no ] Test coverage is 100% (or you have a story for why it's ok)
