### PR TITLE
fix: Update gameover metadata for ext storage opts

### DIFF
--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -286,7 +286,7 @@ export class Master {
     const { deltalog, ...stateWithoutDeltalog } = state;
 
     let newMetadata: Server.MatchData | undefined;
-    if (metadata && !('gameover' in metadata)) {
+    if (metadata && metadata.gameover === undefined) {
       newMetadata = {
         ...metadata,
         updatedAt: Date.now(),


### PR DESCRIPTION
## Description
Older method assumes that the 'gameover' key/value doesn't exist when the game isn't over, but doesn't count the fact that the key could exist with an `undefined` value.

#### Checklist

- [x] Use a separate branch in your local repo (not `main`).
- [x] Test coverage is 100% (or you have a story for why it's ok).
