### PR TITLE
Port server + client fixes from the lean-poker fork

### DIFF
--- a/docs/documentation/api/Client.md
+++ b/docs/documentation/api/Client.md
@@ -192,6 +192,18 @@ The following methods are available on a client instance:
 - `redo()`: Function that redoes the previously undone move.
 
 
+- `previewState(state)`: Visual override. Replaces the state returned by
+  `getState()` (and passed to subscribers) without changing the internal
+  store. Useful for time-travel debugging or AI preview. Call with no
+  arguments (or `null`) to clear the override.
+
+
+- `loadState(state)`: Replaces the entire internal game state with a saved
+  state object, allowing play to continue from that point. Use this to
+  implement save / load or to reconstruct a game from an external source.
+  The state must contain `G`, `ctx` and `_stateID` keys.
+
+
 - `sendChatMessage(message)`: Function that sends a chat message to other
   players. The `message` argument can be a string or you can send objects
   to include more metadata.
@@ -327,6 +339,18 @@ following as `props`:
 
 
 - `redo`: Function that redoes the previously undone move.
+
+
+- `previewState(state)`: Visual override. Replaces the state returned by
+  `getState()` (and passed to subscribers) without changing the internal
+  store. Useful for time-travel debugging or AI preview. Call with no
+  arguments (or `null`) to clear the override.
+
+
+- `loadState(state)`: Replaces the entire internal game state with a saved
+  state object, allowing play to continue from that point. Use this to
+  implement save / load or to reconstruct a game from an external source.
+  The state must contain `G`, `ctx` and `_stateID` keys.
 
 
 - `sendChatMessage(message)`: Function that sends a chat message to other

--- a/docs/documentation/api/Server.md
+++ b/docs/documentation/api/Server.md
@@ -45,6 +45,12 @@ A config object with the following options:
 8. `apiOrigins` (_array_): a list of allowed origins for requests to the Lobby API. Defaults
    to the value provided as the `origins` option (which also applies to the socket transport).
 
+9. `apiBodyLimit` (_string_ | _number_): maximum size for request bodies parsed
+   by the Lobby API (e.g. `'5mb'` or `5 * 1024 * 1024` bytes). Defaults to `'5mb'`.
+   Increase this only if your game legitimately needs large `setupData`. Note that
+   large `setupData` is generally an anti-pattern — prefer passing lightweight
+   config and generating heavy data inside your game's `setup()` function.
+
 #### Returns
 
 An object that contains:

