### PR TITLE
Return an error for turn events in phase onBegin

### DIFF
--- a/src/core/flow.test.ts
+++ b/src/core/flow.test.ts
@@ -1733,9 +1733,45 @@ describe('events in hooks', () => {
 
       client.events.setPhase('A');
       state = client.getState();
-      expect(state.ctx.turn).toBe(2);
-      expect(state.ctx.currentPlayer).toBe('1');
+      expect(state.ctx.turn).toBe(1);
+      expect(state.ctx.currentPlayer).toBe('0');
+      expect(state.ctx.phase).toBeNull();
+      expect(error).toHaveBeenCalled();
+      const errorMessage = (error as jest.Mock).mock.calls[0][0];
+      expect(errorMessage).toMatch(/events plugin declared action invalid/);
+      expect(errorMessage).toMatch(
+        /`endTurn` is disallowed in a phase’s `onBegin` hook/,
+      );
+      expect(errorMessage).toMatch(
+        /Use `turn.order.first` to choose the starting player/,
+      );
+    });
+
+    test('cannot pass from phase.onBegin', () => {
+      const client = Client({
+        game: {
+          phases: {
+            A: {
+              start: true,
+              onBegin: ({ events }) => events.pass(),
+            },
+          },
+        },
+      });
+
+      const state = client.getState();
+      expect(state.ctx.turn).toBe(1);
+      expect(state.ctx.currentPlayer).toBe('0');
       expect(state.ctx.phase).toBe('A');
+      expect(error).toHaveBeenCalled();
+      const errorMessage = (error as jest.Mock).mock.calls[0][0];
+      expect(errorMessage).toMatch(/events plugin declared action invalid/);
+      expect(errorMessage).toMatch(
+        /`endTurn` is disallowed in a phase’s `onBegin` hook/,
+      );
+      expect(errorMessage).toMatch(
+        /Use `turn.order.first` to choose the starting player/,
+      );
     });
 
     test('can end turn from turn.onBegin at start of phase', () => {

--- a/src/core/flow.test.ts
+++ b/src/core/flow.test.ts
@@ -1697,6 +1697,12 @@ describe('events in hooks', () => {
       events.endTurn();
     };
 
+    const conditionalPass = ({ G, events }) => {
+      if (!G.shouldEnd) return;
+      G.shouldEnd = false;
+      events.pass();
+    };
+
     test('can end turn from turn.onBegin', () => {
       const client = Client({
         game: { moves, turn: { onBegin: conditionalEndTurn } },
@@ -1740,7 +1746,7 @@ describe('events in hooks', () => {
       const errorMessage = (error as jest.Mock).mock.calls[0][0];
       expect(errorMessage).toMatch(/events plugin declared action invalid/);
       expect(errorMessage).toMatch(
-        /`endTurn` is disallowed in a phase’s `onBegin` hook/,
+        /`endTurn` & `pass` are disallowed in a phase’s `onBegin` hook/,
       );
       expect(errorMessage).toMatch(
         /Use `turn.order.first` to choose the starting player/,
@@ -1767,7 +1773,7 @@ describe('events in hooks', () => {
       const errorMessage = (error as jest.Mock).mock.calls[0][0];
       expect(errorMessage).toMatch(/events plugin declared action invalid/);
       expect(errorMessage).toMatch(
-        /`endTurn` is disallowed in a phase’s `onBegin` hook/,
+        /`endTurn` & `pass` are disallowed in a phase’s `onBegin` hook/,
       );
       expect(errorMessage).toMatch(
         /Use `turn.order.first` to choose the starting player/,
@@ -1820,7 +1826,34 @@ describe('events in hooks', () => {
       expect(error).toHaveBeenCalled();
       const errorMessage = (error as jest.Mock).mock.calls[0][0];
       expect(errorMessage).toMatch(/events plugin declared action invalid/);
-      expect(errorMessage).toMatch(/`endTurn` is disallowed in `onEnd` hooks/);
+      expect(errorMessage).toMatch(
+        /`endTurn` & `pass` are disallowed in `onEnd` hooks/,
+      );
+    });
+
+    test('cannot pass from turn.onEnd', () => {
+      const client = Client({
+        game: {
+          moves,
+          turn: { onEnd: conditionalPass },
+        },
+      });
+
+      let state = client.getState();
+      expect(state.ctx.turn).toBe(1);
+      expect(state.ctx.currentPlayer).toBe('0');
+
+      client.moves.setAutoEnd();
+      client.events.endTurn();
+      state = client.getState();
+      expect(state.ctx.turn).toBe(1);
+      expect(state.ctx.currentPlayer).toBe('0');
+      expect(error).toHaveBeenCalled();
+      const errorMessage = (error as jest.Mock).mock.calls[0][0];
+      expect(errorMessage).toMatch(/events plugin declared action invalid/);
+      expect(errorMessage).toMatch(
+        /`endTurn` & `pass` are disallowed in `onEnd` hooks/,
+      );
     });
 
     test('cannot end turn from phase.onEnd', () => {
@@ -1850,7 +1883,41 @@ describe('events in hooks', () => {
       expect(error).toHaveBeenCalled();
       const errorMessage = (error as jest.Mock).mock.calls[0][0];
       expect(errorMessage).toMatch(/events plugin declared action invalid/);
-      expect(errorMessage).toMatch(/`endTurn` is disallowed in `onEnd` hooks/);
+      expect(errorMessage).toMatch(
+        /`endTurn` & `pass` are disallowed in `onEnd` hooks/,
+      );
+    });
+
+    test('cannot pass from phase.onEnd', () => {
+      const client = Client({
+        game: {
+          moves,
+          phases: {
+            A: {
+              start: true,
+              onEnd: conditionalPass,
+            },
+          },
+        },
+      });
+
+      let state = client.getState();
+      expect(state.ctx.turn).toBe(1);
+      expect(state.ctx.currentPlayer).toBe('0');
+      expect(state.ctx.phase).toBe('A');
+
+      client.moves.setAutoEnd();
+      client.events.endPhase();
+      state = client.getState();
+      expect(state.ctx.turn).toBe(1);
+      expect(state.ctx.currentPlayer).toBe('0');
+      expect(state.ctx.phase).toBe('A');
+      expect(error).toHaveBeenCalled();
+      const errorMessage = (error as jest.Mock).mock.calls[0][0];
+      expect(errorMessage).toMatch(/events plugin declared action invalid/);
+      expect(errorMessage).toMatch(
+        /`endTurn` & `pass` are disallowed in `onEnd` hooks/,
+      );
     });
   });
 

--- a/src/plugins/events/events.ts
+++ b/src/plugins/events/events.ts
@@ -16,6 +16,9 @@ enum Errors {
 
   EndTurnInOnEnd = '`endTurn` is disallowed in `onEnd` hooks — the turn is already ending.',
 
+  TurnEventInPhaseBegin = '`endTurn` is disallowed in a phase’s `onBegin` hook — no turn has started yet.\n' +
+    'Use `turn.order.first` to choose the starting player.',
+
   MaxTurnEndings = 'Maximum number of turn endings exceeded for this update.\n' +
     'This likely means game code is triggering an infinite loop.',
 
@@ -178,7 +181,12 @@ export class Events {
           break;
         }
 
-        case 'endTurn': {
+        case 'endTurn':
+        case 'pass': {
+          if (event.calledFrom === GameMethod.PHASE_ON_BEGIN) {
+            return stateWithError(event.error, Errors.TurnEventInPhaseBegin);
+          }
+
           if (
             event.calledFrom === GameMethod.TURN_ON_END ||
             event.calledFrom === GameMethod.PHASE_ON_END

--- a/src/plugins/events/events.ts
+++ b/src/plugins/events/events.ts
@@ -14,9 +14,9 @@ enum Errors {
   CalledOutsideHook = 'Events must be called from moves or the `onBegin`, `onEnd`, and `onMove` hooks.\n' +
     'This error probably means you called an event from other game code, like an `endIf` trigger or one of the `turn.order` methods.',
 
-  EndTurnInOnEnd = '`endTurn` is disallowed in `onEnd` hooks — the turn is already ending.',
+  EndTurnInOnEnd = '`endTurn` & `pass` are disallowed in `onEnd` hooks — the turn is already ending.',
 
-  TurnEventInPhaseBegin = '`endTurn` is disallowed in a phase’s `onBegin` hook — no turn has started yet.\n' +
+  TurnEventInPhaseBegin = '`endTurn` & `pass` are disallowed in a phase’s `onBegin` hook — no turn has started yet.\n' +
     'Use `turn.order.first` to choose the starting player.',
 
   MaxTurnEndings = 'Maximum number of turn endings exceeded for this update.\n' +


### PR DESCRIPTION
## Summary

- Add a TurnEventInPhaseBegin error for endTurn and pass calls from phase.onBegin.
- Preserve stale-event protection and return an explicit error instead of silently discarding the event.
- Point game authors to turn.order.first for choosing the starting player.
- Add regression coverage for both endTurn and pass.

## Why

A phase onBegin hook runs before the phase's first turn starts. A queued turn-ending event therefore becomes stale after StartTurn advances the turn counter and was previously discarded without feedback. Processing it would create a phantom turn, so the existing stale-event protection is correct; the missing behavior is an actionable error.

Fixes #1237

## Validation

- Focused phase.onBegin tests: 8 passed.
- ESLint on the two modified files: passed.
- Build: passed.
- git diff --check: passed.
- Full Jest run: 41 of 42 suites passed and all 873 executed tests passed. The debug suite could not load @testing-library/svelte-core because of an unrelated Windows ESM transform/path issue.
