### PR TITLE
feat(packaging): add exports map and ESM server build

### DIFF
--- a/docs/documentation/deployment.md
+++ b/docs/documentation/deployment.md
@@ -83,10 +83,10 @@ production build in `/build`, which you can host just about anywhere.
 [Heroku](https://heroku.com) uses 2 different ways to determine the run command of a node application. It is possible to either:
 
 - Add a Procfile to the project root directory with the following line  
-  `web: node -r esm server.js`
+  `web: node server.js`
 
 - Update the start script in the package.json to  
-  `"start": "node -r esm server.js"`
+  `"start": "node server.js"`
 
 On Heroku, a regular heroku/nodejs buildpack is necessary to build your app which is usually selected by default for node applications.  
 

--- a/docs/documentation/multiplayer.md
+++ b/docs/documentation/multiplayer.md
@@ -232,20 +232,13 @@ server.run(8000);
 ?> See [the Server reference page](api/Server.md) for more detail on
    the various configuration options.
 
-Because `Game.js` is an ES module, we will use [esm](https://github.com/standard-things/esm)
-which enables us to use `import` statements in a Node environment:
-
-```
-npm install esm
-```
-
-We can then add a new script to our `package.json` to simplify
+Add a new script to our `package.json` to simplify
 running the server:
 
 ```json
 {
   "scripts": {
-    "serve": "node -r esm src/server.js"
+    "serve": "node src/server.js"
   }
 }
 ```

--- a/integration/node-smoke/cjs-test.cjs
+++ b/integration/node-smoke/cjs-test.cjs
@@ -1,0 +1,19 @@
+const assert = require('node:assert/strict');
+
+const { Client } = require('boardgame.io/client');
+const { INVALID_MOVE } = require('boardgame.io/core');
+const { Origins, Server } = require('boardgame.io/server');
+
+assert.equal(typeof Server, 'function');
+assert.equal(typeof Client, 'function');
+assert.ok(INVALID_MOVE);
+
+const server = Server({
+  games: [{ name: 'smoke', setup: () => ({}), moves: {} }],
+  origins: [Origins.LOCALHOST],
+});
+
+assert.ok(server.app);
+assert.ok(server.run);
+
+console.log('CJS smoke OK');

--- a/integration/node-smoke/esm-test.mjs
+++ b/integration/node-smoke/esm-test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+
+import { Client } from 'boardgame.io/client';
+import { INVALID_MOVE } from 'boardgame.io/core';
+import { Origins, Server } from 'boardgame.io/server';
+
+assert.equal(typeof Server, 'function');
+assert.equal(typeof Client, 'function');
+assert.ok(INVALID_MOVE);
+
+const server = Server({
+  games: [{ name: 'smoke', setup: () => ({}), moves: {} }],
+  origins: [Origins.LOCALHOST],
+});
+
+assert.ok(server.app);
+assert.ok(server.run);
+
+console.log('ESM smoke OK');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     }
   },
   "description": "library for turn-based games",