--- a/docs/documentation/stages.md
+++ b/docs/documentation/stages.md
@@ -29,6 +29,22 @@ const move = ({ G, ctx, playerID }) => {
 };
 ```
 
+### Inspecting active players
+
+When no stage mechanism is active, `ctx.activePlayers` is `null` and only
+`currentPlayer` may make moves. When one or more players are in a stage,
+`ctx.activePlayers` is an object mapping player IDs to stage names.
+
+Because it can be `null`, always guard property access:
+
+```js
+// Safe
+if (playerId in (ctx.activePlayers || {})) { ... }
+
+// Unsafe — throws when activePlayers is null
+if (playerId in ctx.activePlayers) { ... }
+```
+
 ### Defining Stages
 
 Stages are defined inside a `turn` section:

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -915,7 +915,7 @@ describe('subscribe', () => {
   });
 });
 
-test('override game state', () => {
+test('preview state', () => {
   const game: Game = {
     moves: {
       A: ({ G }) => {
@@ -926,10 +926,57 @@ test('override game state', () => {
   const client = Client({ game });
   client.moves.A();
   expect(client.getState().G).toEqual({ moved: true });
-  client.overrideGameState({ G: { override: true }, ctx: {} });
+  client.previewState({ G: { override: true }, ctx: {} });
   expect(client.getState().G).toEqual({ override: true });
-  client.overrideGameState(null);
+  client.previewState(null);
   expect(client.getState().G).toEqual({ moved: true });
+});
+
+test('loadState allows moves from the loaded phase', () => {
+  const game: Game = {
+    phases: {
+      start: {
+        start: true,
+        moves: {
+          startMove: ({ G }) => {
+            G.started = true;
+          },
+        },
+        next: 'play',
+      },
+      play: {
+        moves: {
+          playMove: ({ G }) => {
+            G.played = true;
+          },
+        },
+      },
+    },
+  };
+  const client = Client({ game });
+
+  // Advance to 'play' phase
+  client.moves.startMove();
+  client.events.endPhase();
+  expect(client.getState().ctx.phase).toBe('play');
+
+  // Capture state
+  const savedState = client.getState();
+
+  // Fresh client (starts in 'start' phase)
+  const freshClient = Client({ game });
+  expect(freshClient.getState().ctx.phase).toBe('start');
+
+  // Move should fail in 'start' phase
+  freshClient.moves.playMove();
+  expect(freshClient.getState().G.played).toBeUndefined();
+
+  // Load saved state
+  freshClient.loadState(savedState);
+
+  // Move should now work
+  freshClient.moves.playMove();
+  expect(freshClient.getState().G.played).toBe(true);
 });
 
 // TODO(#941): These tests should validate DOM mounting/unmounting.

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -136,7 +136,7 @@ export class _ClientImpl<
   G extends any = any,
   PluginAPIs extends Record<string, unknown> = Record<string, unknown>,
 > {
-  private gameStateOverride?: any;
+  private previewStateData?: any;
   private initialState: State<G>;
   readonly multiplayer: (opts: TransportOpts) => Transport;
   private reducer: Reducer;
@@ -186,7 +186,7 @@ export class _ClientImpl<
     this.multiplayer = multiplayer;
     this.debugOpt = debug;
     this.manager = GlobalClientManager;
-    this.gameStateOverride = null;
+    this.previewStateData = null;
     this.subscribers = {};
     this._running = false;
 
@@ -410,9 +410,26 @@ export class _ClientImpl<
     Object.values(this.subscribers).forEach((fn) => fn(this.getState()));
   }
 
-  overrideGameState(state: any) {
-    this.gameStateOverride = state;
+  previewState(state: any) {
+    this.previewStateData = state;
     this.notifySubscribers();
+  }
+
+  /**
+   * Replace the current game state with a saved state and continue playing.
+   * Unlike previewState, this updates the Redux store so that moves,
+   * events, and undo/redo work against the loaded state.
+   * Clears the log since we're starting from a new point in time.
+   */
+  loadState(state: State<G>) {
+    // Clear any active preview
+    this.previewStateData = null;
+
+    // Replace the store state via UPDATE action
+    this.store.dispatch(ActionCreators.update(state, []));
+
+    // Reset the log to prevent stale history
+    this.log = [];
   }
 
   start() {
@@ -449,8 +466,8 @@ export class _ClientImpl<
   getState(): ClientState<G> {
     let state = this.store.getState();
 
-    if (this.gameStateOverride !== null) {
-      state = this.gameStateOverride;
+    if (this.previewStateData !== null && this.previewStateData !== undefined) {
+      state = this.previewStateData;
     }
 
     // This is the state before a sync with the game master.

--- a/src/client/debug/ai/AI.svelte
+++ b/src/client/debug/ai/AI.svelte
@@ -97,7 +97,7 @@
   }
 
   function Exit() {
-    client.overrideGameState(null);
+    client.previewState(null);
     secondaryPane.set(null);
     debug = false;
   }

--- a/src/client/debug/log/Log.svelte
+++ b/src/client/debug/log/Log.svelte
@@ -38,7 +38,7 @@
     const { logIndex } = e.detail;
     const state = rewind(logIndex);
     const renderedLogEntries = log.filter(e => !e.automatic);
-    client.overrideGameState(state);
+    client.previewState(state);
 
     if (pinned == logIndex) {
       pinned = null;
@@ -56,19 +56,19 @@
     const { logIndex } = e.detail;
     if (pinned === null) {
       const state = rewind(logIndex);
-      client.overrideGameState(state);
+      client.previewState(state);
     }
   }
 
   function OnMouseLeave() {
     if (pinned === null) {
-      client.overrideGameState(null);
+      client.previewState(null);
     }
   }
 
   function Reset() {
     pinned = null;
-    client.overrideGameState(null);
+    client.previewState(null);
     secondaryPane.set(null);
   }
 

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -290,6 +290,33 @@ describe('.configureRouter', () => {
         });
       });
 
+      describe('with large setupData (>1MB, <5MB)', () => {
+        beforeEach(async () => {
+          // Create a ~1.5MB string to exceed the default 1MB jsonLimit
+          const largeData = 'x'.repeat(1.5 * 1024 * 1024);
+          response = await apiCall(app)
+            .post('/games/foo/create')
+            .send({ setupData: { payload: largeData } });
+        });
+
+        test('is successful', () => {
+          expect(response.status).toEqual(200);
+        });
+
+        test('preserves large setupData in metadata', () => {
+          expect(db.mocks.createMatch).toHaveBeenCalledWith(
+            'matchID',
+            expect.objectContaining({
+              metadata: expect.objectContaining({
+                setupData: expect.objectContaining({
+                  payload: expect.stringMatching(/^x+$/),
+                }),
+              }),
+            }),
+          );
+        });
+      });
+
       describe('with setupData validation', () => {
         test('creates game if validation passes', async () => {
           response = await apiCall(app)

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -81,13 +81,19 @@ export const configureRouter = ({
   auth,
   games,
   uuid = () => nanoid(11),
+  apiBodyLimit = '5mb',
 }: {
   router: Router<any, Server.AppCtx>;
   auth: Auth;
   games: Game[];
   uuid?: () => string;
   db: StorageAPI.Sync | StorageAPI.Async;
+  apiBodyLimit?: string | number;
 }) => {
+  const bodyParser = koaBody({
+    jsonLimit: apiBodyLimit,
+    formLimit: apiBodyLimit,
+  });
   /**
    * List available games.
    *
@@ -108,7 +114,7 @@ export const configureRouter = ({
    * @param {boolean} unlisted - Whether the match should be excluded from public listing.
    * @return - The ID of the created match.
    */
-  router.post('/games/:name/create', koaBody(), async (ctx) => {
+  router.post('/games/:name/create', bodyParser, async (ctx) => {
     // The name of the game (for example: tic-tac-toe).
     const gameName = ctx.params.name;
     // User-data to pass to the game setup function.
@@ -230,7 +236,7 @@ export const configureRouter = ({
    * @param {object} data - The default data of the player in the match.
    * @return - Player ID and credentials to use when interacting in the joined match.
    */
-  router.post('/games/:name/:id/join', koaBody(), async (ctx) => {
+  router.post('/games/:name/:id/join', bodyParser, async (ctx) => {
     let playerID = (ctx.request.body as any)?.playerID;
     const playerName = (ctx.request.body as any)?.playerName;
     const data = (ctx.request.body as any)?.data;
@@ -286,7 +292,7 @@ export const configureRouter = ({
    * @param {string} credentials - The credentials of the player who leaves.
    * @return - Nothing.
    */
-  router.post('/games/:name/:id/leave', koaBody(), async (ctx) => {
+  router.post('/games/:name/:id/leave', bodyParser, async (ctx) => {
     const matchID = ctx.params.id;
     const playerID = (ctx.request.body as any)?.playerID;
     const credentials = (ctx.request.body as any)?.credentials;
@@ -331,7 +337,7 @@ export const configureRouter = ({
    * @param {boolean} unlisted - Whether the match should be excluded from public listing.
    * @return - The ID of the new match.
    */
-  router.post('/games/:name/:id/playAgain', koaBody(), async (ctx) => {
+  router.post('/games/:name/:id/playAgain', bodyParser, async (ctx) => {
     const gameName = ctx.params.name;
     const matchID = ctx.params.id;
     const playerID = (ctx.request.body as any)?.playerID;
@@ -446,7 +452,7 @@ export const configureRouter = ({
    * @param {object} newName - The new name of the player in the match.
    * @return - Nothing.
    */
-  router.post('/games/:name/:id/rename', koaBody(), async (ctx) => {
+  router.post('/games/:name/:id/rename', bodyParser, async (ctx) => {
     console.warn(
       'This endpoint /rename is deprecated. Please use /update instead.',
     );
@@ -464,7 +470,7 @@ export const configureRouter = ({
    * @param {object} data - The new data of the player in the match.
    * @return - Nothing.
    */
-  router.post('/games/:name/:id/update', koaBody(), updatePlayerMetadata);
+  router.post('/games/:name/:id/update', bodyParser, updatePlayerMetadata);
 
   return router;
 };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -27,6 +27,8 @@ interface ServerConfig {
     apiPort: number;
     apiCallback?: () => void;
   };
+  // Future: apiBodyLimit could be added here to allow runtime overrides.
+  // Currently, it is set once at the factory level in ServerOpts.
 }
 
 interface HttpsOptions {
@@ -67,6 +69,14 @@ interface ServerOpts {
   authenticateCredentials?: ServerTypes.AuthenticateCredentials;
   generateCredentials?: ServerTypes.GenerateCredentials;
   https?: HttpsOptions;
+  /**
+   * Maximum size for request bodies parsed by the lobby API.
+   * Defaults to '5mb'. Increase only if you genuinely need large setupData.
+   *
+   * NOTE: Large setupData is an anti-pattern; prefer generating heavy data
+   * inside your game's setup() function rather than passing it via setupData.
+   */
+  apiBodyLimit?: string | number;
 }
 
 /**
@@ -92,6 +102,7 @@ export function Server({
   apiOrigins = origins,
   generateCredentials = uuid,
   authenticateCredentials,
+  apiBodyLimit = '5mb',
 }: ServerOpts) {
   const app: ServerTypes.App = new Koa();
 
@@ -129,7 +140,7 @@ export function Server({
 
     run: async (portOrConfig: number | ServerConfig, callback?: () => void) => {
       const serverRunConfig = createServerRunConfig(portOrConfig, callback);
-      configureRouter({ router, db, games, uuid, auth });
+      configureRouter({ router, db, games, uuid, auth, apiBodyLimit });
 
       // DB
       await db.connect();

--- a/src/server/transport/socketio-simultaneous.test.ts
+++ b/src/server/transport/socketio-simultaneous.test.ts
@@ -87,6 +87,35 @@ class InMemoryAsync extends Async {
   }
 }
 
+/**
+ * Variant of InMemoryAsync that returns deep copies on fetch.
+ * This makes read-modify-write races reproducible in tests.
+ */
+class CopyingInMemoryAsync extends InMemoryAsync {
+  async fetch<O extends StorageAPI.FetchOpts>(
+    matchID: string,
+    opts: O,
+  ): Promise<StorageAPI.FetchResult<O>> {
+    const result = (await super.fetch(matchID, opts)) as StorageAPI.FetchFields;
+    const copy = {} as StorageAPI.FetchFields;
+
+    if (opts.state && result.state !== undefined) {
+      copy.state = JSON.parse(JSON.stringify(result.state));
+    }
+    if (opts.metadata && result.metadata !== undefined) {
+      copy.metadata = JSON.parse(JSON.stringify(result.metadata));
+    }
+    if (opts.log && result.log !== undefined) {
+      copy.log = JSON.parse(JSON.stringify(result.log));
+    }
+    if (opts.initialState && result.initialState !== undefined) {
+      copy.initialState = JSON.parse(JSON.stringify(result.initialState));
+    }
+
+    return copy as StorageAPI.FetchResult<O>;
+  }
+}
+
 class SocketIOTestAdapter extends SocketIO {
   constructor({
     clientInfo = new Map(),
@@ -599,5 +628,95 @@ describe('inauthentic clients', () => {
       ([type]) => type === 'sync',
     );
     expect(syncEmits).toHaveLength(1);
+  });
+});
+
+describe('simultaneous sync race condition', () => {
+  const game: Game = {
+    name: 'test',
+    setup: () => ({
+      0: 'foo',
+      1: 'bar',
+    }),
+    playerView: ({ G, playerID }) => ({ [playerID]: G[playerID] }),
+  };
+
+  let app;
+  let db: CopyingInMemoryAsync;
+  let transport: SocketIOTestAdapter;
+  let clientInfo: Map<string, Record<string, any>>;
+  let roomInfo: Map<string, Set<string>>;
+  let io;
+  const matchID = 'matchID';
+
+  beforeEach(async () => {
+    clientInfo = new Map();
+    roomInfo = new Map();
+
+    db = new CopyingInMemoryAsync();
+    await db.connect();
+
+    app = { context: { db, auth: new Auth() }, callback: () => () => {} };
+    transport = new SocketIOTestAdapter({ clientInfo, roomInfo });
+    transport.init(app, [ProcessGameConfig(game)]);
+    io = app.context.io;
+
+    const metadata = createMetadata({ game, unlisted: false, numPlayers: 2 });
+    const initialState = InitializeGame({ game, numPlayers: 2 });
+    await db.createMatch(matchID, { initialState, metadata });
+  });
+
+  afterEach(async () => {
+    await db.wipe(matchID);
+  });
+
+  test('concurrent syncs preserve both players isConnected status', async () => {
+    const socket0 = io.sockets.get('0');
+    const socket1 = io.sockets.get('1');
+
+    // Force a deterministic race by using zero delays for onSync fetches
+    // and a long delay for the first onConnectionChange setMetadata.
+    // Without queue protection, the second sync's onConnectionChange
+    // fetch will resolve before the first sync's setMetadata completes,
+    // causing the second player to overwrite the first player's isConnected.
+    db.delays = [0, 0, 0, 0, 50, 0, 50, 0];
+
+    await Promise.all([
+      (async () => {
+        const args: Parameters<Master['onSync']> = [matchID, '0', undefined];
+        await socket0.receive('sync', ...args);
+      })(),
+      (async () => {
+        const args: Parameters<Master['onSync']> = [matchID, '1', undefined];
+        await socket1.receive('sync', ...args);
+      })(),
+    ]);
+
+    const { metadata } = await db.fetch(matchID, { metadata: true });
+    expect(metadata.players['0'].isConnected).toBe(true);
+    expect(metadata.players['1'].isConnected).toBe(true);
+  });
+
+  test('concurrent sync and disconnect preserve connection status', async () => {
+    const socket0 = io.sockets.get('0');
+    const socket1 = io.sockets.get('1');
+
+    // Player 0 syncs, then immediately disconnects while player 1 syncs.
+    db.delays = [0, 0, 0, 0, 50, 0, 50, 0, 50, 0];
+
+    await socket0.receive('sync', matchID, '0', undefined);
+
+    await Promise.all([
+      (async () => {
+        await socket0.receive('disconnect');
+      })(),
+      (async () => {
+        await socket1.receive('sync', matchID, '1', undefined);
+      })(),
+    ]);
+
+    const { metadata } = await db.fetch(matchID, { metadata: true });
+    expect(metadata.players['0'].isConnected).toBe(false);
+    expect(metadata.players['1'].isConnected).toBe(true);
   });
 });

--- a/src/server/transport/socketio.ts
+++ b/src/server/transport/socketio.ts
@@ -208,12 +208,20 @@ export class SocketIO {
             app.context.auth,
           );
 
-          const syncResponse = await master.onSync(...args);
-          if (syncResponse && syncResponse.error === 'unauthorized') {
-            return;
-          }
-          this.addClient(requestingClient, game);
-          await master.onConnectionChange(matchID, playerID, credentials, true);
+          const matchQueue = this.getMatchQueue(matchID);
+          await matchQueue.add(async () => {
+            const syncResponse = await master.onSync(...args);
+            if (syncResponse && syncResponse.error === 'unauthorized') {
+              return;
+            }
+            this.addClient(requestingClient, game);
+            await master.onConnectionChange(
+              matchID,
+              playerID,
+              credentials,
+              true,
+            );
+          });
         });
 
         socket.on('disconnect', async () => {
@@ -227,11 +235,9 @@ export class SocketIO {
               TransportAPI(matchID, socket, filterPlayerView, this.pubSub),
               app.context.auth,
             );
-            await master.onConnectionChange(
-              matchID,
-              playerID,
-              credentials,
-              false,
+            const matchQueue = this.getMatchQueue(matchID);
+            await matchQueue.add(() =>
+              master.onConnectionChange(matchID, playerID, credentials, false),
             );
           }
         });


### PR DESCRIPTION
Ports three functional changes that were developed and reviewed on the lean-poker fork but never landed upstream. Each is a separate commit; all fork-identity churn (the `@lean-poker` rename, fork CHANGELOG/breaking-changes docs, version bumps) has been stripped — these are clean, upstream-appropriate diffs.

### Changes
1. **`fix(server)`: configurable API body-parser limit (`apiBodyLimit`)** — replaces the per-route `koaBody()` parsers with one shared parser whose size limit is configurable (default `'5mb'`), fixing 413 errors on large `setupData`. _(lean-poker #29)_
2. **`feat(client)`: add `loadState`, rename `overrideGameState` → `previewState`** — `previewState` only previews; new `loadState()` makes a loaded state the actual playable state (dispatches update, clears log). _(lean-poker #30)_
3. **`fix(server)`: serialize `sync`/`disconnect` via the per-match queue** — routes both handlers through the existing per-match `PQueue` (as `update` already is) to fix a race in `Master.onConnectionChange` that left clients stuck "Connecting…". Fixes #1100. _(lean-poker #31)_

> [!WARNING]
> **Breaking change** (commit 2): `Client.overrideGameState()` is renamed to `Client.previewState()`. Kept in this PR per request since it was already reviewed on the fork, but happy to split it out if you'd prefer to version it separately.

### Verification
Clean checkout on the pnpm/Node 24 stack: `eslint` clean, `tsc --noEmit` clean, **42 suites / 811 tests pass**, `build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)