### PR TITLE
feat(core): Expose `ctx.playerID` in `onMove` hook

### DIFF
--- a/src/core/flow.test.ts
+++ b/src/core/flow.test.ts
@@ -239,6 +239,19 @@ describe('turn', () => {
       state = flow.processMove(state, makeMove('').payload);
       expect(state.G).toEqual({ B: true });
     });
+
+    test('ctx with playerID', () => {
+      const playerID = 'playerID';
+      const flow = Flow({
+        turn: { onMove: (G, ctx) => ({ playerID: ctx.playerID }) },
+      });
+      let state = { G: {}, ctx: flow.ctx(2) } as State;
+      state = flow.processMove(
+        state,
+        makeMove('', undefined, 'playerID').payload
+      );
+      expect(state.G.playerID).toEqual(playerID);
+    });
   });
 
   describe('minMoves', () => {

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -727,7 +727,10 @@ export function Flow({
     }
 
     const phaseConfig = GetPhase(ctx);
-    const G = phaseConfig.turn.wrapped.onMove(state);
+    const G = phaseConfig.turn.wrapped.onMove({
+      ...state,
+      ctx: { ...ctx, playerID },
+    });
     state = { ...state, G };
 
     const events = [{ fn: OnMove }];


### PR DESCRIPTION
This PR closes #1018 by adding `playerID` to the `ctx` used in the `onMove` hook.

When setting up my local environment, some tests failed on main - it looks like it is related to TypeScript, `api.ts` and possibly koa somehow 🤔 Attaching example output from a failed test

```
 FAIL  src/server/index.test.ts
  ● Test suite failed to run

    src/server/api.ts:151:28 - error TS2339: Property 'toLowerCase' does not exist on type 'string | string[]'.
      Property 'toLowerCase' does not exist on type 'string[]'.
```

In order to create this PR, I pushed the branch with `--no-verify`, hence the WIP prefix 😬  
 
#### Checklist

- [x ] Use a separate branch in your local repo (not `main`).
- [ x] Test coverage is 100% (or you have a story for why it's ok).
