### PR TITLE
fix(server): accept games with custom plugin APIs

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -11,12 +11,14 @@
     "@testing-library/react": "^16.0.1",
     "@vitejs/plugin-react": "^4.3.4",
     "jsdom": "^25.0.1",
+    "typescript": "^5.9.3",
     "vite": "^5.4.10",
     "vitest": "^2.1.4"
   },
   "scripts": {
     "start": "vite",
     "build": "vite build",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --project type-tests/tsconfig.json"
   }
 }

--- a/integration/type-tests/server-custom-plugin.ts
+++ b/integration/type-tests/server-custom-plugin.ts
@@ -1,0 +1,21 @@
+import type { Game, Plugin } from 'boardgame.io';
+import { Server } from 'boardgame.io/server';
+
+interface CustomPluginAPIs extends Record<string, unknown> {
+  custom: { enabled: boolean };
+}
+
+const customPlugin: Plugin<CustomPluginAPIs['custom']> = {
+  name: 'custom',
+  api: () => ({ enabled: true }),
+};
+
+const customGame: Game<{ enabled: boolean }, CustomPluginAPIs> = {
+  name: 'custom-plugin-game',
+  plugins: [customPlugin],
+  setup: ({ custom }) => ({ enabled: custom.enabled }),
+};
+
+Server({
+  games: [customGame, { name: 'standard-game' }],
+});

--- a/integration/type-tests/tsconfig.json
+++ b/integration/type-tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["server-custom-plugin.ts"]
+}

--- a/scripts/integration.js
+++ b/scripts/integration.js
@@ -26,6 +26,7 @@ shell.exec(`pnpm add --config.minimum-release-age=0 ./${packed}`);
 shell.set('-e');
 
 // Test
+shell.exec('pnpm run typecheck');
 shell.exec('pnpm test');
 shell.exec('pnpm run build');
 shell.exec('node node-smoke/esm-test.mjs');

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -52,7 +52,7 @@ jest.mock('socket.io', () => {
 });
 
 describe('new', () => {
-  test('accepts games with custom plugin APIs', () => {
+  test('processes custom-plugin and standard games through transport', () => {
     interface CustomPluginAPIs extends Record<string, unknown> {
       custom: { enabled: boolean };
     }

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -15,7 +15,7 @@ import request from 'supertest';
 import { Server, createServerRunConfig, getPortFromServer } from '.';
 import type { KoaServer } from '.';
 import type { SocketIO } from './transport/socketio';
-import type { Game, StorageAPI } from '../types';
+import type { Game, Plugin, StorageAPI } from '../types';
 
 const game: Game = { seed: 0 };
 
@@ -52,6 +52,42 @@ jest.mock('socket.io', () => {
 });
 
 describe('new', () => {
+  test('accepts games with custom plugin APIs', () => {
+    interface CustomPluginAPIs extends Record<string, unknown> {
+      custom: { enabled: boolean };
+    }
+
+    const customPlugin: Plugin<CustomPluginAPIs['custom']> = {
+      name: 'custom',
+      api: () => ({ enabled: true }),
+    };
+    const customGame: Game<{ enabled: boolean }, CustomPluginAPIs> = {
+      name: 'custom-plugin-game',
+      plugins: [customPlugin],
+      setup: ({ custom }) => ({ enabled: custom.enabled }),
+    };
+    const init = jest.fn();
+    const transport = { init } as unknown as SocketIO;
+
+    Server({
+      games: [customGame, { name: 'standard-game' }],
+      transport,
+    });
+
+    expect(init).toHaveBeenCalledTimes(1);
+    expect(init.mock.calls[0][1]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'custom-plugin-game',
+          processMove: expect.any(Function),
+        }),
+        expect.objectContaining({
+          name: 'standard-game',
+          processMove: expect.any(Function),
+        }),
+      ]),
+    );
+  });
   test('custom db implementation', () => {
     const game: Game = {};
     const db = {} as StorageAPI.Sync;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -62,7 +62,7 @@ export const getPortFromServer = (
 };
 
 interface ServerOpts {
-  games: Game[];
+  games: Game<any, any, any>[];
   origins?: CorsOptions['origin'];
   apiOrigins?: CorsOptions['origin'];
   db?: StorageAPI.Async | StorageAPI.Sync;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,6 @@
     "esModuleInterop": true,
     "jsx": "react",
     "skipLibCheck": true
-  }
+  },
+  "exclude": ["dist", "integration/type-tests"]
 }


### PR DESCRIPTION
## Summary

- Allow `Server` to accept games with custom plugin API types without a type assertion.
- Preserve support for heterogeneous game lists.
- Keep the Jest scenario as runtime coverage for processing a custom-plugin game and a standard game together through `transport.init`.
- Add a strict consumer type fixture to the packed-package integration test so the type regression is enforceable.

## Root cause

`ServerOpts.games` was typed as `Game[]`, which fixes the plugin API parameter to the default type. A game whose `setup` requires a custom plugin API was therefore rejected at the server boundary even though the server only processes the configuration and does not consume that API.

The server input now accepts `Game<any, any, any>[]`; processed games continue through the existing runtime path unchanged.

Fixes #1050.

## Regression guard

The integration harness installs the packed tarball and runs `tsc --noEmit` with `strict: true` against a consumer fixture importing only public APIs from `boardgame.io` and `boardgame.io/server`.

- Positive control: the strict fixture passes with `ServerOpts.games: Game<any, any, any>[]`.
- Negative control: in an isolated worktree, reverting only that declaration to `Game[]` makes the fixture fail at the `Server({ games: [...] })` call with `TS2322`; the `setup` context is incompatible because `custom` is missing.

## Validation

Validated at `0a4f196` against `upstream/main@3dc2af0`, using Node 24.14.0 and pnpm 10.16.0:

- `pnpm install --frozen-lockfile` — passed.
- `pnpm run lint` — passed from an LF snapshot of the published commit.
- `pnpm exec jest src/server/index.test.ts --runInBand` — passed (18 tests).
- `pnpm run ts` — passed.
- `pnpm run build` — passed.
- `pnpm run test:integration` — passed, including the new strict typecheck, Vitest fixture, build, ESM/CJS smoke tests, and publint.
- `git diff --check` — passed.
- `pnpm run test:coverage` — 41/42 suites passed and all 876 executed tests passed. The sole failure is the Windows Jest ESM transform error for `@testing-library/svelte-core/src/index.js` (`Unexpected token 'export'`). The exact command reproduces on a clean LF snapshot of `upstream/main@3dc2af0`: 41/42 suites passed and all 875 executed tests passed.
- GitHub Actions — build/test and integration passed on Node 24.x and 26.x.
- [Coveralls](https://coveralls.io/builds/80697228) — passed; coverage remained at 100.0%.

The normal Windows checkout inherits CRLF line endings, which makes Prettier report errors across untouched files. Validation used Git-archive LF snapshots so lint ran against the repository's actual blob contents.

AI assistance: OpenAI Codex assisted with investigation, implementation, and validation.