### PR TITLE
perf(ai): Run AI iterations using `setImmediate`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22964,6 +22964,11 @@
         }
       }
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "react-cookies": "^0.1.0",
     "redux": "^4.1.0",
     "rfc6902": "^4.0.2",
+    "setimmediate": "^1.0.5",
     "socket.io": "^4.1.3",
     "socket.io-client": "^4.1.3",
     "svelte": "^3.41.0",

--- a/src/ai/mcts-bot.ts
+++ b/src/ai/mcts-bot.ts
@@ -5,6 +5,7 @@
  * license that can be found in the LICENSE file or at
  * https://opensource.org/licenses/MIT.
  */
+import 'setimmediate';
 import { CreateGameReducer } from '../core/reducer';
 import { Bot } from './bot';
 import type { BotAction } from './bot';
@@ -313,7 +314,7 @@ export class MCTSBot extends Bot {
         const asyncIteration = () => {
           if (this.iterationCounter < numIterations) {
             iteration();
-            setTimeout(asyncIteration, 0);
+            setImmediate(asyncIteration);
           } else {
             resolve(getResult());
           }


### PR DESCRIPTION
Use `setImmediate` to run each async iteration of the MCTS bot. In most scenarios this will use a polyfill as `setImmediate` is not widely supported or on a web standards track. See <https://github.com/YuzuJS/setImmediate> for browser support details. This polyfill is pretty old and covers some use cases we don’t need — like Node < 0.9 (!!) — so maybe it would be preferable to roll our own smaller, simpler `postMessage`-based alternative? I tried this library as a proof of concept test, and it did seem to result in faster AI result times using the Tic-Tac-Toe example by maybe 30% (and actually more in later game stages with fewer game branches although at that point the perceived difference is not so significant).

#### Checklist

- [x] Use a separate branch in your local repo (not `main`).
- [x] Test coverage is 100% (or you have a story for why it's ok).
