### PR TITLE
fix: include `chatMessages` property in React client types

### DIFF
--- a/src/client/react.tsx
+++ b/src/client/react.tsx
@@ -31,6 +31,7 @@ type ExposedClientProps<G extends any = any> = Pick<
   | 'matchID'
   | 'matchData'
   | 'sendChatMessage'
+  | 'chatMessages'
 >;
 
 export type BoardProps<G extends any = any> = ClientState<G> &


### PR DESCRIPTION
Fixes #1021 

#### Checklist

- [ ] Use a separate branch in your local repo (not `main`).
- [ ] Test coverage is 100% (or you have a story for why it's ok).
