### PR TITLE
fix(lobby): block creation of matches with invalid player counts

### DIFF
--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -125,6 +125,8 @@ describe('.configureRouter', () => {
             numPlayers == 2 && setupData.tokens !== 2
               ? 'Two player games must use two tokens'
               : undefined,
+          minPlayers: 2,
+          maxPlayers: 2,
         },
       ];
     });
@@ -190,6 +192,18 @@ describe('.configureRouter', () => {
               }),
             })
           );
+        });
+      });
+
+      describe('with invalid numPlayers', () => {
+        beforeEach(async () => {
+          response = await request(app.callback())
+            .post('/games/validate/create')
+            .send({ numPlayers: 3 });
+        });
+
+        test('fails', () => {
+          expect(response.status).toEqual(400);
         });
       });
 

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -196,13 +196,27 @@ describe('.configureRouter', () => {
       });
 
       describe('with invalid numPlayers', () => {
-        beforeEach(async () => {
+        test('not enough players fails', async () => {
+          response = await request(app.callback())
+            .post('/games/validate/create')
+            .send({ numPlayers: 1 });
+
+          expect(response.status).toEqual(400);
+        });
+
+        test('too many players fails', async () => {
           response = await request(app.callback())
             .post('/games/validate/create')
             .send({ numPlayers: 3 });
+
+          expect(response.status).toEqual(400);
         });
 
-        test('fails', () => {
+        test('invalid type fails', async () => {
+          response = await request(app.callback())
+            .post('/games/validate/create')
+            .send({ numPlayers: 'hello' });
+
           expect(response.status).toEqual(400);
         });
       });

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -122,9 +122,10 @@ export const configureRouter = ({
     if (!game) ctx.throw(404, 'Game ' + gameName + ' not found');
 
     if (
-      numPlayers != null &&
-      ((game.minPlayers != null && numPlayers < game.minPlayers) ||
-        (game.maxPlayers != null && numPlayers > game.maxPlayers))
+      ctx.request.body.numPlayers !== undefined &&
+      (Number.isNaN(numPlayers) ||
+        (game.minPlayers && numPlayers < game.minPlayers) ||
+        (game.maxPlayers && numPlayers > game.maxPlayers))
     ) {
       ctx.throw(400, 'Invalid numPlayers');
     }

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -121,6 +121,14 @@ export const configureRouter = ({
     const game = games.find((g) => g.name === gameName);
     if (!game) ctx.throw(404, 'Game ' + gameName + ' not found');
 
+    if (
+      numPlayers != null &&
+      ((game.minPlayers != null && numPlayers < game.minPlayers) ||
+        (game.maxPlayers != null && numPlayers > game.maxPlayers))
+    ) {
+      ctx.throw(400, 'Invalid numPlayers');
+    }
+
     const matchID = await CreateMatch({
       ctx,
       db,


### PR DESCRIPTION
#### Checklist

- [x] Use a separate branch in your local repo (not `main`).
- [x] Test coverage is 100% (or you have a story for why it's ok).

## Description

Fixes https://github.com/boardgameio/boardgame.io/issues/1055. Prevents a user from creating a match with an invalid number of players (only applicable if `minPlayers` and/or `maxPlayers` are defined).

## Testing

I tried to imitate the style and verbosity of the existing tests in `api.test.ts` with the tests I introduced, ~but technically some edge cases are not addressed by tests (eg. player count too low). If verbosity is preferred I'd be happy to add a few more test cases.~ but feel free to let me know if there's anywhere I can make improvements.