### PR TITLE
fix(debug): hide state controls in multiplayer

### DIFF
--- a/src/client/debug/main/Controls.svelte
+++ b/src/client/debug/main/Controls.svelte
@@ -43,6 +43,9 @@
 </style>
 
 <ul id="debug-controls" class="controls">
+  {#if client.multiplayer}
+  <li>State controls are unavailable in multiplayer games.</li>
+  {:else}
   <li>
     <Hotkey value="1" onPress={client.reset} label="reset" />
   </li>
@@ -52,6 +55,7 @@
   <li>
     <Hotkey value="3" onPress={Restore} label="restore" />
   </li>
+  {/if}
   <li>
     <Hotkey value="." onPress={ToggleVisibility} label="hide" />
   </li>

--- a/src/client/debug/tests/debug.test.ts
+++ b/src/client/debug/tests/debug.test.ts
@@ -173,6 +173,19 @@ describe('multiple clients', () => {
     expect(client2.playerID).toBe('1');
   });
 
+  test('hides state controls for multiplayer clients', async () => {
+    const select = screen.getByLabelText('Client');
+    await fireEvent.change(select, { target: { value: 1 } });
+
+    expect(
+      screen.getByText('State controls are unavailable in multiplayer games.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('reset')).not.toBeInTheDocument();
+    expect(screen.queryByText('save')).not.toBeInTheDocument();
+    expect(screen.queryByText('restore')).not.toBeInTheDocument();
+    expect(screen.getByText('hide')).toBeInTheDocument();
+  });
+
   test('switching to current client', async () => {
     const select = screen.getByLabelText('Client');
     await fireEvent.change(select, { target: { value: 0 } });


### PR DESCRIPTION
Closes #1034

## Summary
- Hide reset, save, and restore controls for multiplayer clients.
- Keep the visibility toggle available.
- Explain why the state controls are unavailable.
- Add coverage for multiplayer debug controls.

## Validation
- pnpm install --frozen-lockfile
- pnpm run ts
- pnpm run build

The targeted Jest command currently fails before test execution because the existing Jest configuration does not transform @testing-library/svelte-core; the same error reproduces on upstream/main.