### PR TITLE
InMemory store should delete match data from log and initial

### DIFF
--- a/src/server/db/inmemory.test.ts
+++ b/src/server/db/inmemory.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { InMemory } from './inmemory';
-import type { State, Server } from '../../types';
+import type { State, Server, LogEntry } from '../../types';
 
 describe('InMemory', () => {
   let db: InMemory;
@@ -139,5 +139,21 @@ describe('InMemory', () => {
     expect(db.fetch('matchID', { state: true })).toEqual({});
     // Shall not return error
     db.wipe('matchID');
+  });
+
+  test('create remove', () => {
+    // ensure we have all game attributes stored
+    db.createMatch('remove', {
+      metadata: {} as Server.MatchData,
+      initialState: {} as State,
+    });
+    db.setState('remove', {} as State, [{} as LogEntry]);
+
+    db.wipe('remove');
+
+    expect(db.fetch('remove', { state: true })).toEqual({});
+    expect(db.fetch('remove', { initialState: true })).toEqual({});
+    expect(db.fetch('remove', { log: true })).toEqual({ log: [] });
+    expect(db.fetch('remove', { metadata: true })).toEqual({});
   });
 });

--- a/src/server/db/inmemory.ts
+++ b/src/server/db/inmemory.ts
@@ -92,6 +92,8 @@ export class InMemory extends StorageAPI.Sync {
   wipe(matchID: string) {
     this.state.delete(matchID);
     this.metadata.delete(matchID);
+    this.log.delete(matchID);
+    this.initial.delete(matchID);
   }
 
   /**


### PR DESCRIPTION
InMemory `wipe` is not removing match data from `this.log` and `this.initial`.


#### Checklist

- [x] Use a separate branch in your local repo (not `main`).
- [x] Test coverage is 100% (or you have a story for why it's ok).
