### PR TITLE
chore: move pnpm settings to workspace config

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,19 +2,6 @@
   "name": "boardgame.io",
   "version": "0.50.2",
   "packageManager": "pnpm@10.16.0",
-  "pnpm": {
-    "onlyBuiltDependencies": [],
-    "overrides": {
-      "jest": "30.4.1",
-      "@jest/core": "30.4.1",
-      "jest-cli": "30.4.1",
-      "jest-circus": "30.4.1",
-      "jest-config": "30.4.1",
-      "jest-runner": "30.4.1",
-      "jest-runtime": "30.4.1",
-      "jest-resolve-dependencies": "30.4.1"
-    }
-  },
   "description": "library for turn-based games",
   "repository": {
     "type": "git",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+onlyBuiltDependencies: []
+
+overrides:
+  jest: 30.4.1
+  '@jest/core': 30.4.1
+  jest-cli: 30.4.1
+  jest-circus: 30.4.1
+  jest-config: 30.4.1
+  jest-runner: 30.4.1
+  jest-runtime: 30.4.1
+  jest-resolve-dependencies: 30.4.1


### PR DESCRIPTION
## Summary

- move pnpm overrides and dependency build policy from package.json to pnpm-workspace.yaml
- preserve the existing Jest overrides and empty build allow-list
- keep the workspace root-only so nested example and integration projects remain independent

## Why

pnpm 11 launchers no longer read the pnpm field in package.json and emit an ignored-configuration warning before honoring the pinned package manager version. Moving these settings to pnpm-workspace.yaml keeps the repository compatible with pnpm 10.16 while using the supported configuration location for newer pnpm launchers.

## Verification

- pnpm 10.16 reads the migrated overrides and onlyBuiltDependencies settings
- pnpm install --frozen-lockfile passes with no lockfile changes
- pre-push test:coverage: 43 suites and 884 tests passed