### PR TITLE
chore: Add VS Code dev container support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/typescript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version: 16, 14, 12
+ARG VARIANT="16-buster"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node packages
+# RUN su node -c "npm install -g <your-package-list -here>"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick a Node version: 12, 14, 16
+		"args": { 
+			"VARIANT": "16"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode",
+		"dsznajder.es7-react-js-snippets",
+		"eamodio.gitlens",
+		"github.vscode-pull-request-github"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [3000, 8000],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm ci && npm run prestart",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
 	"forwardPorts": [3000, 8000],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "npm ci && npm run prestart",
+	"postCreateCommand": "npm ci",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,33 +1,33 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/typescript-node
 {
-	"name": "Node.js & TypeScript",
-	"build": {
-		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 12, 14, 16
-		"args": { 
-			"VARIANT": "16"
-		}
-	},
+    "name": "Node.js & TypeScript",
+    "build": {
+        "dockerfile": "Dockerfile",
+        // Update 'VARIANT' to pick a Node version: 12, 14, 16
+        "args": { 
+            "VARIANT": "16"
+        }
+    },
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
+    // Set *default* container specific settings.json values on container create.
+    "settings": {},
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"dbaeumer.vscode-eslint",
-		"esbenp.prettier-vscode",
-		"dsznajder.es7-react-js-snippets",
-		"eamodio.gitlens",
-		"github.vscode-pull-request-github"
-	],
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "dsznajder.es7-react-js-snippets",
+        "eamodio.gitlens",
+        "github.vscode-pull-request-github"
+    ],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [3000, 8000],
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [3000, 8000],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "npm ci",
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "npm ci",
 
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "node"
+    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,33 +1,33 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/typescript-node
 {
-    "name": "Node.js & TypeScript",
-    "build": {
-        "dockerfile": "Dockerfile",
-        // Update 'VARIANT' to pick a Node version: 12, 14, 16
-        "args": { 
-            "VARIANT": "16"
-        }
-    },
+  "name": "Node.js & TypeScript",
+  "build": {
+    "dockerfile": "Dockerfile",
+    // Update 'VARIANT' to pick a Node version: 12, 14, 16
+    "args": {
+      "VARIANT": "16"
+    }
+  },
 
-    // Set *default* container specific settings.json values on container create.
-    "settings": {},
+  // Set *default* container specific settings.json values on container create.
+  "settings": {},
 
-    // Add the IDs of extensions you want installed when the container is created.
-    "extensions": [
-        "dbaeumer.vscode-eslint",
-        "esbenp.prettier-vscode",
-        "dsznajder.es7-react-js-snippets",
-        "eamodio.gitlens",
-        "github.vscode-pull-request-github"
-    ],
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "dsznajder.es7-react-js-snippets",
+    "eamodio.gitlens",
+    "github.vscode-pull-request-github"
+  ],
 
-    // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    "forwardPorts": [3000, 8000],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [3000, 8000],
 
-    // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "npm ci",
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "npm ci",
 
-    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-    "remoteUser": "node"
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "node"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,3 +48,33 @@ Use the following command to preview them:
 ```
 $ npm run docs
 ```
+
+## VS Code remote dev container support
+
+For minimal effort, the repository is configured to run in a remote dev container from VS Code.
+
+- No need to install Node.js or any other project-specific tooling and dependencies
+- No risk of your local machine environment getting in the way
+- Consistent development environment no matter what OS is used
+- Useful extensions preinstalled in the container, independent of your local VS Code settings
+
+### Prerequisites
+
+- [VS Code](https://code.visualstudio.com/) + [Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) extension
+- [git](https://git-scm.com/)
+- [Docker](https://www.docker.com/)
+
+### Getting started
+
+- Launch VS Code
+- Click the Remote Development icon in the bottom left corner of the UI, then "Clone repository in Container Volume..."
+- Paste `https://github.com/boardgameio/boardgame.io` or use your own fork, any branch, or a pull request
+- The container will start up and install all required dependencies automatically
+- Terminal output will cease when everything is set up and ready to go
+
+### Running the examples from the VS Code Explorer
+
+- Open "NPM Scripts" panel in the sidebar
+- Click on `package.json > start`
+
+If the NPM scripts panel is not visible in the Explorer sidebar, open the Explorer settings (3 dots) and check "NPM Scripts".

--- a/README.md
+++ b/README.md
@@ -66,6 +66,27 @@ npm start
 
 The examples can be found in the [examples](examples/) folder.
 
+#### Running inside a dev container using VS Code
+
+It is also possible to run the examples or contribute to the repository using a preconfigured dev container. This removes the need to install dependencies like Node.js on your local machine, and provides a consistent development environment no matter what OS you are on.
+
+Prerequisites on the local machine:
+
+- [VS Code](https://code.visualstudio.com/) + [Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) extension
+- [git](https://git-scm.com/)
+- [Docker](https://www.docker.com/)
+
+To run the examples or start developing:
+
+- Open VS Code
+- Click the Remote Development icon in the bottom left corner of the UI -> "Clone repository in Container Volume..."
+- Paste `https://github.com/boardgameio/boardgame.io` or use your own fork (or any branch or pull request)
+- The container will start up and install all required dependencies automatically
+- Wait for terminal output to finish
+- Open NPM Scripts panel in the sidebar and run `package.json > start`
+
+If your VS Code Explorer sidebar has no NPM scripts panel right-click the Explorer header and check "NPM Scripts", or just run `npm run start` yourself from a terminal.
+
 ## Changelog
 
 See [changelog](docs/documentation/CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -66,26 +66,9 @@ npm start
 
 The examples can be found in the [examples](examples/) folder.
 
-#### Running inside a dev container using VS Code
+#### Using VS Code?
 
-It is also possible to run the examples or contribute to the repository using a preconfigured dev container. This removes the need to install dependencies like Node.js on your local machine, and provides a consistent development environment no matter what OS you are on.
-
-Prerequisites on the local machine:
-
-- [VS Code](https://code.visualstudio.com/) + [Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) extension
-- [git](https://git-scm.com/)
-- [Docker](https://www.docker.com/)
-
-To run the examples or start developing:
-
-- Open VS Code
-- Click the Remote Development icon in the bottom left corner of the UI -> "Clone repository in Container Volume..."
-- Paste `https://github.com/boardgameio/boardgame.io` or use your own fork (or any branch or pull request)
-- The container will start up and install all required dependencies automatically
-- Wait for terminal output to finish
-- Open NPM Scripts panel in the sidebar and run `package.json > start`
-
-If your VS Code Explorer sidebar has no NPM scripts panel right-click the Explorer header and check "NPM Scripts", or just run `npm run start` yourself from a terminal.
+This repository is ready to run in a dev container in VS Code. See [the contributing guidelines for details](CONTRIBUTING.md).
 
 ## Changelog
 


### PR DESCRIPTION
No changes to source files, just configuration files for dev containers. This should make it possible for anyone to just fire up the repository in a container and run it. `devcontainer.json` currently contains a minimum of useful extensions for linting (eslint, prettier), contributing (gitlens, github PR) and developing (React snippets). 

Any suggestions for other default settings or extensions that would make development more consistent/uniform/easy?

#### Checklist

- [x] Use a separate branch in your local repo (not `main`).
- [x] Test coverage is 100%.