### PR TITLE
feat: Expose method types to plugin `fnWrap` & improve events errors

### DIFF
--- a/docs/documentation/events.md
+++ b/docs/documentation/events.md
@@ -158,3 +158,21 @@ const game = {
 
 !> This doesn't apply to events in moves or hooks, but just the
 ability to call an event directly from a client.
+
+### Calling events from hooks
+
+The events API is available in game hooks like it is inside moves. However,
+because of how hooks and events interact, certain events cannot be called from
+certain hooks. The following table shows which hooks support which events.
+
+|                    | turn<br>`onMove` | turn<br>`onBegin` | turn<br>`onEnd` | phase<br>`onBegin` | phase<br>`onEnd` | game<br>`onEnd` |
+|-------------------:|:----------------:|:-----------------:|:---------------:|:------------------:|:----------------:|:---------------:|
+|         `setStage` |         ✅        |         ❌         |        ❌        |          ❌         |         ❌        |        ❌        |
+|         `endStage` |         ✅        |         ❌         |        ❌        |          ❌         |         ❌        |        ❌        |
+| `setActivePlayers` |         ✅        |         ✅         |        ❌        |          ❌         |         ❌        |        ❌        |
+|          `endTurn` |         ✅        |         ✅         |        ❌        |          ✅         |         ❌        |        ❌        |
+|         `setPhase` |         ✅        |         ✅         |        ✅        |          ✅         |         ❌        |        ❌        |
+|         `endPhase` |         ✅        |         ✅         |        ✅        |          ✅         |         ❌        |        ❌        |
+|          `endGame` |         ✅        |         ✅         |        ✅        |          ✅         |         ✅        |        ❌        |
+
+✅ = supported &nbsp;&nbsp;&nbsp; ❌ = not supported

--- a/packages/core.ts
+++ b/packages/core.ts
@@ -7,7 +7,15 @@
  */
 
 import { INVALID_MOVE } from '../src/core/constants';
+import { GameMethod } from '../src/core/game-methods';
 import { ActivePlayers, TurnOrder, Stage } from '../src/core/turn-order';
 import { PlayerView } from '../src/core/player-view';
 
-export { ActivePlayers, Stage, TurnOrder, PlayerView, INVALID_MOVE };
+export {
+  ActivePlayers,
+  GameMethod,
+  Stage,
+  TurnOrder,
+  PlayerView,
+  INVALID_MOVE,
+};

--- a/src/client/transport/local.test.ts
+++ b/src/client/transport/local.test.ts
@@ -19,28 +19,6 @@ import type { ChatMessage, Game, State, Store, SyncInfo } from '../../types';
 
 const sleep = (ms = 500) => new Promise((resolve) => setTimeout(resolve, ms));
 
-/**
- * Run a callback on an interval and resolve when it returns `true`.
- * @param condition Callback that should eventually return `true`.
- * @param interval Interval on which to test the condition callback (in ms).
- * @param timeout How long to wait for the condition to be `true` before rejecting (in ms).
- */
-const waitFor = (condition: () => boolean, interval = 50, timeout = 1000) =>
-  new Promise<void>((resolve, reject) => {
-    const startTime = Date.now();
-    const intervalID = setInterval(checkCondition, interval);
-    checkCondition();
-    function checkCondition() {
-      if (condition()) {
-        clearInterval(intervalID);
-        resolve();
-      } else if (Date.now() > startTime + timeout) {
-        clearInterval(intervalID);
-        reject();
-      }
-    }
-  });
-
 describe('bots', () => {
   const game: Game = {
     moves: {
@@ -67,8 +45,8 @@ describe('bots', () => {
     client.events.endTurn();
     expect(client.getState().ctx.turn).toBe(2);
 
-    // Wait until the bot has completed its move.
-    await waitFor(() => client.getState().ctx.turn === 3);
+    // Wait until the bot has hopefully completed its move.
+    await sleep();
     expect(client.getState().ctx.turn).toBe(3);
   });
 

--- a/src/client/transport/local.test.ts
+++ b/src/client/transport/local.test.ts
@@ -19,6 +19,28 @@ import type { ChatMessage, Game, State, Store, SyncInfo } from '../../types';
 
 const sleep = (ms = 500) => new Promise((resolve) => setTimeout(resolve, ms));
 
+/**
+ * Run a callback on an interval and resolve when it returns `true`.
+ * @param condition Callback that should eventually return `true`.
+ * @param interval Interval on which to test the condition callback (in ms).
+ * @param timeout How long to wait for the condition to be `true` before rejecting (in ms).
+ */
+const waitFor = (condition: () => boolean, interval = 50, timeout = 1000) =>
+  new Promise<void>((resolve, reject) => {
+    const startTime = Date.now();
+    const intervalID = setInterval(checkCondition, interval);
+    checkCondition();
+    function checkCondition() {
+      if (condition()) {
+        clearInterval(intervalID);
+        resolve();
+      } else if (Date.now() > startTime + timeout) {
+        clearInterval(intervalID);
+        reject();
+      }
+    }
+  });
+
 describe('bots', () => {
   const game: Game = {
     moves: {
@@ -45,8 +67,8 @@ describe('bots', () => {
     client.events.endTurn();
     expect(client.getState().ctx.turn).toBe(2);
 
-    // Wait until the bot has hopefully completed its move.
-    await sleep();
+    // Wait until the bot has completed its move.
+    await waitFor(() => client.getState().ctx.turn === 3);
     expect(client.getState().ctx.turn).toBe(3);
   });
 

--- a/src/core/flow.test.ts
+++ b/src/core/flow.test.ts
@@ -1090,18 +1090,22 @@ describe('infinite loops', () => {
     expect(state.ctx.phase).toBe('A');
     expect(state.ctx.turn).toBe(1);
     expect(error).toHaveBeenCalled();
-    expect((error as jest.Mock).mock.calls[0][0]).toMatch(
-      /events plugin declared action invalid/
-    );
+    {
+      const errorMessage = (error as jest.Mock).mock.calls[0][0];
+      expect(errorMessage).toMatch(/events plugin declared action invalid/);
+      expect(errorMessage).toMatch(/Maximum number of turn endings exceeded/);
+    }
     jest.clearAllMocks();
 
     // Moves also fail because of the infinite loop (the game is stuck).
     client.moves.a();
     state = client.getState();
     expect(error).toHaveBeenCalled();
-    expect((error as jest.Mock).mock.calls[0][0]).toMatch(
-      /events plugin declared action invalid/
-    );
+    {
+      const errorMessage = (error as jest.Mock).mock.calls[0][0];
+      expect(errorMessage).toMatch(/events plugin declared action invalid/);
+      expect(errorMessage).toMatch(/Maximum number of turn endings exceeded/);
+    }
     expect(state.ctx.phase).toBe('A');
     expect(state.ctx.turn).toBe(1);
   });
@@ -1149,9 +1153,9 @@ describe('infinite loops', () => {
 
     // Expect state to be unchanged and error to be logged.
     expect(error).toHaveBeenCalled();
-    expect((error as jest.Mock).mock.calls[0][0]).toMatch(
-      /events plugin declared action invalid/
-    );
+    const errorMessage = (error as jest.Mock).mock.calls[0][0];
+    expect(errorMessage).toMatch(/events plugin declared action invalid/);
+    expect(errorMessage).toMatch(/Maximum number of turn endings exceeded/);
     expect(client.getState().ctx.currentPlayer).toBe('0');
     expect(client.getState()).toEqual({ ...initialState, deltalog: [] });
   });

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -784,7 +784,7 @@ export function Flow({
     enabledEventNames.push('setStage');
   }
 
-  function ProcessEvent(state: State, action: ActionShape.GameEvent) {
+  function ProcessEvent(state: State, action: ActionShape.GameEvent): State {
     const { type, playerID, args } = action.payload;
     if (typeof eventHandlers[type] !== 'function') return state;
     return eventHandlers[type](

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -30,7 +30,6 @@ import type {
   Move,
 } from '../types';
 import { GameMethod } from './game-methods';
-import type { GameMethodNames } from './game-methods';
 
 /**
  * Flow
@@ -80,7 +79,7 @@ export function Flow({
 
   const HookWrapper = (
     hook: (G: any, ctx: Ctx) => any,
-    hookType: GameMethodNames
+    hookType: GameMethod
   ) => {
     const withPlugins = plugin.FnWrap(hook, hookType, plugins);
     return (state: State) => {
@@ -97,7 +96,7 @@ export function Flow({
   };
 
   const wrapped = {
-    onEnd: HookWrapper(onEnd, GameMethod.Game.ON_END),
+    onEnd: HookWrapper(onEnd, GameMethod.GAME_ON_END),
     endIf: TriggerWrapper(endIf),
   };
 
@@ -157,15 +156,15 @@ export function Flow({
     }
 
     phaseConfig.wrapped = {
-      onBegin: HookWrapper(phaseConfig.onBegin, GameMethod.Phase.ON_BEGIN),
-      onEnd: HookWrapper(phaseConfig.onEnd, GameMethod.Phase.ON_END),
+      onBegin: HookWrapper(phaseConfig.onBegin, GameMethod.PHASE_ON_BEGIN),
+      onEnd: HookWrapper(phaseConfig.onEnd, GameMethod.PHASE_ON_END),
       endIf: TriggerWrapper(phaseConfig.endIf),
     };
 
     phaseConfig.turn.wrapped = {
-      onMove: HookWrapper(phaseConfig.turn.onMove, GameMethod.Turn.ON_MOVE),
-      onBegin: HookWrapper(phaseConfig.turn.onBegin, GameMethod.Turn.ON_BEGIN),
-      onEnd: HookWrapper(phaseConfig.turn.onEnd, GameMethod.Turn.ON_END),
+      onMove: HookWrapper(phaseConfig.turn.onMove, GameMethod.TURN_ON_MOVE),
+      onBegin: HookWrapper(phaseConfig.turn.onBegin, GameMethod.TURN_ON_BEGIN),
+      onEnd: HookWrapper(phaseConfig.turn.onEnd, GameMethod.TURN_ON_END),
       endIf: TriggerWrapper(phaseConfig.turn.endIf),
     };
 

--- a/src/core/game-methods.ts
+++ b/src/core/game-methods.ts
@@ -1,0 +1,26 @@
+import type { O } from 'ts-toolbelt';
+
+const Game = {
+  ON_END: 'GAME.ON_END',
+} as const;
+
+const Phase = {
+  ON_BEGIN: 'PHASE.ON_BEGIN',
+  ON_END: 'PHASE.ON_END',
+} as const;
+
+const Turn = {
+  ON_BEGIN: 'TURN.ON_BEGIN',
+  ON_MOVE: 'TURN.ON_MOVE',
+  ON_END: 'TURN.ON_END',
+} as const;
+
+const MOVE = 'MOVE';
+
+export const GameMethod = { Game, Phase, Turn, MOVE } as const;
+
+export type GameMethodNames =
+  | O.UnionOf<typeof Game>
+  | O.UnionOf<typeof Phase>
+  | O.UnionOf<typeof Turn>
+  | typeof MOVE;

--- a/src/core/game-methods.ts
+++ b/src/core/game-methods.ts
@@ -1,26 +1,9 @@
-import type { O } from 'ts-toolbelt';
-
-const Game = {
-  ON_END: 'GAME.ON_END',
-} as const;
-
-const Phase = {
-  ON_BEGIN: 'PHASE.ON_BEGIN',
-  ON_END: 'PHASE.ON_END',
-} as const;
-
-const Turn = {
-  ON_BEGIN: 'TURN.ON_BEGIN',
-  ON_MOVE: 'TURN.ON_MOVE',
-  ON_END: 'TURN.ON_END',
-} as const;
-
-const MOVE = 'MOVE';
-
-export const GameMethod = { Game, Phase, Turn, MOVE } as const;
-
-export type GameMethodNames =
-  | O.UnionOf<typeof Game>
-  | O.UnionOf<typeof Phase>
-  | O.UnionOf<typeof Turn>
-  | typeof MOVE;
+export enum GameMethod {
+  MOVE = 'MOVE',
+  GAME_ON_END = 'GAME_ON_END',
+  PHASE_ON_BEGIN = 'PHASE_ON_BEGIN',
+  PHASE_ON_END = 'PHASE_ON_END',
+  TURN_ON_BEGIN = 'TURN_ON_BEGIN',
+  TURN_ON_MOVE = 'TURN_ON_MOVE',
+  TURN_ON_END = 'TURN_ON_END',
+}

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -11,6 +11,7 @@ import { Flow } from './flow';
 import type { INVALID_MOVE } from './constants';
 import type { ActionPayload, Game, Move, LongFormMove, State } from '../types';
 import * as logging from './logger';
+import { GameMethod } from './game-methods';
 
 type ProcessedGame = Game & {
   flow: ReturnType<typeof Flow>;
@@ -87,7 +88,7 @@ export function ProcessGameConfig(game: Game | ProcessedGame): ProcessedGame {
       }
 
       if (moveFn instanceof Function) {
-        const fn = plugins.FnWrap(moveFn, game.plugins);
+        const fn = plugins.FnWrap(moveFn, GameMethod.MOVE, game.plugins);
         const ctxWithAPI = {
           ...plugins.EnhanceCtx(state),
           playerID: action.playerID,

--- a/src/plugins/events/events.test.ts
+++ b/src/plugins/events/events.test.ts
@@ -8,7 +8,14 @@
 
 import { Events } from './events';
 import { Client } from '../../client/client';
+import { error } from '../../core/logger';
 import type { Game, Ctx } from '../../types';
+
+jest.mock('../../core/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+}));
+afterEach(jest.clearAllMocks);
 
 test('constructor', () => {
   const flow = {} as Game['flow'];
@@ -62,7 +69,8 @@ test('no duplicate endTurn', () => {
   const client = Client({ game });
   expect(client.getState().ctx.turn).toBe(1);
   client.events.endTurn();
-  expect(client.getState().ctx.turn).toBe(2);
+  expect(client.getState().ctx.turn).toBe(1);
+  expect(error).toHaveBeenCalled();
 });
 
 test('no duplicate endPhase', () => {
@@ -81,5 +89,6 @@ test('no duplicate endPhase', () => {
   const client = Client({ game });
   expect(client.getState().ctx.phase).toBe('A');
   client.events.setPhase('B');
-  expect(client.getState().ctx.phase).toBe('B');
+  expect(client.getState().ctx.phase).toBe('A');
+  expect(error).toHaveBeenCalled();
 });

--- a/src/plugins/events/events.ts
+++ b/src/plugins/events/events.ts
@@ -13,10 +13,22 @@ import { GameMethod } from '../../core/game-methods';
 const enum Errors {
   CalledOutsideHook = 'Events must be called from moves or the `onBegin`, `onEnd`, and `onMove` hooks.\n' +
     'This error probably means you called an event from other game code, like an `endIf` trigger or one of the `turn.order` methods.',
+
+  EndTurnInOnEnd = '`endTurn` is disallowed in `onEnd` hooks — the turn is already ending.',
+
   MaxTurnEndings = 'Maximum number of turn endings exceeded for this update.\n' +
     'This likely means game code is triggering an infinite loop.',
+
+  PhaseEventInOnEnd = '`setPhase` & `endPhase` are disallowed in a phase’s `onEnd` hook — the phase is already ending.\n' +
+    'If you’re trying to dynamically choose the next phase when a phase ends, use the phase’s `next` trigger.',
+
+  StageEventInOnEnd = '`setStage`, `endStage` & `setActivePlayers` are disallowed in `onEnd` hooks.',
+
   StageEventInPhaseBegin = '`setStage`, `endStage` & `setActivePlayers` are disallowed in a phase’s `onBegin` hook.\n' +
-    'Use the `turn.onBegin` hook or declare stages with `turn.activePlayers` instead.',
+    'Use `setActivePlayers` in a `turn.onBegin` hook or declare stages with `turn.activePlayers` instead.',
+
+  StageEventInTurnBegin = '`setStage` & `endStage` are disallowed in `turn.onBegin`.\n' +
+    'Use `setActivePlayers` or declare stages with `turn.activePlayers` instead.',
 }
 
 export interface EventsAPI {
@@ -102,66 +114,87 @@ export class Events {
     this.currentMethod = undefined;
   }
 
-  stateWithError(state: State, error: Errors): State {
-    return {
-      ...state,
-      plugins: {
-        ...state.plugins,
-        events: {
-          ...state.plugins.events,
-          data: { error },
-        },
-      },
-    };
-  }
-
   /**
    * Updates ctx with the triggered events.
    * @param {object} state - The state object { G, ctx }.
    */
   update(state: State): State {
     const initialState = state;
-    for (let i = 0; i < this.dispatch.length; i++) {
-      const endedTurns = this.currentTurn - this.initialTurn;
-      // This protects against potential infinite loops if specific events are called on hooks.
-      // The moment we exceed the defined threshold, we just bail out of all phases.
-      if (endedTurns >= this.maxEndedTurnsPerAction) {
-        return this.stateWithError(initialState, Errors.MaxTurnEndings);
-      }
+    const stateWithError = (error: Errors) => ({
+      ...initialState,
+      plugins: {
+        ...initialState.plugins,
+        events: {
+          ...initialState.plugins.events,
+          data: { error },
+        },
+      },
+    });
 
+    EventQueue: for (let i = 0; i < this.dispatch.length; i++) {
       const event = this.dispatch[i];
 
-      if (!event.calledFrom) {
-        return this.stateWithError(initialState, Errors.CalledOutsideHook);
+      // This protects against potential infinite loops if specific events are called on hooks.
+      // The moment we exceed the defined threshold, we just bail out of all phases.
+      const endedTurns = this.currentTurn - this.initialTurn;
+      if (endedTurns >= this.maxEndedTurnsPerAction) {
+        return stateWithError(Errors.MaxTurnEndings);
       }
 
-      if (['endStage', 'setStage', 'setActivePlayers'].includes(event.type)) {
-        // Disallow stage events in phase.onBegin hooks.
-        if (event.calledFrom === GameMethod.PHASE_ON_BEGIN) {
-          return this.stateWithError(
-            initialState,
-            Errors.StageEventInPhaseBegin
-          );
+      if (event.calledFrom === undefined) {
+        return stateWithError(Errors.CalledOutsideHook);
+      }
+
+      const isSetActivePlayers = 'setActivePlayers' === event.type;
+      const turnHasEnded = event.turn !== state.ctx.turn;
+
+      switch (event.type) {
+        case 'endStage':
+        case 'setStage':
+        case 'setActivePlayers': {
+          switch (event.calledFrom) {
+            // Disallow all stage events in onEnd and phase.onBegin hooks.
+            case GameMethod.TURN_ON_END:
+            case GameMethod.PHASE_ON_END:
+              return stateWithError(Errors.StageEventInOnEnd);
+            case GameMethod.PHASE_ON_BEGIN:
+              return stateWithError(Errors.StageEventInPhaseBegin);
+            // Disallow setStage & endStage in turn.onBegin hooks.
+            case GameMethod.TURN_ON_BEGIN:
+              if (isSetActivePlayers) break;
+              return stateWithError(Errors.StageEventInTurnBegin);
+          }
+
+          // If the turn already ended, don't try to process stage events.
+          if (turnHasEnded) continue EventQueue;
+          break;
         }
-        // If the turn already ended, don't try to process stage events.
-        if (event.turn !== state.ctx.turn) {
-          continue;
+
+        case 'endTurn': {
+          if (
+            event.calledFrom === GameMethod.TURN_ON_END ||
+            event.calledFrom === GameMethod.PHASE_ON_END
+          ) {
+            return stateWithError(Errors.EndTurnInOnEnd);
+          }
+
+          // If the turn already ended some other way,
+          // don't try to end the turn again.
+          if (turnHasEnded) continue EventQueue;
+          break;
         }
-      }
 
-      // If the turn already ended some other way,
-      // don't try to end the turn again.
-      if (event.type === 'endTurn' && event.turn !== state.ctx.turn) {
-        continue;
-      }
+        case 'endPhase':
+        case 'setPhase': {
+          if (event.calledFrom === GameMethod.PHASE_ON_END) {
+            return stateWithError(Errors.PhaseEventInOnEnd);
+          }
 
-      // If the phase already ended some other way,
-      // don't try to end the phase again.
-      if (
-        (event.type === 'endPhase' || event.type === 'setPhase') &&
-        event.phase !== state.ctx.phase
-      ) {
-        continue;
+          // If the phase already ended some other way,
+          // don't try to end the phase again.
+          if (event.phase !== state.ctx.phase) continue EventQueue;
+          break;
+        }
       }
 
       const action = automaticGameEvent(event.type, event.args, this.playerID);

--- a/src/plugins/events/events.ts
+++ b/src/plugins/events/events.ts
@@ -8,6 +8,17 @@
 
 import type { State, Ctx, PlayerID, Game } from '../../types';
 import { automaticGameEvent } from '../../core/action-creators';
+import { GameMethod } from '../../core/game-methods';
+import type { GameMethodNames } from '../../core/game-methods';
+
+const enum Errors {
+  CalledOutsideHook = 'Events must be called from moves or the `onBegin`, `onEnd`, and `onMove` hooks.\n' +
+    'This error probably means you called an event from other game code, like an `endIf` trigger or one of the `turn.order` methods.',
+  MaxTurnEndings = 'Maximum number of turn endings exceeded for this update.\n' +
+    'This likely means game code is triggering an infinite loop.',
+  StageEventInPhaseBegin = '`setStage`, `endStage` & `setActivePlayers` are disallowed in a phase’s `onBegin` hook.\n' +
+    'Use the `turn.onBegin` hook or declare stages with `turn.activePlayers` instead.',
+}
 
 export interface EventsAPI {
   endGame?(...args: any[]): void;
@@ -23,7 +34,8 @@ export interface EventsAPI {
 export interface PrivateEventsAPI {
   _obj: {
     isUsed(): boolean;
-    updateTurnContext(ctx: Ctx): void;
+    updateTurnContext(ctx: Ctx, methodType: GameMethodNames | undefined): void;
+    unsetCurrentMethod(): void;
     update(state: State): State;
   };
 }
@@ -39,18 +51,20 @@ export class Events {
     args: any[];
     phase: string;
     turn: number;
+    calledFrom: GameMethodNames | undefined;
   }>;
   maxEndedTurnsPerAction: number;
   initialTurn: number;
   currentPhase: string;
   currentTurn: number;
+  currentMethod?: GameMethodNames;
 
   constructor(flow: Game['flow'], ctx: Ctx, playerID?: PlayerID) {
     this.flow = flow;
     this.playerID = playerID;
     this.dispatch = [];
     this.initialTurn = ctx.turn;
-    this.updateTurnContext(ctx);
+    this.updateTurnContext(ctx, undefined);
     // This is an arbitrarily large upper threshold, which could be made
     // configurable via a game option if the need arises.
     this.maxEndedTurnsPerAction = ctx.numPlayers * 100;
@@ -67,6 +81,7 @@ export class Events {
           args,
           phase: this.currentPhase,
           turn: this.currentTurn,
+          calledFrom: this.currentMethod,
         });
       };
     }
@@ -78,23 +93,24 @@ export class Events {
     return this.dispatch.length > 0;
   }
 
-  updateTurnContext(ctx: Ctx) {
+  updateTurnContext(ctx: Ctx, methodType: GameMethodNames | undefined) {
     this.currentPhase = ctx.phase;
     this.currentTurn = ctx.turn;
+    this.currentMethod = methodType;
   }
 
-  stateWithError(state: State): State {
+  unsetCurrentMethod() {
+    this.currentMethod = undefined;
+  }
+
+  stateWithError(state: State, error: Errors): State {
     return {
       ...state,
       plugins: {
         ...state.plugins,
         events: {
           ...state.plugins.events,
-          data: {
-            error:
-              'Maximum number of turn endings exceeded for this update.\n' +
-              'This likely means game code is triggering an infinite loop.',
-          },
+          data: { error },
         },
       },
     };
@@ -111,19 +127,27 @@ export class Events {
       // This protects against potential infinite loops if specific events are called on hooks.
       // The moment we exceed the defined threshold, we just bail out of all phases.
       if (endedTurns >= this.maxEndedTurnsPerAction) {
-        return this.stateWithError(initialState);
+        return this.stateWithError(initialState, Errors.MaxTurnEndings);
       }
 
       const event = this.dispatch[i];
 
-      // If the turn already ended, don't try to process stage events.
-      if (
-        (event.type === 'endStage' ||
-          event.type === 'setStage' ||
-          event.type === 'setActivePlayers') &&
-        event.turn !== state.ctx.turn
-      ) {
-        continue;
+      if (!event.calledFrom) {
+        return this.stateWithError(initialState, Errors.CalledOutsideHook);
+      }
+
+      if (['endStage', 'setStage', 'setActivePlayers'].includes(event.type)) {
+        // Disallow stage events in phase.onBegin hooks.
+        if (event.calledFrom === GameMethod.Phase.ON_BEGIN) {
+          return this.stateWithError(
+            initialState,
+            Errors.StageEventInPhaseBegin
+          );
+        }
+        // If the turn already ended, don't try to process stage events.
+        if (event.turn !== state.ctx.turn) {
+          continue;
+        }
       }
 
       // If the turn already ended some other way,

--- a/src/plugins/events/events.ts
+++ b/src/plugins/events/events.ts
@@ -9,7 +9,6 @@
 import type { State, Ctx, PlayerID, Game } from '../../types';
 import { automaticGameEvent } from '../../core/action-creators';
 import { GameMethod } from '../../core/game-methods';
-import type { GameMethodNames } from '../../core/game-methods';
 
 const enum Errors {
   CalledOutsideHook = 'Events must be called from moves or the `onBegin`, `onEnd`, and `onMove` hooks.\n' +
@@ -34,7 +33,7 @@ export interface EventsAPI {
 export interface PrivateEventsAPI {
   _obj: {
     isUsed(): boolean;
-    updateTurnContext(ctx: Ctx, methodType: GameMethodNames | undefined): void;
+    updateTurnContext(ctx: Ctx, methodType: GameMethod | undefined): void;
     unsetCurrentMethod(): void;
     update(state: State): State;
   };
@@ -51,13 +50,13 @@ export class Events {
     args: any[];
     phase: string;
     turn: number;
-    calledFrom: GameMethodNames | undefined;
+    calledFrom: GameMethod | undefined;
   }>;
   maxEndedTurnsPerAction: number;
   initialTurn: number;
   currentPhase: string;
   currentTurn: number;
-  currentMethod?: GameMethodNames;
+  currentMethod?: GameMethod;
 
   constructor(flow: Game['flow'], ctx: Ctx, playerID?: PlayerID) {
     this.flow = flow;
@@ -93,7 +92,7 @@ export class Events {
     return this.dispatch.length > 0;
   }
 
-  updateTurnContext(ctx: Ctx, methodType: GameMethodNames | undefined) {
+  updateTurnContext(ctx: Ctx, methodType: GameMethod | undefined) {
     this.currentPhase = ctx.phase;
     this.currentTurn = ctx.turn;
     this.currentMethod = methodType;
@@ -138,7 +137,7 @@ export class Events {
 
       if (['endStage', 'setStage', 'setActivePlayers'].includes(event.type)) {
         // Disallow stage events in phase.onBegin hooks.
-        if (event.calledFrom === GameMethod.Phase.ON_BEGIN) {
+        if (event.calledFrom === GameMethod.PHASE_ON_BEGIN) {
           return this.stateWithError(
             initialState,
             Errors.StageEventInPhaseBegin

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -22,7 +22,7 @@ import type {
   PlayerID,
 } from '../types';
 import { error } from '../core/logger';
-import type { GameMethodNames } from '../core/game-methods';
+import type { GameMethod } from '../core/game-methods';
 
 interface PluginOpts {
   game: Game;
@@ -99,7 +99,7 @@ export const EnhanceCtx = (state: PartialGameState): Ctx => {
  */
 export const FnWrap = (
   methodToWrap: AnyFn,
-  methodType: GameMethodNames,
+  methodType: GameMethod,
   plugins: Plugin[]
 ) => {
   return [...DEFAULT_PLUGINS, ...plugins]

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -22,6 +22,7 @@ import type {
   PlayerID,
 } from '../types';
 import { error } from '../core/logger';
+import type { GameMethodNames } from '../core/game-methods';
 
 interface PluginOpts {
   game: Game;
@@ -92,13 +93,21 @@ export const EnhanceCtx = (state: PartialGameState): Ctx => {
 /**
  * Applies the provided plugins to the given move / flow function.
  *
- * @param {function} functionToWrap - The move function or trigger to apply the plugins to.
- * @param {object} plugins - The list of plugins.
+ * @param methodToWrap - The move function or hook to apply the plugins to.
+ * @param methodType - The type of the move or hook being wrapped.
+ * @param plugins - The list of plugins.
  */
-export const FnWrap = (functionToWrap: AnyFn, plugins: Plugin[]) => {
+export const FnWrap = (
+  methodToWrap: AnyFn,
+  methodType: GameMethodNames,
+  plugins: Plugin[]
+) => {
   return [...DEFAULT_PLUGINS, ...plugins]
     .filter((plugin) => plugin.fnWrap !== undefined)
-    .reduce((fn: AnyFn, { fnWrap }: Plugin) => fnWrap(fn), functionToWrap);
+    .reduce(
+      (method: AnyFn, { fnWrap }: Plugin) => fnWrap(method, methodType),
+      methodToWrap
+    );
 };
 
 /**

--- a/src/plugins/plugin-events.ts
+++ b/src/plugins/plugin-events.ts
@@ -23,11 +23,12 @@ const EventsPlugin: Plugin<EventsAPI & PrivateEventsAPI> = {
   // or hook is called. This allows events called after turn or phase
   // endings to dispatch the current turn and phase correctly.
   fnWrap:
-    (fn) =>
+    (method, methodType) =>
     (G, ctx, ...args) => {
       const api = ctx.events as PrivateEventsAPI;
-      if (api) api._obj.updateTurnContext(ctx);
-      G = fn(G, ctx, ...args);
+      if (api) api._obj.updateTurnContext(ctx, methodType);
+      G = method(G, ctx, ...args);
+      if (api) api._obj.unsetCurrentMethod();
       return G;
     },
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ import type { ActionErrorType, UpdateErrorType } from './core/errors';
 import type { Flow } from './core/flow';
 import type { CreateGameReducer } from './core/reducer';
 import type { INVALID_MOVE } from './core/constants';
+import type { GameMethodNames } from './core/game-methods';
 import type { Auth } from './server/auth';
 import type * as StorageAPI from './server/db/base';
 import type { EventsAPI } from './plugins/plugin-events';
@@ -163,7 +164,10 @@ export interface Plugin<
     api: API;
     data: Data;
   }) => State<G, Ctx>;
-  fnWrap?: (fn: AnyFn) => (G: G, ctx: Ctx, ...args: any[]) => any;
+  fnWrap?: (
+    moveOrHook: (G: G, ctx: Ctx, ...args: any[]) => any,
+    methodType: GameMethodNames
+  ) => (G: G, ctx: Ctx, ...args: any[]) => any;
   playerView?: (context: {
     G: G;
     ctx: Ctx;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ import type { ActionErrorType, UpdateErrorType } from './core/errors';
 import type { Flow } from './core/flow';
 import type { CreateGameReducer } from './core/reducer';
 import type { INVALID_MOVE } from './core/constants';
-import type { GameMethodNames } from './core/game-methods';
+import type { GameMethod } from './core/game-methods';
 import type { Auth } from './server/auth';
 import type * as StorageAPI from './server/db/base';
 import type { EventsAPI } from './plugins/plugin-events';
@@ -166,7 +166,7 @@ export interface Plugin<
   }) => State<G, Ctx>;
   fnWrap?: (
     moveOrHook: (G: G, ctx: Ctx, ...args: any[]) => any,
-    methodType: GameMethodNames
+    methodType: GameMethod
   ) => (G: G, ctx: Ctx, ...args: any[]) => any;
   playerView?: (context: {
     G: G;


### PR DESCRIPTION
Here’s an attempt to close #979. Feedback very much wanted and if you want to pick this up and iterate on it, you’re welcome to as I likely won’t have much time in the next couple of weeks.

Also closes #981.

#### Approach

When wrapping game hooks (`onBegin`, `onMove`, `onEnd`), provide a unique string to the plugin interface so that it knows which hook is being wrapped. (These unique strings are from a kind of custom enum accessed like `GameMethod.Phase.ON_BEGIN` or `GameMethod.MOVE`.)

A plugin’s `fnWrap` then receives this string in addition to the function to wrap, so it can change behaviour appropriately.

```js
const plugin = {
  name: 'discerning-wrapper',
  fnWrap: (fn, fnType) => (...args) => {
    if (fnType === GameMethod.Turn.ON_MOVE) {
      console.log('Looks like this is an onMove hook.);
    }
    return fn(...args);
  },
};
```

In the events plugin we store this string, like we do with the turn/phase details and use it when processing events. This is actually pretty nice because we can give more informative errors. The main drawback is that this depends on `fnWrap` which is *not* applied to triggers (like `endIf`) and other game methods (like `turn.order.first`), so the best we can do is error if the hook type is `undefined` (which is probably OK, because *only* hooks should be used for events) without knowing exactly what method triggered the error.

#### Notes

I don’t particularly like that this exposes something new to the public plugin API, but I couldn’t really see how to do this otherwise as that is how the events plugin is built. One alternative could be to only expose this new data via some separate plugin field, like `_internal_fnWrap`, which would still be public but marked as private. Not sure exactly what the best approach is, but happy to see alternative approaches.

#### To-do

- [x] If we go with this model, we should expose the `GameMethod` object properly, so that plugin authors can import it. Probably from the `boardgame.io/core` package?
- [x] Are there any other scenarios where it would be good to error with some useful diagnostic information?

---

**CC:** @cristiands7 — Happy to hear your thoughts too!