### PR TITLE
fix(lobby): Clean up & update refresh polling interval properly

### DIFF
--- a/src/lobby/react.tsx
+++ b/src/lobby/react.tsx
@@ -115,11 +115,11 @@ class Lobby extends React.Component<LobbyProps, LobbyState> {
   };
 
   private connection?: ReturnType<typeof LobbyConnection>;
+  private _currentInterval?: NodeJS.Timeout;
 
   constructor(props: LobbyProps) {
     super(props);
     this._createConnection(this.props);
-    setInterval(this._updateConnection, this.props.refreshInterval);
   }
 
   componentDidMount() {
@@ -132,6 +132,7 @@ class Lobby extends React.Component<LobbyProps, LobbyState> {
       playerName: cookie.playerName || 'Visitor',
       credentialStore: cookie.credentialStore || {},
     });
+    this._startRefreshInterval();
   }
 
   componentDidUpdate(prevProps: LobbyProps, prevState: LobbyState) {
@@ -151,6 +152,25 @@ class Lobby extends React.Component<LobbyProps, LobbyState> {
       };
       Cookies.save('lobbyState', cookie, { path: '/' });
     }
+    if (prevProps.refreshInterval !== this.props.refreshInterval) {
+      this._startRefreshInterval();
+    }
+  }
+
+  componentWillUnmount() {
+    this._clearRefreshInterval();
+  }
+
+  _startRefreshInterval() {
+    this._clearRefreshInterval();
+    this._currentInterval = setInterval(
+      this._updateConnection,
+      this.props.refreshInterval
+    );
+  }
+
+  _clearRefreshInterval() {
+    clearInterval(this._currentInterval);
   }
 
   _createConnection = (props: LobbyProps) => {


### PR DESCRIPTION
Previously, the lobby component started polling on an interval when created, but that interval was never cleared, resulting in the polling continuing even after the component unmounted.

Similarly, the lobby component receives a `refreshInterval` prop, but we weren’t ever updating the polling interval if that prop changed. This commit also updates the polling interval correctly.

#### Checklist

- [x] Use a separate branch in your local repo (not `main`).
- [ ] Test coverage is 100% (or you have a story for why it's ok).
