### PR TITLE
fix: preserve log metadata for game events

### DIFF
--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -173,24 +173,73 @@ function initializeDeltalog(
 }
 
 /**
- * Add metadata set by the log plugin to the final log entry for an event.
+ * Get the event type used in the log for a directly dispatched game event.
  */
-function addLogMetadata(state: State): State {
+function getLogEventType(eventType: string): string | undefined {
+  switch (eventType) {
+    case 'endTurn':
+    case 'pass': {
+      return 'endTurn';
+    }
+    case 'endPhase':
+    case 'setPhase': {
+      return 'endPhase';
+    }
+    case 'endStage':
+    case 'setStage': {
+      return 'endStage';
+    }
+    case 'endGame': {
+      return 'endGame';
+    }
+  }
+}
+
+/**
+ * Add metadata set by the log plugin to the log entry for an event.
+ */
+function addLogMetadata(state: State, action: ActionShape.GameEvent): State {
   const metadata = state.plugins.log?.data.metadata;
   const { deltalog } = state;
+  const eventType = getLogEventType(action.payload.type);
 
-  if (metadata === undefined || !deltalog?.length) {
+  if (metadata === undefined || !deltalog?.length || eventType === undefined) {
     return state;
   }
 
-  const lastEntry = deltalog.length - 1;
+  const eventEntry = deltalog.findIndex(
+    (entry) =>
+      entry.action.type === Actions.GAME_EVENT &&
+      entry.action.payload.type === eventType,
+  );
+  if (eventEntry === -1) return state;
+
   const updatedDeltalog = [...deltalog];
-  updatedDeltalog[lastEntry] = {
-    ...updatedDeltalog[lastEntry],
+  updatedDeltalog[eventEntry] = {
+    ...updatedDeltalog[eventEntry],
     metadata,
   };
 
   return { ...state, deltalog: updatedDeltalog };
+}
+
+/**
+ * Remove metadata set during an action that was rejected.
+ */
+function clearLogMetadata(state: State): State {
+  const logPlugin = state.plugins.log;
+  if (logPlugin?.data.metadata === undefined) return state;
+
+  const data = { ...logPlugin.data };
+  delete data.metadata;
+
+  return {
+    ...state,
+    plugins: {
+      ...state.plugins,
+      log: { ...logPlugin, data },
+    },
+  };
 }
 
 /**
@@ -210,7 +259,11 @@ function flushAndValidatePlugins(
   if (!isInvalid) return [newState];
   return [
     newState,
-    WithError(oldState, ActionErrorType.PluginActionInvalid, isInvalid),
+    WithError(
+      clearLogMetadata(oldState),
+      ActionErrorType.PluginActionInvalid,
+      isInvalid,
+    ),
   ];
 }
 
@@ -322,7 +375,7 @@ export function CreateGameReducer({
       }
 
       case Actions.GAME_EVENT: {
-        state = { ...state, deltalog: [] };
+        const oldState = (state = { ...state, deltalog: [] });
 
         // Process game events only on the server.
         // These events like `endTurn` typically
@@ -356,14 +409,18 @@ export function CreateGameReducer({
 
         // Process event.
         let newState = game.flow.processEvent(state, action);
-        newState = addLogMetadata(newState);
+        newState = addLogMetadata(newState, action);
 
         // Execute plugins.
         let stateWithError: TransientState | undefined;
-        [newState, stateWithError] = flushAndValidatePlugins(newState, state, {
-          game,
-          isClient: false,
-        });
+        [newState, stateWithError] = flushAndValidatePlugins(
+          newState,
+          oldState,
+          {
+            game,
+            isClient: false,
+          },
+        );
         if (stateWithError) return stateWithError;
 
         // Update undo / redo state.

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -173,6 +173,27 @@ function initializeDeltalog(
 }
 
 /**
+ * Add metadata set by the log plugin to the final log entry for an event.
+ */
+function addLogMetadata(state: State): State {
+  const metadata = state.plugins.log?.data.metadata;
+  const { deltalog } = state;
+
+  if (metadata === undefined || !deltalog?.length) {
+    return state;
+  }
+
+  const lastEntry = deltalog.length - 1;
+  const updatedDeltalog = [...deltalog];
+  updatedDeltalog[lastEntry] = {
+    ...updatedDeltalog[lastEntry],
+    metadata,
+  };
+
+  return { ...state, deltalog: updatedDeltalog };
+}
+
+/**
  * Update plugin state after move/event & check if plugins consider the action to be valid.
  * @param state Current version of state in the reducer.
  * @param oldState State to revert to in case of error.
@@ -335,6 +356,7 @@ export function CreateGameReducer({
 
         // Process event.
         let newState = game.flow.processEvent(state, action);
+        newState = addLogMetadata(newState);
 
         // Execute plugins.
         let stateWithError: TransientState | undefined;

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -26,7 +26,7 @@ import type {
   TransientState,
   Undo,
 } from '../types';
-import { stripTransients } from './action-creators';
+import { gameEvent, stripTransients } from './action-creators';
 import { ActionErrorType, UpdateErrorType } from './errors';
 import { applyPatch } from 'rfc6902';
 import { RemovePlayer } from './turn-order';
@@ -196,23 +196,41 @@ function getLogEventType(eventType: string): string | undefined {
 }
 
 /**
- * Add metadata set by the log plugin to the log entry for an event.
+ * Add metadata set by the log plugin to the canonical log entry for an event.
+ * If the event produced no such entry, add one for the dispatched event.
  */
-function addLogMetadata(state: State, action: ActionShape.GameEvent): State {
+function addLogMetadata(
+  state: State,
+  action: ActionShape.GameEvent,
+  actionState: State,
+): State {
   const metadata = state.plugins.log?.data.metadata;
-  const { deltalog } = state;
   const eventType = getLogEventType(action.payload.type);
 
-  if (metadata === undefined || !deltalog?.length || eventType === undefined) {
+  if (metadata === undefined || eventType === undefined) {
     return state;
   }
 
+  // GAME_EVENT processing initializes deltalog before running the flow.
+  const { deltalog } = state;
   const eventEntry = deltalog.findIndex(
     (entry) =>
       entry.action.type === Actions.GAME_EVENT &&
       entry.action.payload.type === eventType,
   );
-  if (eventEntry === -1) return state;
+
+  if (eventEntry === -1) {
+    // Recreate the action without credentials so they are never persisted.
+    const { type, args, playerID } = action.payload;
+    const logEntry: LogEntry = {
+      action: gameEvent(type, args, playerID),
+      _stateID: actionState._stateID,
+      turn: actionState.ctx.turn,
+      phase: actionState.ctx.phase,
+      metadata,
+    };
+    return { ...state, deltalog: [...deltalog, logEntry] };
+  }
 
   const updatedDeltalog = [...deltalog];
   updatedDeltalog[eventEntry] = {
@@ -409,7 +427,7 @@ export function CreateGameReducer({
 
         // Process event.
         let newState = game.flow.processEvent(state, action);
-        newState = addLogMetadata(newState, action);
+        newState = addLogMetadata(newState, action, oldState);
 
         // Execute plugins.
         let stateWithError: TransientState | undefined;

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -196,18 +196,29 @@ function getLogEventType(eventType: string): string | undefined {
 }
 
 /**
+ * Events whose flow implementation never appends a log entry even though their
+ * hooks run: `endGame` is never logged, and `setPhase` starting a phase from
+ * `ctx.phase === null` returns before `EndPhase` reaches its log entry.
+ * Other events either produce a canonical entry or run no hooks at all.
+ */
+const EVENTS_WITHOUT_LOG_ENTRY = new Set(['endGame', 'setPhase']);
+
+/**
  * Add metadata set by the log plugin to the canonical log entry for an event.
- * If the event produced no such entry, add one for the dispatched event.
+ * If the event never produces an entry of its own, add one for the dispatched
+ * event, whether or not metadata was set, so the log shape doesn’t depend on
+ * what a hook happened to do.
  */
 function addLogMetadata(
   state: State,
   action: ActionShape.GameEvent,
   actionState: State,
+  game: Game,
 ): State {
   const metadata = state.plugins.log?.data.metadata;
   const eventType = getLogEventType(action.payload.type);
 
-  if (metadata === undefined || eventType === undefined) {
+  if (game.disableLog || eventType === undefined) {
     return state;
   }
 
@@ -220,6 +231,7 @@ function addLogMetadata(
   );
 
   if (eventEntry === -1) {
+    if (!EVENTS_WITHOUT_LOG_ENTRY.has(action.payload.type)) return state;
     // Recreate the action without credentials so they are never persisted.
     const { type, args, playerID } = action.payload;
     const logEntry: LogEntry = {
@@ -227,10 +239,12 @@ function addLogMetadata(
       _stateID: actionState._stateID,
       turn: actionState.ctx.turn,
       phase: actionState.ctx.phase,
-      metadata,
     };
+    if (metadata !== undefined) logEntry.metadata = metadata;
     return { ...state, deltalog: [...deltalog, logEntry] };
   }
+
+  if (metadata === undefined) return state;
 
   const updatedDeltalog = [...deltalog];
   updatedDeltalog[eventEntry] = {
@@ -427,7 +441,7 @@ export function CreateGameReducer({
 
         // Process event.
         let newState = game.flow.processEvent(state, action);
-        newState = addLogMetadata(newState, action, oldState);
+        newState = addLogMetadata(newState, action, oldState, game);
 
         // Execute plugins.
         let stateWithError: TransientState | undefined;

--- a/src/plugins/plugin-log.test.ts
+++ b/src/plugins/plugin-log.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { Client } from '../client/client';
+import { TurnOrder } from '../core/turn-order';
 import type { Game } from '../types';
 
 describe('log-metadata', () => {
@@ -88,5 +89,73 @@ describe('log-metadata', () => {
     expect(log.at(-1).metadata).toEqual({
       message: 'phase B began',
     });
+  });
+
+  test('It attaches turn metadata before an automatically ended phase', () => {
+    const game: Game = {
+      phases: {
+        A: {
+          start: true,
+          turn: {
+            order: TurnOrder.ONCE,
+            onEnd: ({ log }) => {
+              log.setMetadata({ message: 'turn ended' });
+            },
+          },
+        },
+      },
+    };
+    const client = Client({ game, numPlayers: 1 });
+
+    client.events.endTurn();
+
+    const log = client.getState().log;
+    const endTurn = log.find(
+      (entry) =>
+        entry.action.type === 'GAME_EVENT' &&
+        entry.action.payload.type === 'endTurn' &&
+        !entry.automatic,
+    );
+    const endPhase = log.find(
+      (entry) =>
+        entry.action.type === 'GAME_EVENT' &&
+        entry.action.payload.type === 'endPhase',
+    );
+
+    expect(endTurn.metadata).toEqual({ message: 'turn ended' });
+    expect(endPhase.metadata).toBeUndefined();
+  });
+
+  test('It clears metadata set during a plugin-rejected event', () => {
+    const game: Game<{ invalid: boolean }> = {
+      setup: () => ({ invalid: false }),
+      plugins: [
+        {
+          name: 'validator',
+          isInvalid: ({ G }) => G.invalid && 'invalid',
+        },
+      ],
+      phases: {
+        A: { start: true },
+        B: {
+          onBegin: ({ G, log }) => {
+            log.setMetadata({ message: 'rejected' });
+            G.invalid = true;
+          },
+        },
+      },
+    };
+    const client = Client({ game });
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+
+    client.events.setPhase('B');
+    consoleError.mockRestore();
+
+    expect(client.getState().ctx.phase).toBe('A');
+    expect(client.getState().plugins.log.data).toEqual({});
+
+    client.events.endTurn();
+
+    expect(client.getState().log.at(-1).metadata).toBeUndefined();
   });
 });

--- a/src/plugins/plugin-log.test.ts
+++ b/src/plugins/plugin-log.test.ts
@@ -10,6 +10,8 @@ import { Client } from '../client/client';
 import type { Game } from '../types';
 
 describe('log-metadata', () => {
+  test.todo('preserves metadata from hooks triggered by moves');
+
   test('It sets metadata in a move and then clears the metadata', () => {
     const game: Game = {
       moves: {

--- a/src/plugins/plugin-log.test.ts
+++ b/src/plugins/plugin-log.test.ts
@@ -34,4 +34,57 @@ describe('log-metadata', () => {
     expect(client.getState().plugins.log.data).toEqual({});
     expect(client.getState().log[1].metadata).toEqual(undefined);
   });
+
+  test('It sets metadata in a game event and then clears the metadata', () => {
+    const game: Game = {
+      setup: () => ({ shouldLog: true }),
+      turn: {
+        onEnd: ({ G, log }) => {
+          if (G.shouldLog) {
+            log.setMetadata({ message: 'turn ended' });
+            G.shouldLog = false;
+          }
+        },
+      },
+    };
+    const client = Client({ game });
+
+    client.events.endTurn();
+
+    expect(client.getState().plugins.log.data).toEqual({});
+    expect(client.getState().log[0].metadata).toEqual({
+      message: 'turn ended',
+    });
+
+    client.events.endTurn();
+
+    expect(client.getState().log[1].metadata).toEqual(undefined);
+  });
+
+  test('It uses the last metadata set by hooks during a phase event', () => {
+    const game: Game = {
+      phases: {
+        A: {
+          start: true,
+          next: 'B',
+          onEnd: ({ log }) => {
+            log.setMetadata({ message: 'phase A ended' });
+          },
+        },
+        B: {
+          onBegin: ({ log }) => {
+            log.setMetadata({ message: 'phase B began' });
+          },
+        },
+      },
+    };
+    const client = Client({ game });
+
+    client.events.endPhase();
+
+    const log = client.getState().log;
+    expect(log.at(-1).metadata).toEqual({
+      message: 'phase B began',
+    });
+  });
 });

--- a/src/plugins/plugin-log.test.ts
+++ b/src/plugins/plugin-log.test.ts
@@ -91,6 +91,54 @@ describe('log-metadata', () => {
     });
   });
 
+  test('It logs phase metadata when setPhase starts the first phase', () => {
+    const game: Game = {
+      phases: {
+        B: {
+          onBegin: ({ log }) => {
+            log.setMetadata({ message: 'phase B began' });
+          },
+        },
+      },
+    };
+    const client = Client({ game });
+
+    client.events.setPhase('B');
+
+    const log = client.getState().log;
+    const setPhase = log.find(
+      (entry) =>
+        entry.action.type === 'GAME_EVENT' &&
+        entry.action.payload.type === 'setPhase',
+    );
+
+    expect(client.getState().ctx.phase).toBe('B');
+    expect(setPhase.metadata).toEqual({ message: 'phase B began' });
+    expect(log.at(-2).metadata).toBeUndefined();
+  });
+
+  test('It logs metadata set by the game end hook', () => {
+    const game: Game = {
+      onEnd: ({ log }) => {
+        log.setMetadata({ message: 'game ended' });
+      },
+    };
+    const client = Client({ game });
+
+    client.events.endGame('winner');
+
+    const log = client.getState().log;
+    const endGame = log.find(
+      (entry) =>
+        entry.action.type === 'GAME_EVENT' &&
+        entry.action.payload.type === 'endGame',
+    );
+
+    expect(client.getState().ctx.gameover).toBe('winner');
+    expect(endGame.metadata).toEqual({ message: 'game ended' });
+    expect(log).toHaveLength(1);
+  });
+
   test('It attaches turn metadata before an automatically ended phase', () => {
     const game: Game = {
       phases: {

--- a/src/plugins/plugin-log.test.ts
+++ b/src/plugins/plugin-log.test.ts
@@ -139,6 +139,75 @@ describe('log-metadata', () => {
     expect(log).toHaveLength(1);
   });
 
+  test('It logs events without a canonical entry when no metadata is set', () => {
+    const game: Game = {
+      phases: {
+        B: {},
+      },
+    };
+    const client = Client({ game });
+
+    client.events.setPhase('B');
+
+    const setPhase = client
+      .getState()
+      .log.find(
+        (entry) =>
+          entry.action.type === 'GAME_EVENT' &&
+          entry.action.payload.type === 'setPhase',
+      );
+
+    expect(client.getState().ctx.phase).toBe('B');
+    expect(setPhase).toBeDefined();
+    expect(setPhase.metadata).toBeUndefined();
+
+    client.events.endGame('winner');
+
+    const endGame = client
+      .getState()
+      .log.find(
+        (entry) =>
+          entry.action.type === 'GAME_EVENT' &&
+          entry.action.payload.type === 'endGame',
+      );
+
+    expect(endGame).toBeDefined();
+    expect(endGame.metadata).toBeUndefined();
+  });
+
+  test('It does not log events when the log is disabled', () => {
+    const game: Game = {
+      disableLog: true,
+      onEnd: ({ log }) => {
+        log.setMetadata({ message: 'game ended' });
+      },
+    };
+    const client = Client({ game });
+
+    client.events.endGame('winner');
+
+    expect(client.getState().ctx.gameover).toBe('winner');
+    expect(client.getState().log).toEqual([]);
+  });
+
+  test('It does not log an event that the flow refused', () => {
+    const game: Game = {
+      moves: {
+        A: () => {},
+      },
+      turn: {
+        minMoves: 2,
+        maxMoves: 5,
+      },
+    };
+    const client = Client({ game });
+
+    client.events.endTurn();
+
+    expect(client.getState().ctx.turn).toBe(1);
+    expect(client.getState().log).toEqual([]);
+  });
+
   test('It attaches turn metadata before an automatically ended phase', () => {
     const game: Game = {
       phases: {

--- a/src/plugins/plugin-log.ts
+++ b/src/plugins/plugin-log.ts
@@ -18,8 +18,8 @@ export interface LogAPI {
 
 /**
  * Plugin that makes it possible to add metadata to log entries.
- * During a move or game event, you can set metadata using ctx.log.setMetadata
- * and it will be available on that action's log entry.
+ * Metadata set during a move, or during hooks triggered by a directly
+ * dispatched game event, is attached to that action's log entry.
  */
 const LogPlugin: Plugin<LogAPI, LogData> = {
   name: 'log',

--- a/src/plugins/plugin-log.ts
+++ b/src/plugins/plugin-log.ts
@@ -18,8 +18,8 @@ export interface LogAPI {
 
 /**
  * Plugin that makes it possible to add metadata to log entries.
- * During a move, you can set metadata using ctx.log.setMetadata and it will be
- * available on the log entry for that move.
+ * During a move or game event, you can set metadata using ctx.log.setMetadata
+ * and it will be available on that action's log entry.
  */
 const LogPlugin: Plugin<LogAPI, LogData> = {
   name: 'log',


### PR DESCRIPTION
## Summary

- Preserve metadata set through `log.setMetadata()` while processing directly dispatched game events.
- Attach metadata to the canonical internal event entry when one exists.
- If no canonical entry is emitted, add a sanitized entry for the directly dispatched event.
- Cover `setPhase` from no active phase and `endGame`, without attributing metadata to adjacent internal events.
- Preserve rollback behavior so metadata from plugin-rejected actions cannot leak.
- Document the supported scope and retain a TODO for hooks triggered by moves.

## Root cause

`GAME_EVENT` processing generated its deltalog entries before plugins were flushed, but never copied the log plugin metadata into those entries. Hook metadata was therefore discarded during the flush.

Some directly dispatched events can produce several internal entries or no canonical entry at all. The final attribution rule is deterministic: use the canonical internal entry when present; otherwise create one sanitized entry for the dispatched event using its pre-action turn and phase.

Part of #1228.

## Remaining limitation

Metadata set by hooks triggered from a move, or by automatic turn triggers such as `turn.maxMoves` and `endIf`, is not yet attached to the resulting event log entry. This PR intentionally does not address that attribution path.

## Validation

Validated at `fe905a1` against `upstream/main@65ca73b`:

- Targeted log metadata tests: 7 passed, 1 TODO.
- Reducer, flow, and log metadata tests: 213 passed, 1 TODO.
- Negative control: reverting the no-entry fallback makes both new regression tests fail; restoring it makes them pass.
- `pnpm run ts` — passed.
- ESLint and Prettier on all modified files — passed.
- `pnpm run build` — passed.
- `pnpm run test:integration` — passed, including consumer typecheck, Vitest, build, ESM/CJS smoke tests, and publint.
- Full Jest coverage run on Windows: 41/42 suites passed and all 882 executed tests passed. The sole failure is the existing Jest ESM transform error for `@testing-library/svelte-core`.
- GitHub Actions build/test and integration — passed on Node 24.x and 26.x.
- Coveralls — passed.

The Windows checkout inherits CRLF line endings, so full-repository lint reports formatting errors in untouched files; the modified files pass ESLint and Prettier.

AI assistance: OpenAI Codex assisted with investigation, implementation, and validation.