-  "repository": "https://github.com/boardgameio/boardgame.io",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/boardgameio/boardgame.io.git"
+  },
   "scripts": {
     "prestart": "run-p examples:install build",
     "start": "run-p dev:server dev:client",
@@ -54,6 +57,74 @@
   "unpkg": "dist/boardgameio.min.js",
   "module": "dist/boardgameio.es.js",
   "types": "dist/types/src/types.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/src/types.d.ts",
+      "import": "./dist/esm/main.js",
+      "require": "./dist/cjs/main.js"
+    },
+    "./client": {
+      "types": "./dist/types/packages/client.d.ts",
+      "import": "./dist/esm/client.js",
+      "require": "./dist/cjs/client.js"
+    },
+    "./core": {
+      "types": "./dist/types/packages/core.d.ts",
+      "import": "./dist/esm/core.js",
+      "require": "./dist/cjs/core.js"
+    },
+    "./debug": {
+      "types": "./dist/types/packages/debug.d.ts",
+      "import": "./dist/esm/debug.js",
+      "require": "./dist/cjs/debug.js"
+    },
+    "./react": {
+      "types": "./dist/types/packages/react.d.ts",
+      "import": "./dist/esm/react.js",
+      "require": "./dist/cjs/react.js"
+    },
+    "./react-native": {
+      "types": "./dist/types/packages/react-native.d.ts",
+      "import": "./dist/esm/react-native.js",
+      "require": "./dist/cjs/react-native.js"
+    },
+    "./ai": {
+      "types": "./dist/types/packages/ai.d.ts",
+      "import": "./dist/esm/ai.js",
+      "require": "./dist/cjs/ai.js"
+    },
+    "./plugins": {
+      "types": "./dist/types/packages/plugins.d.ts",
+      "import": "./dist/esm/plugins.js",
+      "require": "./dist/cjs/plugins.js"
+    },
+    "./master": {
+      "types": "./dist/types/packages/master.d.ts",
+      "import": "./dist/esm/master.js",
+      "require": "./dist/cjs/master.js"
+    },
+    "./multiplayer": {
+      "types": "./dist/types/packages/multiplayer.d.ts",
+      "import": "./dist/esm/multiplayer.js",
+      "require": "./dist/cjs/multiplayer.js"
+    },
+    "./internal": {
+      "types": "./dist/types/packages/internal.d.ts",
+      "import": "./dist/esm/internal.js",
+      "require": "./dist/cjs/internal.js"
+    },
+    "./testing": {
+      "types": "./dist/types/packages/testing.d.ts",
+      "import": "./dist/esm/testing.js",
+      "require": "./dist/cjs/testing.js"
+    },
+    "./server": {
+      "types": "./dist/types/packages/server.d.ts",
+      "import": "./dist/esm/server.js",
+      "require": "./dist/cjs/server.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "src",
     "!src/**/*.test.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -71,10 +71,13 @@ const minifiedPlugins = [
 export default [
   // Subpackages.
   {
-    input: subpackages.reduce((obj, name) => {
-      obj[name] = `packages/${name}.ts`;
-      return obj;
-    }, {}),
+    input: subpackages.reduce(
+      (obj, name) => {
+        obj[name] = `packages/${name}.ts`;
+        return obj;
+      },
+      { main: 'packages/main.js' },
+    ),
     external,
     plugins,
     output: [
@@ -92,7 +95,10 @@ export default [
   // Server.
   {
     input: 'packages/server.ts',
-    output: { dir: 'dist/cjs', format: 'cjs', interop: 'auto' },
+    output: [
+      { dir: 'dist/cjs', format: 'cjs', interop: 'auto' },
+      { dir: 'dist/esm', format: 'esm' },
+    ],
     external,
     plugins: serverPlugins,
   },

--- a/scripts/integration.js
+++ b/scripts/integration.js
@@ -1,8 +1,12 @@
 const shell = require('shelljs');
+const pkg = require('../package.json');
 
 shell.rm('-rf', 'dist');
 const packResult = shell.exec('npm pack --silent', { silent: true });
-const packed = packResult.stdout.trim().split('\n').pop();
+if (packResult.code !== 0) shell.exit(packResult.code);
+const packed =
+  packResult.stdout.trim().split('\n').pop() ||
+  `${pkg.name}-${pkg.version}.tgz`;
 
 shell.mv(packed, 'integration');
 shell.cd('integration');
@@ -18,10 +22,18 @@ shell.exec('pnpm install --config.minimum-release-age=0');
 // rather than a registry package name (npm install <name>.tgz is forgiving;
 // pnpm add is not).
 shell.exec(`pnpm add --config.minimum-release-age=0 ./${packed}`);
-shell.rm(packed);
 
 shell.set('-e');
 
 // Test
 shell.exec('pnpm test');
 shell.exec('pnpm run build');
+shell.exec('node node-smoke/esm-test.mjs');
+shell.exec('node node-smoke/cjs-test.cjs');
+shell.exec('pnpm dlx publint@latest', { cwd: 'node_modules/boardgame.io' });
+
+shell.set('+e');
+shell.exec(`pnpm dlx @arethetypeswrong/cli@0.18.2 ./${packed} --format table`);
+shell.set('-e');
+
+shell.rm(packed);

--- a/scripts/proxy-dirs.js
+++ b/scripts/proxy-dirs.js
@@ -35,3 +35,12 @@ subpackages.forEach((name) => {
 });
 
 makeSubpackage('server', { mainDir: 'cjs' });
+
+writeFileSync(
+  path.resolve(__dirname, '../dist/esm/package.json'),
+  JSON.stringify({ type: 'module', sideEffects: false }, null, 2) + '\n',
+);
+writeFileSync(
+  path.resolve(__dirname, '../dist/cjs/package.json'),
+  JSON.stringify({ type: 'commonjs', sideEffects: false }, null, 2) + '\n',
+);


### PR DESCRIPTION
## Motivation

boardgame.io's packaging predates Node's `exports`-map resolution. Subpath imports (`boardgame.io/client`, `boardgame.io/server`, …) only work through generated proxy directories, which bundlers and the CJS resolver understand but **Node's ESM resolver does not**. Any `"type": "module"` project — i.e. the default for Vite-era tooling — fails on `import { Server } from 'boardgame.io/server'`. This is one of the most-reported problems in the project's history: #902, #1136, #1152, and #844 (docs recommending the long-dead `esm` require hook) all share this root cause, and game developers have been resorting to dual-build workarounds in their own projects to get around it.

## Changes

- **`exports` map** covering the root, all 11 subpackages, `./server`, and `./package.json`, with `types`/`import`/`require` conditions per entry. The legacy `main`/`module`/`types` fields and the proxy directories are retained, so old TypeScript (`moduleResolution: node10`) and legacy bundlers keep working.
- **ESM build of the server entry** (`dist/esm/server.js`). All server dependencies ship ESM entry points (koa 3, @koa/router 15) or import cleanly from ESM, so no interop shims are needed.
- **`packages/main.js` joins the dual-format build**, giving the root export format-correct files; `dist/esm/package.json` / `dist/cjs/package.json` format markers are emitted at pack time — without them Node parses `dist/esm/*.js` by the root package's implicit CJS type and the map would lie.
- **Integration test hardening**: after installing the packed tarball, the flow now runs Node ESM-import and CJS-require smoke tests (which instantiate a real `Server`), plus `publint` as a strict gate and `arethetypeswrong` as an informational step.
- **Docs**: `node -r esm` and the `npm install esm` instructions are gone from multiplayer.md and deployment.md; servers run with plain `node`.

## Known caveats

- A single `.d.ts` serves both the `import` and `require` conditions, so TS under `nodenext` treats the import-side types as CJS-flavored. Benign for this API (named exports throughout); verified by type-checking a consumer project against the packed tarball under both `nodenext` and `bundler` resolution.
- `attw` crashes on this package's layout ("Cannot read properties of undefined") — **including on the already-published 0.50.2**, so it's a pre-existing tool incompatibility, kept non-fatal in the integration script.
- The `exports` map ends support for unsanctioned deep imports (`boardgame.io/dist/cjs/…`). Worth a changelog note in the next release.

## Testing

- `tsc --noEmit` ✓, `eslint` ✓, full jest suite 43 suites / 880 tests ✓
- `pnpm run test:integration`: vitest ✓, vite build ✓, `ESM smoke OK`, `CJS smoke OK`, publint zero errors ✓
- TS consumer smoke: `nodenext` ✓, `bundler` ✓ (types + values resolve for root, client, core, server entries)

Closes #844. Fixes #1136. Addresses #902 / #1152.