### PR TITLE
docs: Export TicTacToeBoard in Board.js

### DIFF
--- a/docs/documentation/tutorial.md
+++ b/docs/documentation/tutorial.md
@@ -512,7 +512,7 @@ Let’s create a new file at `src/Board.js`:
 ```js
 import React from 'react';
 
-function TicTacToeBoard({ ctx, G, moves }) {
+export function TicTacToeBoard({ ctx, G, moves }) {
   const onClick = (id) => moves.clickCell(id);
 
   let winner = '';


### PR DESCRIPTION
There is a missing `export` of `TicTacToeBoard` in `Board.js` in the React tutorial.