### PR TITLE
LobbyClientError

### DIFF
--- a/src/lobby/client.test.ts
+++ b/src/lobby/client.test.ts
@@ -90,7 +90,9 @@ describe('LobbyClient', () => {
       (global as any).fetch = jest.fn(async () => ({
         ok: false,
         status: 404,
-        json: async () => ({ moreInformation: 'some helpful details' }),
+        clone: () => ({
+          json: async () => ({ moreInformation: 'some helpful details' }),
+        }),
       }));
 
       await expect(client.listGames()).rejects.toThrow(

--- a/src/lobby/client.ts
+++ b/src/lobby/client.ts
@@ -52,7 +52,7 @@ export class LobbyClient {
       let details: any;
 
       try {
-        details = await response.json();
+        details = await response.clone().json();
       } catch {
         try {
           details = await response.text();


### PR DESCRIPTION
Added the clone method to the first access of the response so when access again it dose not fail.
A fix for issue #1004.

#### Checklist

- [ ] Use a separate branch in your local repo (not `main`).
- [ ] Test coverage is 100% (or you have a story for why it's ok).
