### PR TITLE
fix: fix example type errors

### DIFF
--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -392,7 +392,9 @@ export const configureRouter = ({
     ctx.body = body;
   });
 
-  const updatePlayerMetadata = async (ctx: Koa.Context) => {
+  const updatePlayerMetadata = async (
+    ctx: Koa.Context & { params?: { id?: string } }
+  ) => {
     const matchID = ctx.params.id;
     const playerID = ctx.request.body.playerID;
     const credentials = ctx.request.body.credentials;

--- a/src/server/transport/socketio.ts
+++ b/src/server/transport/socketio.ts
@@ -164,7 +164,6 @@ export class SocketIO {
       },
     });
 
-    app.context.io = io;
     io.attach(app, !!this.https, this.https);
 
     if (this.socketAdapter) {


### PR DESCRIPTION
#### Checklist

Fixes issue #1204 

*src/server/transport/socketio.ts*
The assignment of `io` to `app.context` is not correct and since it is not correct and not used. I removed it. 

*src/server/api.ts*
Types params with an id property to be optional. `updatePlayerMetadata` is already checking that exists and if not it throws so this type makes sense


