### PR TITLE
TypeScript: AiEnumerate return type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -298,6 +298,13 @@ export interface PhaseMap<
   [phaseName: string]: PhaseConfig<G, CtxWithPlugins>;
 }
 
+export type AiEnumerate = Array<
+  | { event: string; args?: any[] }
+  | { move: string; args?: any[] }
+  | ActionShape.MakeMove
+  | ActionShape.GameEvent
+>
+
 export interface Game<
   G extends any = any,
   CtxWithPlugins extends Ctx = Ctx,
@@ -336,12 +343,7 @@ export interface Game<
       G: G,
       ctx: Ctx,
       playerID: PlayerID
-    ) => Array<
-      | { event: string; args?: any[] }
-      | { move: string; args?: any[] }
-      | ActionShape.MakeMove
-      | ActionShape.GameEvent
-    >;
+    ) => AiEnumerate;
   };
   processMove?: (
     state: State<G, Ctx | CtxWithPlugins>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -303,7 +303,7 @@ export type AiEnumerate = Array<
   | { move: string; args?: any[] }
   | ActionShape.MakeMove
   | ActionShape.GameEvent
->
+>;
 
 export interface Game<
   G extends any = any,
@@ -339,11 +339,7 @@ export interface Game<
   playerView?: (G: G, ctx: CtxWithPlugins, playerID: PlayerID | null) => any;
   plugins?: Array<Plugin<any, any, G>>;
   ai?: {
-    enumerate: (
-      G: G,
-      ctx: Ctx,
-      playerID: PlayerID
-    ) => AiEnumerate;
+    enumerate: (G: G, ctx: Ctx, playerID: PlayerID) => AiEnumerate;
   };
   processMove?: (
     state: State<G, Ctx | CtxWithPlugins>,


### PR DESCRIPTION
I tried doing TicTacToe as much typed in TypeScript as possible. This `AiEnumerate` is the only type that I needed and that could be available from boardgame.io

----

Here is the code where I used the `AiEnumerate` type:
```TypeScript
type TicTacToeGameOver = {
  draw?: boolean;
  winner?: PlayerID;
}

type TicTacToeCell = PlayerID;

export type TicTacToeG = {
  cells: TicTacToeCell[];
};

export type TicTacToeMoves = MoveMap<TicTacToeG> & {
  clickCell: (G: TicTacToeG, ctx: Ctx, cellId: number) => void;
};

type TicTacToeGame = Game<TicTacToeG> & {
  moves: TicTacToeMoves;
  endIf: (G: TicTacToeG, ctx: Ctx) => TicTacToeGameOver | undefined;
};

export const TicTacToe: TicTacToeGame = {
...
  ai: {
    enumerate: (G, _ctx, _playerId) => {
      const movesEnumeration: AiEnumerate = [];
      const moves = TicTacToe.moves;
      for (let i = 0; i < G.cells.length; i++) {
        if (G.cells[i] === null) {
          movesEnumeration.push({move: moves.clickCell.name, args: [i]});
        }
      }
      return movesEnumeration;
    },
  },
};
```