### PR TITLE
Lobby component: Stopped polling for list of games when list of games should not be visible

### DIFF
--- a/src/lobby/react.tsx
+++ b/src/lobby/react.tsx
@@ -127,12 +127,14 @@ class Lobby extends React.Component<LobbyProps, LobbyState> {
     if (cookie.phase && cookie.phase === LobbyPhases.PLAY) {
       cookie.phase = LobbyPhases.LIST;
     }
+    if (cookie.phase && cookie.phase !== LobbyPhases.ENTER) {
+      this._startRefreshInterval();
+    }
     this.setState({
       phase: cookie.phase || LobbyPhases.ENTER,
       playerName: cookie.playerName || 'Visitor',
       credentialStore: cookie.credentialStore || {},
     });
-    this._startRefreshInterval();
   }
 
   componentDidUpdate(prevProps: LobbyProps, prevState: LobbyState) {
@@ -198,10 +200,12 @@ class Lobby extends React.Component<LobbyProps, LobbyState> {
   };
 
   _enterLobby = (playerName: string) => {
+    this._startRefreshInterval();
     this.setState({ playerName, phase: LobbyPhases.LIST });
   };
 
   _exitLobby = async () => {
+    this._clearRefreshInterval();
     await this.connection.disconnect();
     this.setState({ phase: LobbyPhases.ENTER, errorMsg: '' });
   };
@@ -282,10 +286,12 @@ class Lobby extends React.Component<LobbyProps, LobbyState> {
       credentials: this.connection.playerCredentials,
     };
 
+    this._clearRefreshInterval();
     this.setState({ phase: LobbyPhases.PLAY, runningMatch: match });
   };
 
   _exitMatch = () => {
+    this._startRefreshInterval();
     this.setState({ phase: LobbyPhases.LIST, runningMatch: null });
   };
 


### PR DESCRIPTION
#### Checklist

- [x] Use a separate branch in your local repo (not `main`).
- [x] Test coverage is 100% (or you have a story for why it's ok).

## Description

Fix for https://github.com/boardgameio/boardgame.io/issues/1043: pause polling for list of games when not showing list of games

## Testing

(note: in end-to-end description. "Queries" refers to the polling queries against `/games` and `/games/<gamename>` endpoints)

- [x] Unit tests added
- [x] End-to-end test:
  - build and link against a game I am working on
  -  Loaded localhost:8000, see "Choose a player name:", noted queries are not repeating
  - Chose name and hit Enter, noted queries started
  - Created game, `Join` game and hit `Play`, noted queries stopped
  - `Exit match`, noted queries resumed
  - `Play` game again, noted queries stopped
  - `Exit lobby`, noted queries still stopped
  - entered name and re-entered lobby, noted queries resume
  - refresh browser, noted we go directly to game list and queries resume
  - `Join` game and `Play` game, noted queries stopped
  - refresh browser, noted we go directly to game list and queries resume