### PR TITLE
feat: deliver move-rejection errors to the acting client (#723)

### DIFF
--- a/docs/documentation/api/Client.md
+++ b/docs/documentation/api/Client.md
@@ -132,8 +132,9 @@ The following properties are available on a client instance:
 
 - `lastActionError`: The reason this client’s most recent action was
   rejected, or `undefined` if it wasn’t. Cleared when a subsequent
-  action succeeds. In multiplayer, rejections are delivered only to
-  the client that made the move. An error object has:
+  action succeeds. In multiplayer, this reflects the authoritative
+  result from the master, and rejections are delivered only to the
+  client that made the move. An error object has:
 
     - `type`: an error code string, e.g. `'action/invalid_move'`
     - `payload`: the value the move returned via
@@ -191,15 +192,17 @@ The following methods are available on a client instance:
 
 - `subscribe(callback)`: Add a callback for every state change.
   The passed function will be called with the same value as returned by
-  `getState`, and — if the client’s most recent action was rejected —
-  an error object as its second argument (see `lastActionError` below).
-  `subscribe` returns an unsubscribe function.
+  `getState`. When a newly processed action is rejected, that notification
+  includes the error object as its second argument. Other notifications pass
+  `undefined`, so an error can be handled as a one-time event. Use
+  `lastActionError` when you need to inspect the current error between
+  notifications. `subscribe` returns an unsubscribe function.
 
   ```js
   const unsubscribe = client.subscribe((state, error) => {
     // use updated state
     if (error) {
-      // the last action was rejected, e.g. show error.payload.message
+      // a new action rejection arrived, e.g. show error.payload.message
     }
   });
 

--- a/docs/documentation/api/Client.md
+++ b/docs/documentation/api/Client.md
@@ -130,6 +130,34 @@ The following properties are available on a client instance:
   ```
 
 
+- `lastActionError`: The reason this client’s most recent action was
+  rejected, or `undefined` if it wasn’t. Cleared when a subsequent
+  action succeeds, the client is reset, or an authoritative sync is received.
+  In multiplayer, this reflects the authoritative
+  result from the master, and rejections are delivered only to the
+  client that made the move. If the rejected move had been applied
+  optimistically, the client automatically requests a sync to restore the
+  authoritative state; that sync clears this field, so treat the
+  `subscribe` error argument as the one-time rejection signal. If several actions are still awaiting a result,
+  only the latest action’s result is reflected here; older results are treated
+  as stale. An error object has:
+
+    - `type`: an `ErrorType` code. Game-action failures use `action/*` codes
+      and update failures use `update/*` codes, e.g. `'action/invalid_move'`
+    - `payload`: the value the move returned via
+      [`Invalid(payload)`](/immutability.md#telling-the-player-why),
+      if any
+
+  Example:
+
+  ```js
+  {
+    type: 'action/invalid_move',
+    payload: { message: 'That cell is already filled' },
+  }
+  ```
+
+
 #### Methods
 
 The following methods are available on a client instance:
@@ -171,11 +199,18 @@ The following methods are available on a client instance:
 
 - `subscribe(callback)`: Add a callback for every state change.
   The passed function will be called with the same value as returned by
-  `getState`. `subscribe` returns an unsubscribe function.
+  `getState`. When a newly processed action is rejected, that notification
+  includes the error object as its second argument. Other notifications pass
+  `undefined`, so an error can be handled as a one-time event. Use
+  `lastActionError` when you need to inspect the current error between
+  notifications. `subscribe` returns an unsubscribe function.
 
   ```js
-  const unsubscribe = client.subscribe(state => {
+  const unsubscribe = client.subscribe((state, error) => {
     // use updated state
+    if (error) {
+      // a new action rejection arrived, e.g. show error.payload.message
+    }
   });
 
   // unsubscribe from the client
@@ -372,6 +407,20 @@ following as `props`:
     { id: 'foo', sender: '0', payload: 'Ready to play?' },
     { id: 'bar', sender: '1', payload: 'Let’s go!' },
   ]
+  ```
+
+
+- `lastActionError`: The reason this client’s most recent action was
+  rejected (an object with `type` and optional `payload` — see the
+  Plain JS tab), or `undefined` if it wasn’t. Useful for showing the
+  player an error toast when the server turns down a move:
+
+  ```js
+  useEffect(() => {
+    if (props.lastActionError) {
+      showToast(props.lastActionError.payload?.message ?? 'Invalid action');
+    }
+  }, [props.lastActionError]);
   ```
 
 

--- a/docs/documentation/api/Client.md
+++ b/docs/documentation/api/Client.md
@@ -135,7 +135,10 @@ The following properties are available on a client instance:
   action succeeds, the client is reset, or an authoritative sync is received.
   In multiplayer, this reflects the authoritative
   result from the master, and rejections are delivered only to the
-  client that made the move. If several actions are still awaiting a result,
+  client that made the move. If the rejected move had been applied
+  optimistically, the client automatically requests a sync to restore the
+  authoritative state; that sync clears this field, so treat the
+  `subscribe` error argument as the one-time rejection signal. If several actions are still awaiting a result,
   only the latest action’s result is reflected here; older results are treated
   as stale. An error object has:
 

--- a/docs/documentation/api/Client.md
+++ b/docs/documentation/api/Client.md
@@ -132,11 +132,15 @@ The following properties are available on a client instance:
 
 - `lastActionError`: The reason this client’s most recent action was
   rejected, or `undefined` if it wasn’t. Cleared when a subsequent
-  action succeeds. In multiplayer, this reflects the authoritative
+  action succeeds, the client is reset, or an authoritative sync is received.
+  In multiplayer, this reflects the authoritative
   result from the master, and rejections are delivered only to the
-  client that made the move. An error object has:
+  client that made the move. If several actions are still awaiting a result,
+  only the latest action’s result is reflected here; older results are treated
+  as stale. An error object has:
 
-    - `type`: an error code string, e.g. `'action/invalid_move'`
+    - `type`: an `ErrorType` code. Game-action failures use `action/*` codes
+      and update failures use `update/*` codes, e.g. `'action/invalid_move'`
     - `payload`: the value the move returned via
       [`Invalid(payload)`](/immutability.md#telling-the-player-why),
       if any

--- a/docs/documentation/api/Client.md
+++ b/docs/documentation/api/Client.md
@@ -130,6 +130,26 @@ The following properties are available on a client instance:
   ```
 
 
+- `lastActionError`: The reason this client’s most recent action was
+  rejected, or `undefined` if it wasn’t. Cleared when a subsequent
+  action succeeds. In multiplayer, rejections are delivered only to
+  the client that made the move. An error object has:
+
+    - `type`: an error code string, e.g. `'action/invalid_move'`
+    - `payload`: the value the move returned via
+      [`Invalid(payload)`](/immutability.md#telling-the-player-why),
+      if any
+
+  Example:
+
+  ```js
+  {
+    type: 'action/invalid_move',
+    payload: { message: 'That cell is already filled' },
+  }
+  ```
+
+
 #### Methods
 
 The following methods are available on a client instance:
@@ -171,11 +191,16 @@ The following methods are available on a client instance:
 
 - `subscribe(callback)`: Add a callback for every state change.
   The passed function will be called with the same value as returned by
-  `getState`. `subscribe` returns an unsubscribe function.
+  `getState`, and — if the client’s most recent action was rejected —
+  an error object as its second argument (see `lastActionError` below).
+  `subscribe` returns an unsubscribe function.
 
   ```js
-  const unsubscribe = client.subscribe(state => {
+  const unsubscribe = client.subscribe((state, error) => {
     // use updated state
+    if (error) {
+      // the last action was rejected, e.g. show error.payload.message
+    }
   });
 
   // unsubscribe from the client
@@ -372,6 +397,20 @@ following as `props`:
     { id: 'foo', sender: '0', payload: 'Ready to play?' },
     { id: 'bar', sender: '1', payload: 'Let’s go!' },
   ]
+  ```
+
+
+- `lastActionError`: The reason this client’s most recent action was
+  rejected (an object with `type` and optional `payload` — see the
+  Plain JS tab), or `undefined` if it wasn’t. Useful for showing the
+  player an error toast when the server turns down a move:
+
+  ```js
+  useEffect(() => {
+    if (props.lastActionError) {
+      showToast(props.lastActionError.payload?.message ?? 'Invalid action');
+    }
+  }, [props.lastActionError]);
   ```
 
 

--- a/docs/documentation/api/Client.md
+++ b/docs/documentation/api/Client.md
@@ -132,13 +132,13 @@ The following properties are available on a client instance:
 
 - `lastActionError`: The reason this client’s most recent action was
   rejected, or `undefined` if it wasn’t. Cleared when a subsequent
-  action succeeds, the client is reset, or an authoritative sync is received.
-  In multiplayer, this reflects the authoritative
+  action succeeds, the client is reset, or an unsolicited sync arrives, such as
+  after a reconnect. In multiplayer, this reflects the authoritative
   result from the master, and rejections are delivered only to the
   client that made the move. If the rejected move had been applied
   optimistically, the client automatically requests a sync to restore the
-  authoritative state; that sync clears this field, so treat the
-  `subscribe` error argument as the one-time rejection signal. If several actions are still awaiting a result,
+  authoritative state; that repair keeps this field set, so the reason survives
+  the rollback it explains. If several actions are still awaiting a result,
   only the latest action’s result is reflected here; older results are treated
   as stale. An error object has:
 

--- a/docs/documentation/immutability.md
+++ b/docs/documentation/immutability.md
@@ -95,8 +95,10 @@ The move is discarded exactly as with `INVALID_MOVE`, and the payload
 is delivered to the client that made the move — and only that client —
 where you can read it from the second argument of
 [`subscribe`](/api/Client.md) or the `lastActionError` board prop and
-show it to the player. The payload can be any JSON-serializable value
-and never becomes part of the game state.
+show it to the player. The `subscribe` argument is emitted once for the
+new rejection, while `lastActionError` remains set until a later action
+succeeds. The payload can be any JSON-serializable value and never becomes
+part of the game state.
 
 ### Additional Reading
 

--- a/docs/documentation/immutability.md
+++ b/docs/documentation/immutability.md
@@ -71,6 +71,33 @@ moves: {
 }
 ```
 
+### Telling the player why
+
+`INVALID_MOVE` discards the move, but the rejected player’s client
+is only told that _something_ was invalid. To attach a reason,
+return `Invalid(payload)` instead:
+
+```js
+import { Invalid } from 'boardgame.io/core';
+
+moves: {
+  clickCell: function({ G, ctx }, id) {
+    if (G.cells[id] !== null) {
+      return Invalid({ message: 'That cell is already filled' });
+    }
+
+    G.cells[id] = ctx.currentPlayer;
+  }
+}
+```
+
+The move is discarded exactly as with `INVALID_MOVE`, and the payload
+is delivered to the client that made the move — and only that client —
+where you can read it from the second argument of
+[`subscribe`](/api/Client.md) or the `lastActionError` board prop and
+show it to the player. The payload can be any JSON-serializable value
+and never becomes part of the game state.
+
 ### Additional Reading
 
 [Immutable Update Patterns](https://redux.js.org/recipes/structuring-reducers/immutable-update-patterns)

--- a/docs/documentation/immutability.md
+++ b/docs/documentation/immutability.md
@@ -98,7 +98,11 @@ where you can read it from the second argument of
 show it to the player. The `subscribe` argument is emitted once for the
 new rejection, while `lastActionError` remains set until a later action
 succeeds. The payload can be any JSON-serializable value and never becomes
-part of the game state.
+part of the game state. Values read from `G` are safe to include: boardgame.io
+snapshots them before delivering the payload.
+
+`INVALID_MOVE` and `Invalid(payload)` are supported as return values from move
+functions. They are not supported as return values from turn or phase hooks.
 
 ### Additional Reading
 

--- a/docs/documentation/immutability.md
+++ b/docs/documentation/immutability.md
@@ -71,6 +71,39 @@ moves: {
 }
 ```
 
+### Telling the player why
+
+`INVALID_MOVE` discards the move, but the rejected player’s client
+is only told that _something_ was invalid. To attach a reason,
+return `Invalid(payload)` instead:
+
+```js
+import { Invalid } from 'boardgame.io/core';
+
+moves: {
+  clickCell: function({ G, ctx }, id) {
+    if (G.cells[id] !== null) {
+      return Invalid({ message: 'That cell is already filled' });
+    }
+
+    G.cells[id] = ctx.currentPlayer;
+  }
+}
+```
+
+The move is discarded exactly as with `INVALID_MOVE`, and the payload
+is delivered to the client that made the move — and only that client —
+where you can read it from the second argument of
+[`subscribe`](/api/Client.md) or the `lastActionError` board prop and
+show it to the player. The `subscribe` argument is emitted once for the
+new rejection, while `lastActionError` remains set until a later action
+succeeds. The payload can be any JSON-serializable value and never becomes
+part of the game state. Values read from `G` are safe to include: boardgame.io
+snapshots them before delivering the payload.
+
+`INVALID_MOVE` and `Invalid(payload)` are supported as return values from move
+functions. They are not supported as return values from turn or phase hooks.
+
 ### Additional Reading
 
 [Immutable Update Patterns](https://redux.js.org/recipes/structuring-reducers/immutable-update-patterns)

--- a/packages/core.ts
+++ b/packages/core.ts
@@ -6,7 +6,12 @@
  * https://opensource.org/licenses/MIT.
  */
 
-export { INVALID_MOVE } from '../src/core/constants';
+export {
+  INVALID_MOVE,
+  Invalid,
+  isInvalidMoveResult,
+} from '../src/core/constants';
+export type { InvalidMoveResult } from '../src/core/constants';
 export { ActivePlayers, TurnOrder, Stage } from '../src/core/turn-order';
 export { GameMethod } from '../src/core/game-methods';
 

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -842,6 +842,73 @@ describe('action errors', () => {
     });
   });
 
+  describe('optimistic self-heal', () => {
+    let sendToClient: (data: TransportData) => void;
+    let requestSync: jest.Mock;
+    let client: ReturnType<typeof Client>;
+
+    beforeEach(() => {
+      const game: Game = {
+        moves: {
+          valid: ({ G }) => G,
+          invalidEverywhere: () => INVALID_MOVE,
+        },
+      };
+      requestSync = jest.fn();
+      client = Client({
+        game,
+        matchID: 'A',
+        debug: false,
+        multiplayer: ({ transportDataCallback }) => {
+          sendToClient = transportDataCallback;
+          return {
+            connect() {},
+            disconnect() {},
+            subscribe() {},
+            subscribeToConnectionStatus() {},
+            requestSync,
+            sendAction() {},
+          } as unknown as Transport;
+        },
+      });
+      client.start();
+      const state = InitializeGame({ game: ProcessGameConfig(game) });
+      sendToClient({ type: 'sync', args: ['A', { state } as SyncInfo] });
+    });
+
+    afterEach(() => {
+      client.stop();
+    });
+
+    test('a rejection while ahead of the master requests a sync', () => {
+      client.moves.valid();
+      const error = { type: ActionErrorType.InvalidMove, payload: undefined };
+      sendToClient({ type: 'actionResult', args: ['A', 1, { error }] });
+      expect(requestSync).toHaveBeenCalledTimes(1);
+      expect(client.lastActionError).toEqual(error);
+
+      const state = InitializeGame({
+        game: ProcessGameConfig({ moves: { valid: ({ G }) => G } }),
+      });
+      sendToClient({ type: 'sync', args: ['A', { state } as SyncInfo] });
+      expect(client.lastActionError).toBeUndefined();
+    });
+
+    test('a rejection with no optimistic lead does not request a sync', () => {
+      client.moves.invalidEverywhere();
+      const error = { type: ActionErrorType.InvalidMove, payload: undefined };
+      sendToClient({ type: 'actionResult', args: ['A', 1, { error }] });
+      expect(requestSync).not.toHaveBeenCalled();
+      expect(client.lastActionError).toEqual(error);
+    });
+
+    test('a successful result does not request a sync', () => {
+      client.moves.valid();
+      sendToClient({ type: 'actionResult', args: ['A', 1, {}] });
+      expect(requestSync).not.toHaveBeenCalled();
+    });
+  });
+
   describe('synchronous transport', () => {
     test('an action result delivered during dispatch is reported once', () => {
       let sendToClient: (data: TransportData) => void;

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -704,6 +704,14 @@ describe('action errors', () => {
         undefined,
       );
     });
+
+    test('a successful undo clears the error', () => {
+      client.moves.valid();
+      client.moves.rejected();
+      expect(client.lastActionError).toBeDefined();
+      client.undo();
+      expect(client.lastActionError).toBeUndefined();
+    });
   });
 
   describe('multiplayer client', () => {
@@ -751,6 +759,42 @@ describe('action errors', () => {
       const error = { type: ActionErrorType.InvalidMove, payload: undefined };
       sendToClient({ type: 'actionError', args: ['B', error] });
       expect(client.lastActionError).toBeUndefined();
+    });
+  });
+
+  describe('synchronous transport', () => {
+    test('an error delivered during dispatch is not cleared', () => {
+      let sendToClient: (data: TransportData) => void;
+      const error = {
+        type: ActionErrorType.InvalidMove,
+        payload: { reason: 'sync' },
+      };
+      const game: Game = { moves: { A: ({ G }) => G } };
+      const client = Client({
+        game,
+        matchID: 'default',
+        debug: false,
+        multiplayer: ({ transportDataCallback }) => {
+          sendToClient = transportDataCallback;
+          return {
+            connect() {},
+            disconnect() {},
+            subscribe() {},
+            subscribeToConnectionStatus() {},
+            requestSync() {},
+            sendAction() {
+              sendToClient({ type: 'actionError', args: ['default', error] });
+            },
+          } as unknown as Transport;
+        },
+      });
+      client.start();
+      // Sync a valid state so the move is accepted (and reaches sendAction).
+      const state = InitializeGame({ game: ProcessGameConfig(game) });
+      sendToClient({ type: 'sync', args: ['default', { state } as SyncInfo] });
+      client.moves.A();
+      expect(client.lastActionError).toEqual(error);
+      client.stop();
     });
   });
 });

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -6,7 +6,8 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { INVALID_MOVE } from '../core/constants';
+import { INVALID_MOVE, Invalid } from '../core/constants';
+import { ActionErrorType } from '../core/errors';
 import { createStore } from 'redux';
 import { CreateGameReducer } from '../core/reducer';
 import { InitializeGame } from '../core/initialize';
@@ -661,6 +662,299 @@ describe('transient handling', () => {
   });
 });
 
+describe('action errors', () => {
+  describe('local client', () => {
+    let client = null;
+    let fn;
+
+    beforeEach(() => {
+      const game: Game = {
+        moves: {
+          valid: ({ G }) => {
+            G.moved = true;
+          },
+          rejected: () => Invalid({ reason: 'not enough gold' }),
+        },
+      };
+      client = Client({ game });
+      fn = jest.fn();
+      client.subscribe(fn);
+      fn.mockClear();
+    });
+
+    test('subscriber receives the error for a rejected move', () => {
+      client.moves.rejected();
+      const expectedError = {
+        type: 'action/invalid_move',
+        payload: { reason: 'not enough gold' },
+      };
+      expect(client.lastActionError).toEqual(expectedError);
+      expect(fn.mock.calls.map(([, error]) => error)).toEqual([expectedError]);
+      expect(fn.mock.calls[0][0]).not.toEqual(
+        expect.objectContaining({ transients: expect.anything() }),
+      );
+    });
+
+    test('a subsequent successful move clears the error', () => {
+      client.moves.rejected();
+      expect(client.lastActionError).toBeDefined();
+      client.moves.valid();
+      expect(client.lastActionError).toBeUndefined();
+      expect(fn).toHaveBeenLastCalledWith(
+        expect.objectContaining({ G: { moved: true } }),
+        undefined,
+      );
+    });
+
+    test('a successful undo clears the error', () => {
+      client.moves.valid();
+      client.moves.rejected();
+      expect(client.lastActionError).toBeDefined();
+      client.undo();
+      expect(client.lastActionError).toBeUndefined();
+    });
+
+    test('reset clears the error', () => {
+      client.moves.rejected();
+      expect(client.lastActionError).toBeDefined();
+      client.reset();
+      expect(client.lastActionError).toBeUndefined();
+    });
+  });
+
+  describe('multiplayer client', () => {
+    let sendToClient: (data: TransportData) => void;
+    let client: ReturnType<typeof Client>;
+
+    beforeEach(() => {
+      const game: Game = { moves: { A: ({ G }) => G } };
+      client = Client({
+        game,
+        matchID: 'A',
+        debug: false,
+        multiplayer: ({ transportDataCallback }) => {
+          sendToClient = transportDataCallback;
+          return {
+            connect() {},
+            disconnect() {},
+            subscribe() {},
+            subscribeToConnectionStatus() {},
+            requestSync() {},
+            sendAction() {},
+          } as unknown as Transport;
+        },
+      });
+      client.start();
+      const state = InitializeGame({ game: ProcessGameConfig(game) });
+      sendToClient({ type: 'sync', args: ['A', { state } as SyncInfo] });
+    });
+
+    afterEach(() => {
+      client.stop();
+    });
+
+    test('action result from the master reaches subscribers', () => {
+      const fn = jest.fn();
+      client.subscribe(fn);
+      fn.mockClear();
+      client.moves.A();
+      const error = {
+        type: ActionErrorType.InvalidMove,
+        payload: { reason: 'slot taken' },
+      };
+      sendToClient({
+        type: 'actionResult',
+        args: ['A', 1, { error }],
+      });
+      expect(client.lastActionError).toEqual(error);
+      expect(fn).toHaveBeenCalledWith(expect.anything(), error);
+    });
+
+    test('action result for another match is ignored', () => {
+      client.moves.A();
+      const error = { type: ActionErrorType.InvalidMove, payload: undefined };
+      sendToClient({
+        type: 'actionResult',
+        args: ['B', 1, { error }],
+      });
+      expect(client.lastActionError).toBeUndefined();
+    });
+
+    test('a successful result clears the previous error', () => {
+      const error = {
+        type: ActionErrorType.InvalidMove,
+        payload: { reason: 'slot taken' },
+      };
+      client.moves.A();
+      sendToClient({
+        type: 'actionResult',
+        args: ['A', 1, { error }],
+      });
+      expect(client.lastActionError).toEqual(error);
+
+      client.moves.A();
+      // Wait for the authoritative success before clearing the error.
+      expect(client.lastActionError).toEqual(error);
+      sendToClient({ type: 'actionResult', args: ['A', 2, {}] });
+      expect(client.lastActionError).toBeUndefined();
+    });
+
+    test('a stale result cannot overwrite a newer action', () => {
+      client.moves.A();
+      client.moves.A();
+      sendToClient({
+        type: 'actionResult',
+        args: [
+          'A',
+          1,
+          {
+            error: {
+              type: ActionErrorType.InvalidMove,
+              payload: { reason: 'stale' },
+            },
+          },
+        ],
+      });
+      expect(client.lastActionError).toBeUndefined();
+    });
+
+    test('sync clears the error and invalidates an in-flight result', () => {
+      const error = {
+        type: ActionErrorType.InvalidMove,
+        payload: { reason: 'slot taken' },
+      };
+      client.moves.A();
+      sendToClient({
+        type: 'actionResult',
+        args: ['A', 1, { error }],
+      });
+      expect(client.lastActionError).toEqual(error);
+
+      const state = client.store.getState();
+      sendToClient({ type: 'sync', args: ['A', { state } as SyncInfo] });
+      expect(client.lastActionError).toBeUndefined();
+
+      sendToClient({
+        type: 'actionResult',
+        args: ['A', 1, { error }],
+      });
+      expect(client.lastActionError).toBeUndefined();
+    });
+  });
+
+  describe('optimistic self-heal', () => {
+    let sendToClient: (data: TransportData) => void;
+    let requestSync: jest.Mock;
+    let client: ReturnType<typeof Client>;
+
+    beforeEach(() => {
+      const game: Game = {
+        moves: {
+          valid: ({ G }) => G,
+          invalidEverywhere: () => INVALID_MOVE,
+        },
+      };
+      requestSync = jest.fn();
+      client = Client({
+        game,
+        matchID: 'A',
+        debug: false,
+        multiplayer: ({ transportDataCallback }) => {
+          sendToClient = transportDataCallback;
+          return {
+            connect() {},
+            disconnect() {},
+            subscribe() {},
+            subscribeToConnectionStatus() {},
+            requestSync,
+            sendAction() {},
+          } as unknown as Transport;
+        },
+      });
+      client.start();
+      const state = InitializeGame({ game: ProcessGameConfig(game) });
+      sendToClient({ type: 'sync', args: ['A', { state } as SyncInfo] });
+    });
+
+    afterEach(() => {
+      client.stop();
+    });
+
+    test('a rejection while ahead of the master requests a sync', () => {
+      client.moves.valid();
+      const error = { type: ActionErrorType.InvalidMove, payload: undefined };
+      sendToClient({ type: 'actionResult', args: ['A', 1, { error }] });
+      expect(requestSync).toHaveBeenCalledTimes(1);
+      expect(client.lastActionError).toEqual(error);
+
+      const state = InitializeGame({
+        game: ProcessGameConfig({ moves: { valid: ({ G }) => G } }),
+      });
+      sendToClient({ type: 'sync', args: ['A', { state } as SyncInfo] });
+      expect(client.lastActionError).toBeUndefined();
+    });
+
+    test('a rejection with no optimistic lead does not request a sync', () => {
+      client.moves.invalidEverywhere();
+      const error = { type: ActionErrorType.InvalidMove, payload: undefined };
+      sendToClient({ type: 'actionResult', args: ['A', 1, { error }] });
+      expect(requestSync).not.toHaveBeenCalled();
+      expect(client.lastActionError).toEqual(error);
+    });
+
+    test('a successful result does not request a sync', () => {
+      client.moves.valid();
+      sendToClient({ type: 'actionResult', args: ['A', 1, {}] });
+      expect(requestSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('synchronous transport', () => {
+    test('an action result delivered during dispatch is reported once', () => {
+      let sendToClient: (data: TransportData) => void;
+      const error = {
+        type: ActionErrorType.InvalidMove,
+        payload: { reason: 'sync' },
+      };
+      const game: Game = { moves: { A: ({ G }) => G } };
+      const client = Client({
+        game,
+        matchID: 'default',
+        debug: false,
+        multiplayer: ({ transportDataCallback }) => {
+          sendToClient = transportDataCallback;
+          return {
+            connect() {},
+            disconnect() {},
+            subscribe() {},
+            subscribeToConnectionStatus() {},
+            requestSync() {},
+            sendAction(_state, _action, actionID) {
+              sendToClient({
+                type: 'actionResult',
+                args: ['default', actionID, { error }],
+              });
+            },
+          } as unknown as Transport;
+        },
+      });
+      client.start();
+      // Sync a valid state so the move is accepted (and reaches sendAction).
+      const state = InitializeGame({ game: ProcessGameConfig(game) });
+      sendToClient({ type: 'sync', args: ['default', { state } as SyncInfo] });
+      const fn = jest.fn();
+      client.subscribe(fn);
+      fn.mockClear();
+      client.moves.A();
+      expect(client.lastActionError).toEqual(error);
+      expect(fn.mock.calls.map(([, receivedError]) => receivedError)).toEqual([
+        error,
+      ]);
+      client.stop();
+    });
+  });
+});
+
 describe('log handling', () => {
   let client = null;
 
@@ -802,6 +1096,7 @@ describe('subscribe', () => {
         G: {},
         ctx: expect.objectContaining({ turn: 1 }),
       }),
+      undefined,
     );
   });
 
@@ -812,6 +1107,7 @@ describe('subscribe', () => {
       expect.objectContaining({
         G: { moved: true },
       }),
+      undefined,
     );
   });
 
@@ -822,6 +1118,7 @@ describe('subscribe', () => {
       expect.objectContaining({
         ctx: expect.objectContaining({ turn: 2 }),
       }),
+      undefined,
     );
   });
 
@@ -837,6 +1134,7 @@ describe('subscribe', () => {
       expect.objectContaining({
         G: { moved: true },
       }),
+      undefined,
     );
 
     fn.mockClear();
@@ -849,11 +1147,13 @@ describe('subscribe', () => {
       expect.objectContaining({
         G: { moved: true },
       }),
+      undefined,
     );
     expect(fn2).toHaveBeenCalledWith(
       expect.objectContaining({
         G: { moved: true },
       }),
+      undefined,
     );
 
     unsubscribe();
@@ -867,6 +1167,7 @@ describe('subscribe', () => {
       expect.objectContaining({
         G: { moved: true },
       }),
+      undefined,
     );
     expect(fn2).not.toHaveBeenCalled();
   });

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -684,18 +684,15 @@ describe('action errors', () => {
 
     test('subscriber receives the error for a rejected move', () => {
       client.moves.rejected();
-      expect(client.lastActionError).toEqual({
+      const expectedError = {
         type: 'action/invalid_move',
         payload: { reason: 'not enough gold' },
-      });
-      expect(fn).toHaveBeenCalledWith(expect.anything(), {
-        type: 'action/invalid_move',
-        payload: { reason: 'not enough gold' },
-      });
-      const errorNotifications = fn.mock.calls.filter(
-        ([, error]) => error !== undefined,
+      };
+      expect(client.lastActionError).toEqual(expectedError);
+      expect(fn.mock.calls.map(([, error]) => error)).toEqual([expectedError]);
+      expect(fn.mock.calls[0][0]).not.toEqual(
+        expect.objectContaining({ transients: expect.anything() }),
       );
-      expect(errorNotifications).toHaveLength(1);
     });
 
     test('a subsequent successful move clears the error', () => {
@@ -714,6 +711,13 @@ describe('action errors', () => {
       client.moves.rejected();
       expect(client.lastActionError).toBeDefined();
       client.undo();
+      expect(client.lastActionError).toBeUndefined();
+    });
+
+    test('reset clears the error', () => {
+      client.moves.rejected();
+      expect(client.lastActionError).toBeDefined();
+      client.reset();
       expect(client.lastActionError).toBeUndefined();
     });
   });
@@ -813,6 +817,29 @@ describe('action errors', () => {
       });
       expect(client.lastActionError).toBeUndefined();
     });
+
+    test('sync clears the error and invalidates an in-flight result', () => {
+      const error = {
+        type: ActionErrorType.InvalidMove,
+        payload: { reason: 'slot taken' },
+      };
+      client.moves.A();
+      sendToClient({
+        type: 'actionResult',
+        args: ['A', 1, { error }],
+      });
+      expect(client.lastActionError).toEqual(error);
+
+      const state = client.store.getState();
+      sendToClient({ type: 'sync', args: ['A', { state } as SyncInfo] });
+      expect(client.lastActionError).toBeUndefined();
+
+      sendToClient({
+        type: 'actionResult',
+        args: ['A', 1, { error }],
+      });
+      expect(client.lastActionError).toBeUndefined();
+    });
   });
 
   describe('synchronous transport', () => {
@@ -853,10 +880,9 @@ describe('action errors', () => {
       fn.mockClear();
       client.moves.A();
       expect(client.lastActionError).toEqual(error);
-      const errorNotifications = fn.mock.calls.filter(
-        ([, receivedError]) => receivedError !== undefined,
-      );
-      expect(errorNotifications).toHaveLength(1);
+      expect(fn.mock.calls.map(([, receivedError]) => receivedError)).toEqual([
+        error,
+      ]);
       client.stop();
     });
   });

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -692,6 +692,10 @@ describe('action errors', () => {
         type: 'action/invalid_move',
         payload: { reason: 'not enough gold' },
       });
+      const errorNotifications = fn.mock.calls.filter(
+        ([, error]) => error !== undefined,
+      );
+      expect(errorNotifications).toHaveLength(1);
     });
 
     test('a subsequent successful move clears the error', () => {
@@ -719,8 +723,9 @@ describe('action errors', () => {
     let client: ReturnType<typeof Client>;
 
     beforeEach(() => {
+      const game: Game = { moves: { A: ({ G }) => G } };
       client = Client({
-        game: {},
+        game,
         matchID: 'A',
         debug: false,
         multiplayer: ({ transportDataCallback }) => {
@@ -731,39 +736,87 @@ describe('action errors', () => {
             subscribe() {},
             subscribeToConnectionStatus() {},
             requestSync() {},
+            sendAction() {},
           } as unknown as Transport;
         },
       });
       client.start();
+      const state = InitializeGame({ game: ProcessGameConfig(game) });
+      sendToClient({ type: 'sync', args: ['A', { state } as SyncInfo] });
     });
 
     afterEach(() => {
       client.stop();
     });
 
-    test('actionError from the master reaches subscribers', () => {
+    test('action result from the master reaches subscribers', () => {
       const fn = jest.fn();
       client.subscribe(fn);
       fn.mockClear();
+      client.moves.A();
       const error = {
         type: ActionErrorType.InvalidMove,
         payload: { reason: 'slot taken' },
       };
-      sendToClient({ type: 'actionError', args: ['A', error] });
+      sendToClient({
+        type: 'actionResult',
+        args: ['A', 1, { error }],
+      });
       expect(client.lastActionError).toEqual(error);
-      // State is null here because this stub transport never syncs.
-      expect(fn).toHaveBeenCalledWith(null, error);
+      expect(fn).toHaveBeenCalledWith(expect.anything(), error);
     });
 
-    test('actionError for another match is ignored', () => {
+    test('action result for another match is ignored', () => {
+      client.moves.A();
       const error = { type: ActionErrorType.InvalidMove, payload: undefined };
-      sendToClient({ type: 'actionError', args: ['B', error] });
+      sendToClient({
+        type: 'actionResult',
+        args: ['B', 1, { error }],
+      });
+      expect(client.lastActionError).toBeUndefined();
+    });
+
+    test('a successful result clears the previous error', () => {
+      const error = {
+        type: ActionErrorType.InvalidMove,
+        payload: { reason: 'slot taken' },
+      };
+      client.moves.A();
+      sendToClient({
+        type: 'actionResult',
+        args: ['A', 1, { error }],
+      });
+      expect(client.lastActionError).toEqual(error);
+
+      client.moves.A();
+      // Wait for the authoritative success before clearing the error.
+      expect(client.lastActionError).toEqual(error);
+      sendToClient({ type: 'actionResult', args: ['A', 2, {}] });
+      expect(client.lastActionError).toBeUndefined();
+    });
+
+    test('a stale result cannot overwrite a newer action', () => {
+      client.moves.A();
+      client.moves.A();
+      sendToClient({
+        type: 'actionResult',
+        args: [
+          'A',
+          1,
+          {
+            error: {
+              type: ActionErrorType.InvalidMove,
+              payload: { reason: 'stale' },
+            },
+          },
+        ],
+      });
       expect(client.lastActionError).toBeUndefined();
     });
   });
 
   describe('synchronous transport', () => {
-    test('an error delivered during dispatch is not cleared', () => {
+    test('an action result delivered during dispatch is reported once', () => {
       let sendToClient: (data: TransportData) => void;
       const error = {
         type: ActionErrorType.InvalidMove,
@@ -782,8 +835,11 @@ describe('action errors', () => {
             subscribe() {},
             subscribeToConnectionStatus() {},
             requestSync() {},
-            sendAction() {
-              sendToClient({ type: 'actionError', args: ['default', error] });
+            sendAction(_state, _action, actionID) {
+              sendToClient({
+                type: 'actionResult',
+                args: ['default', actionID, { error }],
+              });
             },
           } as unknown as Transport;
         },
@@ -792,8 +848,15 @@ describe('action errors', () => {
       // Sync a valid state so the move is accepted (and reaches sendAction).
       const state = InitializeGame({ game: ProcessGameConfig(game) });
       sendToClient({ type: 'sync', args: ['default', { state } as SyncInfo] });
+      const fn = jest.fn();
+      client.subscribe(fn);
+      fn.mockClear();
       client.moves.A();
       expect(client.lastActionError).toEqual(error);
+      const errorNotifications = fn.mock.calls.filter(
+        ([, receivedError]) => receivedError !== undefined,
+      );
+      expect(errorNotifications).toHaveLength(1);
       client.stop();
     });
   });

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -6,7 +6,8 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { INVALID_MOVE } from '../core/constants';
+import { INVALID_MOVE, Invalid } from '../core/constants';
+import { ActionErrorType } from '../core/errors';
 import { createStore } from 'redux';
 import { CreateGameReducer } from '../core/reducer';
 import { InitializeGame } from '../core/initialize';
@@ -661,6 +662,99 @@ describe('transient handling', () => {
   });
 });
 
+describe('action errors', () => {
+  describe('local client', () => {
+    let client = null;
+    let fn;
+
+    beforeEach(() => {
+      const game: Game = {
+        moves: {
+          valid: ({ G }) => {
+            G.moved = true;
+          },
+          rejected: () => Invalid({ reason: 'not enough gold' }),
+        },
+      };
+      client = Client({ game });
+      fn = jest.fn();
+      client.subscribe(fn);
+      fn.mockClear();
+    });
+
+    test('subscriber receives the error for a rejected move', () => {
+      client.moves.rejected();
+      expect(client.lastActionError).toEqual({
+        type: 'action/invalid_move',
+        payload: { reason: 'not enough gold' },
+      });
+      expect(fn).toHaveBeenCalledWith(expect.anything(), {
+        type: 'action/invalid_move',
+        payload: { reason: 'not enough gold' },
+      });
+    });
+
+    test('a subsequent successful move clears the error', () => {
+      client.moves.rejected();
+      expect(client.lastActionError).toBeDefined();
+      client.moves.valid();
+      expect(client.lastActionError).toBeUndefined();
+      expect(fn).toHaveBeenLastCalledWith(
+        expect.objectContaining({ G: { moved: true } }),
+        undefined,
+      );
+    });
+  });
+
+  describe('multiplayer client', () => {
+    let sendToClient: (data: TransportData) => void;
+    let client: ReturnType<typeof Client>;
+
+    beforeEach(() => {
+      client = Client({
+        game: {},
+        matchID: 'A',
+        debug: false,
+        multiplayer: ({ transportDataCallback }) => {
+          sendToClient = transportDataCallback;
+          return {
+            connect() {},
+            disconnect() {},
+            subscribe() {},
+            subscribeToConnectionStatus() {},
+            requestSync() {},
+          } as unknown as Transport;
+        },
+      });
+      client.start();
+    });
+
+    afterEach(() => {
+      client.stop();
+    });
+
+    test('actionError from the master reaches subscribers', () => {
+      const fn = jest.fn();
+      client.subscribe(fn);
+      fn.mockClear();
+      const error = {
+        type: ActionErrorType.InvalidMove,
+        payload: { reason: 'slot taken' },
+      };
+      sendToClient({ type: 'actionError', args: ['A', error] });
+      expect(client.lastActionError).toEqual(error);
+      // State is null here because this stub transport never syncs.
+      expect(fn).toHaveBeenCalledWith(null, error);
+    });
+
+    test('actionError for another match is ignored', () => {
+      const error = { type: ActionErrorType.InvalidMove, payload: undefined };
+      sendToClient({ type: 'actionError', args: ['B', error] });
+      expect(client.lastActionError).toBeUndefined();
+    });
+  });
+});
+
 describe('log handling', () => {
   let client = null;
 
@@ -802,6 +896,7 @@ describe('subscribe', () => {
         G: {},
         ctx: expect.objectContaining({ turn: 1 }),
       }),
+      undefined,
     );
   });
 
@@ -812,6 +907,7 @@ describe('subscribe', () => {
       expect.objectContaining({
         G: { moved: true },
       }),
+      undefined,
     );
   });
 
@@ -822,6 +918,7 @@ describe('subscribe', () => {
       expect.objectContaining({
         ctx: expect.objectContaining({ turn: 2 }),
       }),
+      undefined,
     );
   });
 
@@ -837,6 +934,7 @@ describe('subscribe', () => {
       expect.objectContaining({
         G: { moved: true },
       }),
+      undefined,
     );
 
     fn.mockClear();
@@ -849,11 +947,13 @@ describe('subscribe', () => {
       expect.objectContaining({
         G: { moved: true },
       }),
+      undefined,
     );
     expect(fn2).toHaveBeenCalledWith(
       expect.objectContaining({
         G: { moved: true },
       }),
+      undefined,
     );
 
     unsubscribe();
@@ -867,6 +967,7 @@ describe('subscribe', () => {
       expect.objectContaining({
         G: { moved: true },
       }),
+      undefined,
     );
     expect(fn2).not.toHaveBeenCalled();
   });

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -727,7 +727,9 @@ describe('action errors', () => {
     let client: ReturnType<typeof Client>;
 
     beforeEach(() => {
-      const game: Game = { moves: { A: ({ G }) => G } };
+      const game: Game = {
+        moves: { A: ({ G }) => G, invalidEverywhere: () => INVALID_MOVE },
+      };
       client = Client({
         game,
         matchID: 'A',
@@ -767,7 +769,11 @@ describe('action errors', () => {
         args: ['A', 1, { error }],
       });
       expect(client.lastActionError).toEqual(error);
-      expect(fn).toHaveBeenCalledWith(expect.anything(), error);
+      // Strict, so a duplicate delivery of the same error fails the test.
+      expect(fn.mock.calls.map(([, receivedError]) => receivedError)).toEqual([
+        undefined,
+        error,
+      ]);
     });
 
     test('action result for another match is ignored', () => {
@@ -818,12 +824,14 @@ describe('action errors', () => {
       expect(client.lastActionError).toBeUndefined();
     });
 
-    test('sync clears the error and invalidates an in-flight result', () => {
+    test('an unsolicited sync clears the error and invalidates an in-flight result', () => {
       const error = {
         type: ActionErrorType.InvalidMove,
         payload: { reason: 'slot taken' },
       };
-      client.moves.A();
+      // Rejected locally too, so the client never runs ahead of the master and
+      // never asks for a repair sync: the sync below is unsolicited.
+      client.moves.invalidEverywhere();
       sendToClient({
         type: 'actionResult',
         args: ['A', 1, { error }],
@@ -886,12 +894,70 @@ describe('action errors', () => {
       sendToClient({ type: 'actionResult', args: ['A', 1, { error }] });
       expect(requestSync).toHaveBeenCalledTimes(1);
       expect(client.lastActionError).toEqual(error);
+    });
+
+    test('the repair sync keeps the rejection that requested it', () => {
+      const fn = jest.fn();
+      client.subscribe(fn);
+      client.moves.valid();
+      const error = { type: ActionErrorType.InvalidMove, payload: undefined };
+      sendToClient({ type: 'actionResult', args: ['A', 1, { error }] });
 
       const state = InitializeGame({
         game: ProcessGameConfig({ moves: { valid: ({ G }) => G } }),
       });
       sendToClient({ type: 'sync', args: ['A', { state } as SyncInfo] });
+      // The repair rolls the optimistic move back, but the player still needs
+      // to be told why it went away.
+      expect(client.store.getState()._stateID).toBe(0);
+      expect(client.lastActionError).toEqual(error);
+      expect(
+        fn.mock.calls.filter(([, receivedError]) => receivedError),
+      ).toEqual([[expect.anything(), error]]);
+    });
+
+    test('a later unsolicited sync clears a healed rejection', () => {
+      client.moves.valid();
+      const error = { type: ActionErrorType.InvalidMove, payload: undefined };
+      sendToClient({ type: 'actionResult', args: ['A', 1, { error }] });
+
+      const state = InitializeGame({
+        game: ProcessGameConfig({ moves: { valid: ({ G }) => G } }),
+      });
+      // The first sync is the repair and preserves the error; a second one is
+      // a fresh baseline, e.g. after a reconnect.
+      sendToClient({ type: 'sync', args: ['A', { state } as SyncInfo] });
+      sendToClient({ type: 'sync', args: ['A', { state } as SyncInfo] });
       expect(client.lastActionError).toBeUndefined();
+    });
+
+    test('a move sent while the repair sync is in flight still reports', () => {
+      const fn = jest.fn();
+      client.subscribe(fn);
+      client.moves.valid();
+      const first = {
+        type: ActionErrorType.InvalidMove,
+        payload: { reason: 'first' },
+      };
+      sendToClient({ type: 'actionResult', args: ['A', 1, { error: first }] });
+
+      // The player acts again before the repair sync lands. Channels are FIFO,
+      // so the sync arrives ahead of the second action's result.
+      client.moves.valid();
+      const state = InitializeGame({
+        game: ProcessGameConfig({ moves: { valid: ({ G }) => G } }),
+      });
+      sendToClient({ type: 'sync', args: ['A', { state } as SyncInfo] });
+
+      const second = {
+        type: ActionErrorType.InvalidMove,
+        payload: { reason: 'second' },
+      };
+      sendToClient({ type: 'actionResult', args: ['A', 2, { error: second }] });
+      expect(client.lastActionError).toEqual(second);
+      expect(
+        fn.mock.calls.map(([, receivedError]) => receivedError).filter(Boolean),
+      ).toEqual([first, second]);
     });
 
     test('a rejection with no optimistic lead does not request a sync', () => {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -175,11 +175,12 @@ export class _ClientImpl<
   chatMessages: ChatMessage[];
   /**
    * Why this client’s most recent action was rejected, or undefined.
-   * Cleared when a subsequent action succeeds.
+   * Cleared when a subsequent action succeeds, or on reset / sync.
    */
   lastActionError?: ActionError;
   private nextActionID = 0;
   private latestActionID?: number;
+  private actionResultDeliveries = 0;
 
   constructor({
     game,
@@ -316,16 +317,33 @@ export class _ClientImpl<
      * Single-player clients read action errors directly from reducer
      * transients. Multiplayer clients wait for the master's correlated result.
      */
+    let pendingActionError: ActionError | undefined;
     const SubscriptionMiddleware =
       (store: Store) => (next: Dispatch<Action>) => (action: Action) => {
+        const deliveriesBefore = this.actionResultDeliveries;
         const result = next(action);
-        let actionError: ActionError | undefined;
-        if (!this.multiplayer && action.type !== Actions.STRIP_TRANSIENTS) {
+
+        // Notify after transient metadata has been stripped, so subscribers
+        // receive one rejection event paired with clean public state.
+        if (action.type === Actions.STRIP_TRANSIENTS) {
+          const actionError = pendingActionError;
+          pendingActionError = undefined;
+          if (actionError) this.notifySubscribers(actionError);
+          return result;
+        }
+
+        if (action.type === Actions.RESET) {
+          this.lastActionError = undefined;
+          this.latestActionID = undefined;
+        }
+
+        if (!this.multiplayer) {
           const transientError = (store.getState() as TransientState<G> | null)
             ?.transients?.error;
           if (transientError) {
             this.lastActionError = transientError;
-            actionError = transientError;
+            pendingActionError = transientError;
+            return result;
           } else if (
             action.type === Actions.MAKE_MOVE ||
             action.type === Actions.GAME_EVENT ||
@@ -335,7 +353,8 @@ export class _ClientImpl<
             this.lastActionError = undefined;
           }
         }
-        this.notifySubscribers(actionError);
+        if (this.actionResultDeliveries !== deliveriesBefore) return result;
+        this.notifySubscribers();
         return result;
       };
 
@@ -390,7 +409,10 @@ export class _ClientImpl<
 
   /** Handle the authoritative result of an action sent to the master. */
   private receiveActionResult(actionID: number, error?: ActionError): void {
+    // Only the latest submitted action owns lastActionError. Older results are
+    // stale once the player has attempted another action.
     if (actionID !== this.latestActionID) return;
+    this.actionResultDeliveries++;
     this.lastActionError = error;
     this.notifySubscribers(error);
   }
@@ -401,6 +423,10 @@ export class _ClientImpl<
     if (matchID !== this.matchID) return;
     switch (data.type) {
       case 'sync': {
+        // Transient errors are not persisted by the master. A sync establishes
+        // a fresh authoritative baseline and invalidates any in-flight result.
+        this.lastActionError = undefined;
+        this.latestActionID = undefined;
         const [, syncInfo] = data.args;
         const action = ActionCreators.sync(syncInfo);
         this.receiveMatchData(syncInfo.filteredMetadata);

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -181,6 +181,7 @@ export class _ClientImpl<
   private nextActionID = 0;
   private latestActionID?: number;
   private actionResultDeliveries = 0;
+  private latestAuthoritativeStateID = -1;
 
   constructor({
     game,
@@ -415,6 +416,14 @@ export class _ClientImpl<
     this.actionResultDeliveries++;
     this.lastActionError = error;
     this.notifySubscribers(error);
+    // Broadcasts older than the optimistic state are ignored, so a rejected
+    // optimistic move can only be rolled back by an explicit resync.
+    if (
+      error &&
+      this.store.getState()._stateID > this.latestAuthoritativeStateID
+    ) {
+      this.transport.requestSync();
+    }
   }
 
   /** Handle all incoming updates from a multiplayer transport. */
@@ -428,6 +437,7 @@ export class _ClientImpl<
         this.lastActionError = undefined;
         this.latestActionID = undefined;
         const [, syncInfo] = data.args;
+        this.latestAuthoritativeStateID = syncInfo.state._stateID;
         const action = ActionCreators.sync(syncInfo);
         this.receiveMatchData(syncInfo.filteredMetadata);
         this.store.dispatch(action);
@@ -435,6 +445,10 @@ export class _ClientImpl<
       }
       case 'update': {
         const [, state, deltalog] = data.args;
+        this.latestAuthoritativeStateID = Math.max(
+          this.latestAuthoritativeStateID,
+          state._stateID,
+        );
         const currentState = this.store.getState();
         if (state._stateID >= currentState._stateID) {
           const action = ActionCreators.update(state, deltalog);
@@ -444,6 +458,10 @@ export class _ClientImpl<
       }
       case 'patch': {
         const [, prevStateID, stateID, patch, deltalog] = data.args;
+        this.latestAuthoritativeStateID = Math.max(
+          this.latestAuthoritativeStateID,
+          stateID,
+        );
         const currentStateID = this.store.getState()._stateID;
         if (prevStateID !== currentStateID) break;
         const action = ActionCreators.patch(

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -178,12 +178,8 @@ export class _ClientImpl<
    * Cleared when a subsequent action succeeds.
    */
   lastActionError?: ActionError;
-  /**
-   * Count of action errors delivered via receiveActionError. Lets
-   * SubscriptionMiddleware detect a rejection that a synchronous transport
-   * delivered during `next(action)` and avoid clearing it on the same pass.
-   */
-  private actionErrorDeliveries = 0;
+  private nextActionID = 0;
+  private latestActionID?: number;
 
   constructor({
     game,
@@ -300,13 +296,16 @@ export class _ClientImpl<
     const TransportMiddleware =
       (store: Store) => (next: Dispatch<Action>) => (action: Action) => {
         const baseState = store.getState();
+        const shouldSend =
+          !('clientOnly' in action) && action.type !== Actions.STRIP_TRANSIENTS;
+        const actionID =
+          shouldSend && this.multiplayer
+            ? (this.latestActionID = ++this.nextActionID)
+            : undefined;
         const result = next(action);
 
-        if (
-          !('clientOnly' in action) &&
-          action.type !== Actions.STRIP_TRANSIENTS
-        ) {
-          this.transport.sendAction(baseState, action);
+        if (shouldSend) {
+          this.transport.sendAction(baseState, action, actionID);
         }
 
         return result;
@@ -314,31 +313,29 @@ export class _ClientImpl<
 
     /**
      * Middleware that intercepts actions and invokes the subscription callback.
-     * Also tracks action errors: the store still holds this action's transients
-     * here (TransientHandlingMiddleware strips them after we run), and the
-     * deliveries counter keeps the clear-on-success branch from wiping an
-     * error that a synchronous transport delivered during `next(action)`.
+     * Single-player clients read action errors directly from reducer
+     * transients. Multiplayer clients wait for the master's correlated result.
      */
     const SubscriptionMiddleware =
       (store: Store) => (next: Dispatch<Action>) => (action: Action) => {
-        const deliveriesBefore = this.actionErrorDeliveries;
         const result = next(action);
-        if (action.type !== Actions.STRIP_TRANSIENTS) {
+        let actionError: ActionError | undefined;
+        if (!this.multiplayer && action.type !== Actions.STRIP_TRANSIENTS) {
           const transientError = (store.getState() as TransientState<G> | null)
             ?.transients?.error;
           if (transientError) {
             this.lastActionError = transientError;
+            actionError = transientError;
           } else if (
-            (action.type === Actions.MAKE_MOVE ||
-              action.type === Actions.GAME_EVENT ||
-              action.type === Actions.UNDO ||
-              action.type === Actions.REDO) &&
-            this.actionErrorDeliveries === deliveriesBefore
+            action.type === Actions.MAKE_MOVE ||
+            action.type === Actions.GAME_EVENT ||
+            action.type === Actions.UNDO ||
+            action.type === Actions.REDO
           ) {
             this.lastActionError = undefined;
           }
         }
-        this.notifySubscribers();
+        this.notifySubscribers(actionError);
         return result;
       };
 
@@ -391,11 +388,11 @@ export class _ClientImpl<
     this.notifySubscribers();
   }
 
-  /** Handle an action error sent to this client by a multiplayer master. */
-  private receiveActionError(error: ActionError): void {
-    this.actionErrorDeliveries++;
+  /** Handle the authoritative result of an action sent to the master. */
+  private receiveActionResult(actionID: number, error?: ActionError): void {
+    if (actionID !== this.latestActionID) return;
     this.lastActionError = error;
-    this.notifySubscribers();
+    this.notifySubscribers(error);
   }
 
   /** Handle all incoming updates from a multiplayer transport. */
@@ -446,16 +443,16 @@ export class _ClientImpl<
         this.receiveChatMessage(chatMessage);
         break;
       }
-      case 'actionError': {
-        const [, error] = data.args;
-        this.receiveActionError(error);
+      case 'actionResult': {
+        const [, actionID, result] = data.args;
+        this.receiveActionResult(actionID, result.error);
         break;
       }
     }
   }
 
-  private notifySubscribers() {
-    this.subscribers.forEach((fn) => fn(this.getState(), this.lastActionError));
+  private notifySubscribers(actionError?: ActionError) {
+    this.subscribers.forEach((fn) => fn(this.getState(), actionError));
   }
 
   previewState(state: any) {
@@ -498,7 +495,7 @@ export class _ClientImpl<
     this.transport.subscribeToConnectionStatus(() => this.notifySubscribers());
 
     if (this._running || !this.multiplayer) {
-      fn(this.getState(), this.lastActionError);
+      fn(this.getState(), undefined);
     }
 
     // Return a handle that allows the caller to unsubscribe.

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -174,11 +174,16 @@ export class _ClientImpl<
   sendChatMessage: (message: any) => void;
   chatMessages: ChatMessage[];
   /**
-   * The most recent action error affecting this client, or undefined.
-   * Set when one of this client’s actions is rejected (locally or by
-   * the master) and cleared when a subsequent action succeeds.
+   * Why this client’s most recent action was rejected, or undefined.
+   * Cleared when a subsequent action succeeds.
    */
   lastActionError?: ActionError;
+  /**
+   * Count of action errors delivered via receiveActionError. Lets
+   * SubscriptionMiddleware detect a rejection that a synchronous transport
+   * delivered during `next(action)` and avoid clearing it on the same pass.
+   */
+  private actionErrorDeliveries = 0;
 
   constructor({
     game,
@@ -309,13 +314,14 @@ export class _ClientImpl<
 
     /**
      * Middleware that intercepts actions and invokes the subscription callback.
-     * Also tracks action errors: TransientHandlingMiddleware runs outside this
-     * middleware, so when we are notified the store still holds any transients
-     * produced by the action. A player action that produces an error records
-     * it; one that succeeds clears it. STRIP_TRANSIENTS passes are neutral.
+     * Also tracks action errors: the store still holds this action's transients
+     * here (TransientHandlingMiddleware strips them after we run), and the
+     * deliveries counter keeps the clear-on-success branch from wiping an
+     * error that a synchronous transport delivered during `next(action)`.
      */
     const SubscriptionMiddleware =
       (store: Store) => (next: Dispatch<Action>) => (action: Action) => {
+        const deliveriesBefore = this.actionErrorDeliveries;
         const result = next(action);
         if (action.type !== Actions.STRIP_TRANSIENTS) {
           const transientError = (store.getState() as TransientState<G> | null)
@@ -323,8 +329,11 @@ export class _ClientImpl<
           if (transientError) {
             this.lastActionError = transientError;
           } else if (
-            action.type === Actions.MAKE_MOVE ||
-            action.type === Actions.GAME_EVENT
+            (action.type === Actions.MAKE_MOVE ||
+              action.type === Actions.GAME_EVENT ||
+              action.type === Actions.UNDO ||
+              action.type === Actions.REDO) &&
+            this.actionErrorDeliveries === deliveriesBefore
           ) {
             this.lastActionError = undefined;
           }
@@ -384,6 +393,7 @@ export class _ClientImpl<
 
   /** Handle an action error sent to this client by a multiplayer master. */
   private receiveActionError(error: ActionError): void {
+    this.actionErrorDeliveries++;
     this.lastActionError = error;
     this.notifySubscribers();
   }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -24,6 +24,7 @@ import { DummyTransport } from './transport/dummy';
 import { ClientManager } from './manager';
 import type { TransportData } from '../master/master';
 import type {
+  ActionError,
   ActivePlayersArg,
   ActionShape,
   CredentialedActionShape,
@@ -34,6 +35,7 @@ import type {
   Reducer,
   State,
   Store,
+  TransientState,
   ChatMessage,
 } from '../types';
 
@@ -141,7 +143,10 @@ export class _ClientImpl<
   readonly multiplayer: (opts: TransportOpts) => Transport;
   private reducer: Reducer;
   private _running: boolean;
-  private subscribers: Map<symbol, (state: State<G> | null) => void>;
+  private subscribers: Map<
+    symbol,
+    (state: State<G> | null, error?: ActionError) => void
+  >;
   private transport: Transport;
   private manager: ClientManager;
   readonly debugOpt?: DebugOpt | boolean;
@@ -168,6 +173,12 @@ export class _ClientImpl<
   redo: () => void;
   sendChatMessage: (message: any) => void;
   chatMessages: ChatMessage[];
+  /**
+   * The most recent action error affecting this client, or undefined.
+   * Set when one of this client’s actions is rejected (locally or by
+   * the master) and cleared when a subsequent action succeeds.
+   */
+  lastActionError?: ActionError;
 
   constructor({
     game,
@@ -298,10 +309,26 @@ export class _ClientImpl<
 
     /**
      * Middleware that intercepts actions and invokes the subscription callback.
+     * Also tracks action errors: TransientHandlingMiddleware runs outside this
+     * middleware, so when we are notified the store still holds any transients
+     * produced by the action. A player action that produces an error records
+     * it; one that succeeds clears it. STRIP_TRANSIENTS passes are neutral.
      */
     const SubscriptionMiddleware =
-      () => (next: Dispatch<Action>) => (action: Action) => {
+      (store: Store) => (next: Dispatch<Action>) => (action: Action) => {
         const result = next(action);
+        if (action.type !== Actions.STRIP_TRANSIENTS) {
+          const transientError = (store.getState() as TransientState<G> | null)
+            ?.transients?.error;
+          if (transientError) {
+            this.lastActionError = transientError;
+          } else if (
+            action.type === Actions.MAKE_MOVE ||
+            action.type === Actions.GAME_EVENT
+          ) {
+            this.lastActionError = undefined;
+          }
+        }
         this.notifySubscribers();
         return result;
       };
@@ -355,6 +382,12 @@ export class _ClientImpl<
     this.notifySubscribers();
   }
 
+  /** Handle an action error sent to this client by a multiplayer master. */
+  private receiveActionError(error: ActionError): void {
+    this.lastActionError = error;
+    this.notifySubscribers();
+  }
+
   /** Handle all incoming updates from a multiplayer transport. */
   private receiveTransportData(data: TransportData): void {
     const [matchID] = data.args;
@@ -403,11 +436,16 @@ export class _ClientImpl<
         this.receiveChatMessage(chatMessage);
         break;
       }
+      case 'actionError': {
+        const [, error] = data.args;
+        this.receiveActionError(error);
+        break;
+      }
     }
   }
 
   private notifySubscribers() {
-    this.subscribers.forEach((fn) => fn(this.getState()));
+    this.subscribers.forEach((fn) => fn(this.getState(), this.lastActionError));
   }
 
   previewState(state: any) {
@@ -444,13 +482,13 @@ export class _ClientImpl<
     this.manager.unregister(this);
   }
 
-  subscribe(fn: (state: ClientState<G>) => void) {
+  subscribe(fn: (state: ClientState<G>, error?: ActionError) => void) {
     const id = Symbol();
     this.subscribers.set(id, fn);
     this.transport.subscribeToConnectionStatus(() => this.notifySubscribers());
 
     if (this._running || !this.multiplayer) {
-      fn(this.getState());
+      fn(this.getState(), this.lastActionError);
     }
 
     // Return a handle that allows the caller to unsubscribe.

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -24,6 +24,7 @@ import { DummyTransport } from './transport/dummy';
 import { ClientManager } from './manager';
 import type { TransportData } from '../master/master';
 import type {
+  ActionError,
   ActivePlayersArg,
   ActionShape,
   CredentialedActionShape,
@@ -34,6 +35,7 @@ import type {
   Reducer,
   State,
   Store,
+  TransientState,
   ChatMessage,
 } from '../types';
 
@@ -141,7 +143,10 @@ export class _ClientImpl<
   readonly multiplayer: (opts: TransportOpts) => Transport;
   private reducer: Reducer;
   private _running: boolean;
-  private subscribers: Map<symbol, (state: State<G> | null) => void>;
+  private subscribers: Map<
+    symbol,
+    (state: State<G> | null, error?: ActionError) => void
+  >;
   private transport: Transport;
   private manager: ClientManager;
   readonly debugOpt?: DebugOpt | boolean;
@@ -168,6 +173,15 @@ export class _ClientImpl<
   redo: () => void;
   sendChatMessage: (message: any) => void;
   chatMessages: ChatMessage[];
+  /**
+   * Why this client’s most recent action was rejected, or undefined.
+   * Cleared when a subsequent action succeeds, or on reset / sync.
+   */
+  lastActionError?: ActionError;
+  private nextActionID = 0;
+  private latestActionID?: number;
+  private actionResultDeliveries = 0;
+  private latestAuthoritativeStateID = -1;
 
   constructor({
     game,
@@ -284,13 +298,16 @@ export class _ClientImpl<
     const TransportMiddleware =
       (store: Store) => (next: Dispatch<Action>) => (action: Action) => {
         const baseState = store.getState();
+        const shouldSend =
+          !('clientOnly' in action) && action.type !== Actions.STRIP_TRANSIENTS;
+        const actionID =
+          shouldSend && this.multiplayer
+            ? (this.latestActionID = ++this.nextActionID)
+            : undefined;
         const result = next(action);
 
-        if (
-          !('clientOnly' in action) &&
-          action.type !== Actions.STRIP_TRANSIENTS
-        ) {
-          this.transport.sendAction(baseState, action);
+        if (shouldSend) {
+          this.transport.sendAction(baseState, action, actionID);
         }
 
         return result;
@@ -298,10 +315,46 @@ export class _ClientImpl<
 
     /**
      * Middleware that intercepts actions and invokes the subscription callback.
+     * Single-player clients read action errors directly from reducer
+     * transients. Multiplayer clients wait for the master's correlated result.
      */
+    let pendingActionError: ActionError | undefined;
     const SubscriptionMiddleware =
-      () => (next: Dispatch<Action>) => (action: Action) => {
+      (store: Store) => (next: Dispatch<Action>) => (action: Action) => {
+        const deliveriesBefore = this.actionResultDeliveries;
         const result = next(action);
+
+        // Notify after transient metadata has been stripped, so subscribers
+        // receive one rejection event paired with clean public state.
+        if (action.type === Actions.STRIP_TRANSIENTS) {
+          const actionError = pendingActionError;
+          pendingActionError = undefined;
+          if (actionError) this.notifySubscribers(actionError);
+          return result;
+        }
+
+        if (action.type === Actions.RESET) {
+          this.lastActionError = undefined;
+          this.latestActionID = undefined;
+        }
+
+        if (!this.multiplayer) {
+          const transientError = (store.getState() as TransientState<G> | null)
+            ?.transients?.error;
+          if (transientError) {
+            this.lastActionError = transientError;
+            pendingActionError = transientError;
+            return result;
+          } else if (
+            action.type === Actions.MAKE_MOVE ||
+            action.type === Actions.GAME_EVENT ||
+            action.type === Actions.UNDO ||
+            action.type === Actions.REDO
+          ) {
+            this.lastActionError = undefined;
+          }
+        }
+        if (this.actionResultDeliveries !== deliveriesBefore) return result;
         this.notifySubscribers();
         return result;
       };
@@ -355,13 +408,36 @@ export class _ClientImpl<
     this.notifySubscribers();
   }
 
+  /** Handle the authoritative result of an action sent to the master. */
+  private receiveActionResult(actionID: number, error?: ActionError): void {
+    // Only the latest submitted action owns lastActionError. Older results are
+    // stale once the player has attempted another action.
+    if (actionID !== this.latestActionID) return;
+    this.actionResultDeliveries++;
+    this.lastActionError = error;
+    this.notifySubscribers(error);
+    // Broadcasts older than the optimistic state are ignored, so a rejected
+    // optimistic move can only be rolled back by an explicit resync.
+    if (
+      error &&
+      this.store.getState()._stateID > this.latestAuthoritativeStateID
+    ) {
+      this.transport.requestSync();
+    }
+  }
+
   /** Handle all incoming updates from a multiplayer transport. */
   private receiveTransportData(data: TransportData): void {
     const [matchID] = data.args;
     if (matchID !== this.matchID) return;
     switch (data.type) {
       case 'sync': {
+        // Transient errors are not persisted by the master. A sync establishes
+        // a fresh authoritative baseline and invalidates any in-flight result.
+        this.lastActionError = undefined;
+        this.latestActionID = undefined;
         const [, syncInfo] = data.args;
+        this.latestAuthoritativeStateID = syncInfo.state._stateID;
         const action = ActionCreators.sync(syncInfo);
         this.receiveMatchData(syncInfo.filteredMetadata);
         this.store.dispatch(action);
@@ -369,6 +445,10 @@ export class _ClientImpl<
       }
       case 'update': {
         const [, state, deltalog] = data.args;
+        this.latestAuthoritativeStateID = Math.max(
+          this.latestAuthoritativeStateID,
+          state._stateID,
+        );
         const currentState = this.store.getState();
         if (state._stateID >= currentState._stateID) {
           const action = ActionCreators.update(state, deltalog);
@@ -378,6 +458,10 @@ export class _ClientImpl<
       }
       case 'patch': {
         const [, prevStateID, stateID, patch, deltalog] = data.args;
+        this.latestAuthoritativeStateID = Math.max(
+          this.latestAuthoritativeStateID,
+          stateID,
+        );
         const currentStateID = this.store.getState()._stateID;
         if (prevStateID !== currentStateID) break;
         const action = ActionCreators.patch(
@@ -403,11 +487,16 @@ export class _ClientImpl<
         this.receiveChatMessage(chatMessage);
         break;
       }
+      case 'actionResult': {
+        const [, actionID, result] = data.args;
+        this.receiveActionResult(actionID, result.error);
+        break;
+      }
     }
   }
 
-  private notifySubscribers() {
-    this.subscribers.forEach((fn) => fn(this.getState()));
+  private notifySubscribers(actionError?: ActionError) {
+    this.subscribers.forEach((fn) => fn(this.getState(), actionError));
   }
 
   previewState(state: any) {
@@ -444,13 +533,13 @@ export class _ClientImpl<
     this.manager.unregister(this);
   }
 
-  subscribe(fn: (state: ClientState<G>) => void) {
+  subscribe(fn: (state: ClientState<G>, error?: ActionError) => void) {
     const id = Symbol();
     this.subscribers.set(id, fn);
     this.transport.subscribeToConnectionStatus(() => this.notifySubscribers());
 
     if (this._running || !this.multiplayer) {
-      fn(this.getState());
+      fn(this.getState(), undefined);
     }
 
     // Return a handle that allows the caller to unsubscribe.

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -182,6 +182,7 @@ export class _ClientImpl<
   private latestActionID?: number;
   private actionResultDeliveries = 0;
   private latestAuthoritativeStateID = -1;
+  private healSyncPending = false;
 
   constructor({
     game,
@@ -336,6 +337,7 @@ export class _ClientImpl<
         if (action.type === Actions.RESET) {
           this.lastActionError = undefined;
           this.latestActionID = undefined;
+          this.healSyncPending = false;
         }
 
         if (!this.multiplayer) {
@@ -422,6 +424,7 @@ export class _ClientImpl<
       error &&
       this.store.getState()._stateID > this.latestAuthoritativeStateID
     ) {
+      this.healSyncPending = true;
       this.transport.requestSync();
     }
   }
@@ -432,10 +435,18 @@ export class _ClientImpl<
     if (matchID !== this.matchID) return;
     switch (data.type) {
       case 'sync': {
-        // Transient errors are not persisted by the master. A sync establishes
-        // a fresh authoritative baseline and invalidates any in-flight result.
-        this.lastActionError = undefined;
-        this.latestActionID = undefined;
+        // Transient errors are not persisted by the master. An unsolicited sync
+        // establishes a fresh authoritative baseline and invalidates any
+        // in-flight result. A sync this client requested to roll back a
+        // rejected action is not unsolicited: discarding the error here would
+        // erase the rejection that asked for the repair, and discarding the
+        // action ID would strand the result of an action sent since.
+        if (this.healSyncPending) {
+          this.healSyncPending = false;
+        } else {
+          this.lastActionError = undefined;
+          this.latestActionID = undefined;
+        }
         const [, syncInfo] = data.args;
         this.latestAuthoritativeStateID = syncInfo.state._stateID;
         const action = ActionCreators.sync(syncInfo);

--- a/src/client/multiplayer-fuzz.test.ts
+++ b/src/client/multiplayer-fuzz.test.ts
@@ -1,0 +1,1010 @@
+/*
+ * Copyright 2026 The boardgame.io Authors
+ *
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+import { isDeepStrictEqual } from 'node:util';
+import { Invalid } from '../core/constants';
+import { ActivePlayers } from '../core/turn-order';
+import { getFilterPlayerView } from '../master/filter-player-view';
+import {
+  Master,
+  type TransportActionResult,
+  type TransportData,
+} from '../master/master';
+import { InMemory } from '../server/db';
+import type { ActionError, CredentialedActionShape, Game } from '../types';
+import { Client } from './client';
+import type { Transport } from './transport/transport';
+
+jest.mock('../core/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+}));
+
+type StressG = {
+  cells: Array<string | null>;
+  counter: number;
+};
+
+const game: Game<StressG> = {
+  name: 'stress',
+  setup: () => ({
+    cells: Array.from({ length: 10 }, (): string | null => null),
+    counter: 0,
+  }),
+  turn: { activePlayers: ActivePlayers.ALL },
+  moves: {
+    take: ({ G, playerID }, cell: number) => {
+      if (G.cells[cell] !== null) return Invalid({ code: 'TAKEN', cell });
+      G.cells[cell] = playerID;
+    },
+    gift: ({ G }) => {
+      G.counter += 1;
+    },
+    reject: () => Invalid({ code: 'NO' }),
+  },
+};
+
+const MATCH_ID = 'stress-match';
+
+type ScriptedAction =
+  | { type: 'take'; cell: number }
+  | { type: 'gift' }
+  | { type: 'reject' }
+  | { type: 'endTurn' };
+
+type ClientToMasterMessage =
+  | { type: 'sync' }
+  | {
+      type: 'update';
+      action: CredentialedActionShape.Any;
+      stateID: number;
+      actionID: number;
+    };
+
+type SentAction = {
+  actionID: number;
+  stateID: number;
+  actionType: string;
+  name: string;
+  args: any[];
+};
+
+type ActionOrigin = {
+  playerID: string;
+  actionID: number;
+};
+
+type MasterToClientMessage = {
+  data: TransportData;
+  origin?: ActionOrigin;
+  broadcast: boolean;
+};
+
+type DeliveredActionResult = ActionOrigin & {
+  targetPlayerID: string;
+  result: TransportActionResult;
+  seq: number;
+};
+
+type Notification = {
+  state: ReturnType<ReturnType<typeof Client>['getState']>;
+  error?: ActionError;
+  latestSentActionID?: number;
+  actionResultID?: number;
+};
+
+type VirtualClient = {
+  playerID: string;
+  client: ReturnType<typeof Client>;
+  deliver: (data: TransportData) => void;
+  transport: Transport;
+  clientToMaster: ClientToMasterMessage[];
+  masterToClient: MasterToClientMessage[];
+  sentActions: SentAction[];
+  results: DeliveredActionResult[];
+  notifications: Notification[];
+  deliveredStateMessages: TransportData[];
+  deliveryCounter: number;
+  lastSyncSeq: number;
+  latestSentActionID?: number;
+  deliveringActionResultID?: number;
+  script: ScriptedAction[];
+  scriptIndex: number;
+};
+
+function mulberry32(seed: number) {
+  let value = seed >>> 0;
+  return () => {
+    value = (value + 0x6d_2b_79_f5) >>> 0;
+    let result = value;
+    result = Math.imul(result ^ (result >>> 15), result | 1);
+    result ^= result + Math.imul(result ^ (result >>> 7), result | 61);
+    return ((result ^ (result >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+const randomIndex = (random: () => number, length: number) =>
+  Math.floor(random() * length);
+
+const drainMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const hasTransientsKey = (value: unknown): boolean => {
+  if (value === null || typeof value !== 'object') return false;
+  if (Object.prototype.hasOwnProperty.call(value, 'transients')) return true;
+  return Object.values(value).some((entry) => hasTransientsKey(entry));
+};
+
+class VirtualNetwork {
+  readonly db = new InMemory();
+  readonly master: Master;
+  readonly clients: VirtualClient[] = [];
+  readonly trace: string[] = [];
+  private readonly filterPlayerView: ReturnType<typeof getFilterPlayerView>;
+  private processingUpdate?: ActionOrigin;
+
+  constructor(numPlayers = 3) {
+    this.master = new Master(game, this.db, {
+      send: ({ playerID, ...payload }) => {
+        const target = this.getClient(playerID);
+        const origin =
+          payload.type === 'actionResult'
+            ? this.processingUpdate && { ...this.processingUpdate }
+            : undefined;
+        if (payload.type === 'actionResult' && origin === undefined) {
+          throw new Error('actionResult emitted outside an update');
+        }
+        target.masterToClient.push({
+          data: this.filterPlayerView(target.playerID, payload),
+          origin,
+          broadcast: false,
+        });
+      },
+      sendAll: (payload) => {
+        for (const target of this.clients) {
+          target.masterToClient.push({
+            data: this.filterPlayerView(target.playerID, payload),
+            broadcast: true,
+          });
+        }
+      },
+    });
+    this.filterPlayerView = getFilterPlayerView(this.master.game);
+
+    for (let index = 0; index < numPlayers; index++) {
+      this.addClient(String(index), numPlayers);
+    }
+  }
+
+  private addClient(playerID: string, numPlayers: number) {
+    const record = {
+      playerID,
+      client: undefined,
+      deliver: undefined,
+      transport: undefined,
+      clientToMaster: [],
+      masterToClient: [],
+      sentActions: [],
+      results: [],
+      notifications: [],
+      deliveredStateMessages: [],
+      deliveryCounter: 0,
+      lastSyncSeq: -1,
+      script: [],
+      scriptIndex: 0,
+    } as unknown as VirtualClient;
+
+    const client = Client<StressG>({
+      game,
+      matchID: MATCH_ID,
+      playerID,
+      numPlayers,
+      debug: false,
+      multiplayer: ({ transportDataCallback }) => {
+        record.deliver = transportDataCallback;
+        record.transport = {
+          isConnected: true,
+          connect: () => record.clientToMaster.push({ type: 'sync' }),
+          disconnect() {},
+          subscribeToConnectionStatus() {},
+          requestSync: () => record.clientToMaster.push({ type: 'sync' }),
+          sendAction: (state, action, actionID) => {
+            if (actionID === undefined) {
+              throw new Error(`missing actionID for player ${playerID}`);
+            }
+            const args = Array.isArray(action.payload.args)
+              ? action.payload.args
+              : [];
+            record.latestSentActionID = actionID;
+            record.sentActions.push({
+              actionID,
+              stateID: state._stateID,
+              actionType: action.type,
+              name: action.payload.type,
+              args,
+            });
+            record.clientToMaster.push({
+              type: 'update',
+              action,
+              stateID: state._stateID,
+              actionID,
+            });
+            this.trace.push(
+              `p${playerID} send #${actionID} ${action.payload.type}${JSON.stringify(
+                args,
+              )} base=${state._stateID} local=${
+                record.client.store.getState()._stateID
+              }`,
+            );
+          },
+          sendChatMessage() {},
+          updateMatchID() {},
+          updatePlayerID() {},
+          updateCredentials() {},
+        } as unknown as Transport;
+        return record.transport;
+      },
+    });
+
+    record.client = client;
+    client.subscribe((state, error) => {
+      record.notifications.push({
+        state,
+        error,
+        latestSentActionID: record.latestSentActionID,
+        actionResultID: record.deliveringActionResultID,
+      });
+    });
+    this.clients.push(record);
+    client.start();
+  }
+
+  private getClient(playerID: string) {
+    const client = this.clients.find((entry) => entry.playerID === playerID);
+    if (!client) throw new Error(`unknown player ${playerID}`);
+    return client;
+  }
+
+  setScripts(scripts: ScriptedAction[][]) {
+    scripts.forEach((script, index) => {
+      this.clients[index].script = script;
+      this.clients[index].scriptIndex = 0;
+    });
+  }
+
+  requestSync(playerID: string) {
+    this.getClient(playerID).transport.requestSync();
+  }
+
+  dispatch(playerID: string, action: ScriptedAction) {
+    const client = this.getClient(playerID).client;
+    switch (action.type) {
+      case 'take': {
+        client.moves.take(action.cell);
+        break;
+      }
+      case 'gift': {
+        client.moves.gift();
+        break;
+      }
+      case 'reject': {
+        client.moves.reject();
+        break;
+      }
+      case 'endTurn': {
+        if (!client.events.endTurn) throw new Error('endTurn is not enabled');
+        client.events.endTurn();
+        break;
+      }
+    }
+  }
+
+  dispatchNext(playerID: string) {
+    const client = this.getClient(playerID);
+    const action = client.script[client.scriptIndex++];
+    if (!action) throw new Error(`player ${playerID} has no scripted action`);
+    this.dispatch(playerID, action);
+  }
+
+  async deliverToMaster(playerID: string) {
+    const client = this.getClient(playerID);
+    const message = client.clientToMaster.shift();
+    if (!message) throw new Error(`no client→master message for ${playerID}`);
+
+    if (message.type === 'sync') {
+      await this.master.onSync(
+        MATCH_ID,
+        playerID,
+        undefined,
+        this.clients.length,
+      );
+      this.trace.push(`master sync p${playerID}`);
+    } else {
+      const masterBefore = this.db.fetch(MATCH_ID, { state: true }).state
+        ._stateID;
+      this.processingUpdate = { playerID, actionID: message.actionID };
+      try {
+        await this.master.onUpdate(
+          message.action,
+          message.stateID,
+          MATCH_ID,
+          playerID,
+          message.actionID,
+        );
+      } finally {
+        this.processingUpdate = undefined;
+      }
+      const masterAfter = this.db.fetch(MATCH_ID, { state: true }).state
+        ._stateID;
+      const resultMessage = client.masterToClient.findLast(
+        ({ data, origin }) =>
+          data.type === 'actionResult' && origin?.actionID === message.actionID,
+      );
+      const outcome =
+        resultMessage?.data.type === 'actionResult'
+          ? resultMessage.data.args[2].error?.type || 'success'
+          : 'missing-result';
+      this.trace.push(
+        `master recv p${playerID} #${message.actionID} base=${
+          message.stateID
+        } state=${masterBefore}->${masterAfter} ${outcome}`,
+      );
+    }
+    await drainMicrotasks();
+  }
+
+  async deliverToClient(playerID: string, index = 0) {
+    const client = this.getClient(playerID);
+    const [message] = client.masterToClient.splice(index, 1);
+    if (!message) throw new Error(`no master→client message for ${playerID}`);
+
+    const seq = ++client.deliveryCounter;
+    if (message.data.type === 'actionResult') {
+      const [, actionID, result] = message.data.args;
+      client.results.push({
+        targetPlayerID: playerID,
+        playerID: message.origin?.playerID,
+        actionID,
+        result,
+        seq,
+      });
+      client.deliveringActionResultID = actionID;
+    }
+    if (
+      message.data.type === 'sync' ||
+      message.data.type === 'update' ||
+      message.data.type === 'patch'
+    ) {
+      client.deliveredStateMessages.push(message.data);
+      if (message.data.type === 'sync') client.lastSyncSeq = seq;
+    }
+
+    const stateBefore = client.client.getState()?._stateID;
+    try {
+      client.deliver(message.data);
+    } finally {
+      client.deliveringActionResultID = undefined;
+    }
+    const stateAfter = client.client.getState()?._stateID;
+    const description = (() => {
+      switch (message.data.type) {
+        case 'sync': {
+          return `sync state=${message.data.args[1].state._stateID}`;
+        }
+        case 'update': {
+          return `update state=${message.data.args[1]._stateID}`;
+        }
+        case 'patch': {
+          return `patch state=${message.data.args[2]}`;
+        }
+        case 'actionResult': {
+          const [, actionID, result] = message.data.args;
+          return `result #${actionID} ${result.error?.type || 'success'}`;
+        }
+        default: {
+          return message.data.type;
+        }
+      }
+    })();
+    this.trace.push(
+      `p${playerID} recv ${description} local=${stateBefore}->${stateAfter}`,
+    );
+    await drainMicrotasks();
+  }
+
+  async deliverToClientByType(playerID: string, type: TransportData['type']) {
+    const client = this.getClient(playerID);
+    const index = client.masterToClient.findIndex(
+      (message) => message.data.type === type,
+    );
+    if (index === -1) {
+      throw new Error(`no ${type} message for player ${playerID}`);
+    }
+    await this.deliverToClient(playerID, index);
+  }
+
+  async syncAll() {
+    for (const client of this.clients)
+      await this.deliverToMaster(client.playerID);
+    while (this.clients.some((client) => client.masterToClient.length > 0)) {
+      const client = this.clients.find(
+        (entry) => entry.masterToClient.length > 0,
+      );
+      await this.deliverToClient(client.playerID);
+    }
+  }
+
+  async drain() {
+    while (this.hasQueuedMessages()) {
+      const toMaster = this.clients.find(
+        (client) => client.clientToMaster.length > 0,
+      );
+      if (toMaster) {
+        await this.deliverToMaster(toMaster.playerID);
+        continue;
+      }
+      const toClient = this.clients.find(
+        (client) => client.masterToClient.length > 0,
+      );
+      await this.deliverToClient(toClient.playerID);
+    }
+  }
+
+  hasQueuedMessages() {
+    return this.clients.some(
+      (client) =>
+        client.clientToMaster.length > 0 || client.masterToClient.length > 0,
+    );
+  }
+
+  hasRemainingScripts() {
+    return this.clients.some(
+      (client) => client.scriptIndex < client.script.length,
+    );
+  }
+
+  stop() {
+    for (const client of this.clients) client.client.stop();
+  }
+}
+
+function createScripts(seed: number): ScriptedAction[][] {
+  const random = mulberry32(seed ^ 0xa5_a5_a5_a5);
+  return Array.from({ length: 3 }, () =>
+    Array.from({ length: 20 }, (): ScriptedAction => {
+      const choice = random();
+      if (choice < 0.1) return { type: 'endTurn' };
+      if (choice < 0.55) {
+        return { type: 'take', cell: randomIndex(random, 10) };
+      }
+      if (choice < 0.78) return { type: 'gift' };
+      return { type: 'reject' };
+    }),
+  );
+}
+
+async function runSeed(seed: number) {
+  const network = new VirtualNetwork();
+  const random = mulberry32(seed);
+  network.setScripts(createScripts(seed));
+
+  let steps = 0;
+  while (network.clients.some(({ client }) => client.getState() === null)) {
+    const queues = network.clients.flatMap((client) => [
+      ...(client.clientToMaster.length > 0
+        ? [{ direction: 'toMaster' as const, playerID: client.playerID }]
+        : []),
+      ...(client.masterToClient.length > 0
+        ? [{ direction: 'toClient' as const, playerID: client.playerID }]
+        : []),
+    ]);
+    if (queues.length === 0) {
+      throw new Error(`[seed ${seed}] initial sync reached a dead end`);
+    }
+    const queue = queues[randomIndex(random, queues.length)];
+    await (queue.direction === 'toMaster'
+      ? network.deliverToMaster(queue.playerID)
+      : network.deliverToClient(queue.playerID));
+    if (++steps > 1000) {
+      throw new Error(`[seed ${seed}] initial sync exceeded 1000 steps`);
+    }
+  }
+
+  while (network.hasQueuedMessages() || network.hasRemainingScripts()) {
+    const dispatchable = network.clients.filter(
+      (client) => client.scriptIndex < client.script.length,
+    );
+    const queues = network.clients.flatMap((client) => [
+      ...(client.clientToMaster.length > 0
+        ? [{ direction: 'toMaster' as const, playerID: client.playerID }]
+        : []),
+      ...(client.masterToClient.length > 0
+        ? [{ direction: 'toClient' as const, playerID: client.playerID }]
+        : []),
+    ]);
+
+    const shouldDispatch =
+      dispatchable.length > 0 && (queues.length === 0 || random() < 0.5);
+    if (shouldDispatch) {
+      const client = dispatchable[randomIndex(random, dispatchable.length)];
+      network.dispatchNext(client.playerID);
+    } else {
+      const queue = queues[randomIndex(random, queues.length)];
+      await (queue.direction === 'toMaster'
+        ? network.deliverToMaster(queue.playerID)
+        : network.deliverToClient(queue.playerID));
+    }
+
+    await drainMicrotasks();
+    if (++steps > 10_000) {
+      throw new Error(`[seed ${seed}] scheduler exceeded 10000 steps`);
+    }
+  }
+
+  return network;
+}
+
+function collectInvariantViolations(seed: number, network: VirtualNetwork) {
+  const violations: string[] = [];
+  const masterState = network.db.fetch(MATCH_ID, { state: true }).state;
+  const sentByPlayerAndID = new Map<string, SentAction>();
+  let convergenceFailed = false;
+
+  for (const client of network.clients) {
+    for (const sent of client.sentActions) {
+      sentByPlayerAndID.set(`${client.playerID}:${sent.actionID}`, sent);
+    }
+
+    const sentIDs = client.sentActions.map(({ actionID }) => actionID).sort();
+    const resultIDs = client.results.map(({ actionID }) => actionID).sort();
+    if (!isDeepStrictEqual(resultIDs, sentIDs)) {
+      violations.push(
+        `player ${client.playerID} result IDs ${JSON.stringify(
+          resultIDs,
+        )} did not exactly match sent IDs ${JSON.stringify(sentIDs)}`,
+      );
+    }
+
+    for (const result of client.results) {
+      if (result.targetPlayerID !== client.playerID) {
+        violations.push(
+          `player ${client.playerID} recorded a result targeted at ${result.targetPlayerID}`,
+        );
+      }
+      if (result.playerID !== client.playerID) {
+        violations.push(
+          `player ${client.playerID} received player ${result.playerID}'s action ${result.actionID}`,
+        );
+      }
+      if (
+        !client.sentActions.some((sent) => sent.actionID === result.actionID)
+      ) {
+        violations.push(
+          `player ${client.playerID} received unsent actionID ${result.actionID}`,
+        );
+      }
+    }
+
+    const state = client.client.getState();
+    if (state === null) {
+      violations.push(`player ${client.playerID} has no final state`);
+    } else {
+      if (!isDeepStrictEqual(state.G, masterState.G)) {
+        convergenceFailed = true;
+        violations.push(
+          `player ${client.playerID} G diverged: ${JSON.stringify(
+            state.G,
+          )} vs ${JSON.stringify(masterState.G)}`,
+        );
+      }
+      if (state._stateID !== masterState._stateID) {
+        convergenceFailed = true;
+        violations.push(
+          `player ${client.playerID} stateID ${state._stateID} != ${masterState._stateID}`,
+        );
+      }
+      if (state.ctx.turn !== masterState.ctx.turn) {
+        convergenceFailed = true;
+        violations.push(
+          `player ${client.playerID} turn ${state.ctx.turn} != ${masterState.ctx.turn}`,
+        );
+      }
+      if (state.ctx.currentPlayer !== masterState.ctx.currentPlayer) {
+        convergenceFailed = true;
+        violations.push(
+          `player ${client.playerID} currentPlayer ${state.ctx.currentPlayer} != ${masterState.ctx.currentPlayer}`,
+        );
+      }
+      if (hasTransientsKey(state)) {
+        violations.push(
+          `player ${client.playerID} final state contains transients`,
+        );
+      }
+    }
+
+    if (
+      client.deliveredStateMessages.some((message) => hasTransientsKey(message))
+    ) {
+      violations.push(
+        `player ${client.playerID} received a state payload containing transients`,
+      );
+    }
+
+    const highestSent = client.sentActions.at(-1);
+    const highestResult = client.results.find(
+      ({ actionID }) => actionID === highestSent?.actionID,
+    );
+    // A sync delivered after the result clears lastActionError.
+    const expectedError =
+      highestResult !== undefined && client.lastSyncSeq > highestResult.seq
+        ? undefined
+        : highestResult?.result.error;
+    if (!isDeepStrictEqual(client.client.lastActionError, expectedError)) {
+      violations.push(
+        `player ${client.playerID} lastActionError ${JSON.stringify(
+          client.client.lastActionError,
+        )} != expected ${JSON.stringify(expectedError)}`,
+      );
+    }
+
+    const errorNotifications = client.notifications.filter(
+      ({ error }) => error !== undefined,
+    );
+    const receivedErrors = client.results.filter(
+      ({ result }) => result.error !== undefined,
+    );
+    if (errorNotifications.length > receivedErrors.length) {
+      violations.push(
+        `player ${client.playerID} emitted ${errorNotifications.length} error events for ${receivedErrors.length} error results`,
+      );
+    }
+    for (const notification of errorNotifications) {
+      if (
+        notification.actionResultID === undefined ||
+        notification.actionResultID !== notification.latestSentActionID
+      ) {
+        violations.push(
+          `player ${client.playerID} emitted an error for action ${notification.actionResultID} while latest was ${notification.latestSentActionID}`,
+        );
+      }
+      const result = client.results.find(
+        ({ actionID }) => actionID === notification.actionResultID,
+      );
+      if (!isDeepStrictEqual(notification.error, result?.result.error)) {
+        violations.push(
+          `player ${client.playerID} emitted an error not matching action ${notification.actionResultID}`,
+        );
+      }
+    }
+  }
+
+  const allResults = network.clients.flatMap(({ results }) => results);
+  const successfulResults = allResults.filter(({ result }) => !result.error);
+  if (masterState._stateID !== successfulResults.length) {
+    violations.push(
+      `master stateID ${masterState._stateID} != ${successfulResults.length} successful results`,
+    );
+  }
+
+  const successfulActions = successfulResults.map((result) => ({
+    result,
+    sent: sentByPlayerAndID.get(`${result.playerID}:${result.actionID}`),
+  }));
+  const successfulGifts = successfulActions.filter(
+    ({ sent }) => sent?.actionType === 'MAKE_MOVE' && sent.name === 'gift',
+  );
+  if (masterState.G.counter !== successfulGifts.length) {
+    violations.push(
+      `counter ${masterState.G.counter} != ${successfulGifts.length} successful gifts`,
+    );
+  }
+
+  for (let cell = 0; cell < masterState.G.cells.length; cell++) {
+    const successfulTakes = successfulActions.filter(
+      ({ sent }) =>
+        sent?.actionType === 'MAKE_MOVE' &&
+        sent.name === 'take' &&
+        sent.args[0] === cell,
+    );
+    const owner = masterState.G.cells[cell];
+    if (owner === null && successfulTakes.length > 0) {
+      violations.push(
+        `empty cell ${cell} had ${successfulTakes.length} successful takes`,
+      );
+    }
+    if (
+      owner !== null &&
+      (successfulTakes.length !== 1 ||
+        successfulTakes[0].result.playerID !== owner)
+    ) {
+      violations.push(
+        `cell ${cell} owner ${owner} did not match successful takes ${JSON.stringify(
+          successfulTakes.map(({ result }) => result.playerID),
+        )}`,
+      );
+    }
+  }
+
+  for (const client of network.clients) {
+    for (const sent of client.sentActions.filter(
+      ({ actionType, name }) => actionType === 'MAKE_MOVE' && name === 'take',
+    )) {
+      const delivered = client.results.find(
+        ({ actionID }) => actionID === sent.actionID,
+      );
+      if (!delivered?.result.error) continue;
+      const { error } = delivered.result;
+      const isStale = error.type === 'action/stale_state_id';
+      const isTaken =
+        error.type === 'action/invalid_move' &&
+        isDeepStrictEqual(error.payload, {
+          code: 'TAKEN',
+          cell: sent.args[0],
+        });
+      if (!isStale && !isTaken) {
+        violations.push(
+          `player ${client.playerID} take(${sent.args[0]}) failed with ${JSON.stringify(
+            error,
+          )}`,
+        );
+      }
+    }
+  }
+
+  if (convergenceFailed) {
+    violations.push(
+      `final interleaving: ${network.trace.slice(-30).join(' | ')}`,
+    );
+  }
+
+  return { seed, violations };
+}
+
+const DEFAULT_SEEDS = [
+  0x00_00_00_01, 0x00_00_00_02, 0x00_00_00_03, 0x00_00_00_05, 0x00_00_00_08,
+  0x00_00_00_0d, 0x00_00_00_15, 0x00_00_00_22, 0x00_00_00_37, 0x00_00_00_59,
+  0x00_00_00_90, 0x00_00_00_e9, 0x00_00_01_79, 0x00_00_02_62, 0x00_00_03_db,
+  0x00_00_06_3d, 0x00_00_0a_18, 0x00_00_10_55, 0x00_00_1a_6d, 0x00_00_2a_c2,
+  0x00_00_45_2f, 0x00_00_6f_f1, 0x00_00_b5_20, 0x00_01_25_11, 0x00_01_da_31,
+];
+
+const requestedSeedCount = Number.parseInt(process.env.STRESS_SEEDS || '', 10);
+const seedCount =
+  Number.isFinite(requestedSeedCount) && requestedSeedCount > 0
+    ? requestedSeedCount
+    : DEFAULT_SEEDS.length;
+const soakSeedGenerator = mulberry32(0x12_74_c0_de);
+const seeds = Array.from({ length: seedCount }, (_, index) =>
+  index < DEFAULT_SEEDS.length
+    ? DEFAULT_SEEDS[index]
+    : Math.floor(soakSeedGenerator() * 0x1_00_00_00_00),
+);
+
+describe('multiplayer action-result interleaving fuzz', () => {
+  test.each(seeds)('preserves all invariants for seed %i', async (seed) => {
+    const network = await runSeed(seed);
+    const report = collectInvariantViolations(seed, network);
+    network.stop();
+    expect(report).toEqual({ seed, violations: [] });
+  });
+});
+
+const expectConverged = (network: VirtualNetwork, playerIDs = ['0', '1']) => {
+  const masterState = network.db.fetch(MATCH_ID, { state: true }).state;
+  for (const playerID of playerIDs) {
+    const state = network.clients[Number(playerID)].client.getState();
+    expect(state).not.toBeNull();
+    expect(state.G).toEqual(masterState.G);
+    expect(state._stateID).toBe(masterState._stateID);
+  }
+};
+
+describe('directed action-result interleavings', () => {
+  test('two clients racing the same cell converge with one loser error', async () => {
+    const network = new VirtualNetwork();
+    await network.syncAll();
+
+    network.dispatch('0', { type: 'take', cell: 4 });
+    network.dispatch('1', { type: 'take', cell: 4 });
+    await network.deliverToMaster('0');
+    await network.deliverToClient('1');
+    await network.deliverToMaster('1');
+    await network.drain();
+
+    const masterState = network.db.fetch(MATCH_ID, { state: true }).state;
+    const loserError = network.clients[1].results[0].result.error;
+    const result = {
+      owner: masterState.G.cells[4],
+      loserError,
+      winnerResults: network.clients[0].results.length,
+      loserResults: network.clients[1].results.length,
+    };
+    expectConverged(network);
+    network.stop();
+
+    expect(result.owner).toBe('0');
+    expect(result.winnerResults).toBe(1);
+    expect(result.loserResults).toBe(1);
+    expect([
+      {
+        type: 'action/invalid_move',
+        payload: { code: 'TAKEN', cell: 4 },
+      },
+      { type: 'action/stale_state_id' },
+    ]).toContainEqual(result.loserError);
+  });
+
+  test('pipelined rejection is stale and the newer result owns lastActionError', async () => {
+    const network = new VirtualNetwork();
+    await network.syncAll();
+
+    network.dispatch('0', { type: 'reject' });
+    network.dispatch('0', { type: 'gift' });
+    network.clients[0].notifications = [];
+    await network.deliverToMaster('0');
+    await network.deliverToMaster('0');
+    await network.drain();
+
+    const actor = network.clients[0];
+    const result = {
+      sentIDs: actor.sentActions.map(({ actionID }) => actionID),
+      resultErrors: actor.results.map(({ result }) => result.error),
+      errorEvents: actor.notifications.filter(({ error }) => error).length,
+      lastActionError: actor.client.lastActionError,
+    };
+    expectConverged(network, ['0']);
+    const masterState = network.db.fetch(MATCH_ID, { state: true }).state;
+    network.stop();
+
+    expect(result.sentIDs).toEqual([1, 2]);
+    expect(result.resultErrors[0]).toEqual({
+      type: 'action/invalid_move',
+      payload: { code: 'NO' },
+    });
+    expect(result.resultErrors[1]).toBeUndefined();
+    expect(result.errorEvents).toBe(0);
+    expect(result.lastActionError).toBeUndefined();
+    expect(masterState.G.counter).toBe(1);
+  });
+
+  test('result-before-broadcast reports the error and preserves it', async () => {
+    const network = new VirtualNetwork();
+    await network.syncAll();
+
+    network.dispatch('0', { type: 'reject' });
+    await network.deliverToMaster('0');
+    network.clients[0].notifications = [];
+    await network.deliverToClientByType('0', 'actionResult');
+    const errorAfterResult = network.clients[0].client.lastActionError;
+    await network.deliverToClientByType('0', 'update');
+
+    const actor = network.clients[0];
+    const notificationErrors = actor.notifications.map(({ error }) => error);
+    const finalError = actor.client.lastActionError;
+    await network.drain();
+    network.stop();
+
+    expect(errorAfterResult).toEqual({
+      type: 'action/invalid_move',
+      payload: { code: 'NO' },
+    });
+    expect(notificationErrors).toEqual([errorAfterResult, undefined]);
+    expect(finalError).toEqual(errorAfterResult);
+  });
+
+  test('a fresh sync invalidates a queued in-flight result', async () => {
+    const network = new VirtualNetwork();
+    await network.syncAll();
+
+    network.dispatch('0', { type: 'reject' });
+    await network.deliverToMaster('0');
+    network.requestSync('0');
+    await network.deliverToMaster('0');
+    network.clients[0].notifications = [];
+
+    await network.deliverToClientByType('0', 'sync');
+    await network.deliverToClientByType('0', 'actionResult');
+    await network.drain();
+
+    const actor = network.clients[0];
+    const result = {
+      lastActionError: actor.client.lastActionError,
+      errorEvents: actor.notifications.filter(({ error }) => error).length,
+    };
+    network.stop();
+
+    expect(result).toEqual({ lastActionError: undefined, errorEvents: 0 });
+  });
+
+  test('a rejection while optimistically ahead self-heals via sync', async () => {
+    const network = new VirtualNetwork();
+    await network.syncAll();
+    const actor = network.clients[0];
+    actor.notifications = [];
+    actor.deliveredStateMessages = [];
+
+    // p0 pipelines three locally-valid moves; the master accepts two of p1's
+    // moves first, so all of p0's are rejected and every broadcast stays
+    // below p0's optimistic stateID.
+    network.dispatch('1', { type: 'take', cell: 3 });
+    network.dispatch('1', { type: 'take', cell: 4 });
+    network.dispatch('0', { type: 'take', cell: 2 });
+    network.dispatch('0', { type: 'take', cell: 4 });
+    network.dispatch('0', { type: 'take', cell: 3 });
+    await network.deliverToMaster('1');
+    await network.deliverToMaster('1');
+    await network.deliverToMaster('0');
+    await network.deliverToMaster('0');
+    await network.deliverToMaster('0');
+    await network.drain();
+
+    const observed = {
+      resultErrors: actor.results.map(({ result }) => result.error?.type),
+      errorEvents: actor.notifications.filter(({ error }) => error).length,
+      lastActionError: actor.client.lastActionError,
+      healSyncs: actor.deliveredStateMessages.filter(
+        ({ type }) => type === 'sync',
+      ).length,
+    };
+    expectConverged(network, ['0', '1', '2']);
+    network.stop();
+
+    expect(observed.resultErrors).toEqual([
+      'action/stale_state_id',
+      'action/stale_state_id',
+      'action/invalid_move',
+    ]);
+    expect(observed.errorEvents).toBe(1);
+    expect(observed.lastActionError).toBeUndefined();
+    expect(observed.healSyncs).toBe(1);
+  });
+
+  test('an error subscriber can synchronously dispatch the next action', async () => {
+    const network = new VirtualNetwork();
+    await network.syncAll();
+    const actor = network.clients[0];
+    actor.notifications = [];
+    let reentered = false;
+    const unsubscribe = actor.client.subscribe((_state, error) => {
+      if (error && !reentered) {
+        reentered = true;
+        actor.client.moves.gift();
+      }
+    });
+
+    network.dispatch('0', { type: 'reject' });
+    await network.deliverToMaster('0');
+    await network.deliverToClient('0');
+    await network.deliverToClient('0');
+    await network.drain();
+
+    const masterState = network.db.fetch(MATCH_ID, { state: true }).state;
+    const result = {
+      reentered,
+      sentIDs: actor.sentActions.map(({ actionID }) => actionID),
+      resultIDs: actor.results.map(({ actionID }) => actionID),
+      errorEvents: actor.notifications.filter(({ error }) => error).length,
+      lastActionError: actor.client.lastActionError,
+      counter: masterState.G.counter,
+    };
+    expectConverged(network, ['0']);
+    unsubscribe();
+    network.stop();
+
+    expect(result).toEqual({
+      reentered: true,
+      sentIDs: [1, 2],
+      resultIDs: [1, 2],
+      errorEvents: 1,
+      lastActionError: undefined,
+      counter: 1,
+    });
+  });
+});

--- a/src/client/multiplayer-fuzz.test.ts
+++ b/src/client/multiplayer-fuzz.test.ts
@@ -111,6 +111,14 @@ type VirtualClient = {
   deliveredStateMessages: TransportData[];
   deliveryCounter: number;
   lastSyncSeq: number;
+  /** Delivery seq of every sync the client received. */
+  syncDeliverySeqs: number[];
+  /**
+   * Delivery seq of every sync the client asked for, with the action result
+   * being delivered at the time, if any. A request made while handling a
+   * result is a repair for that rejection.
+   */
+  syncRequests: Array<{ seq: number; actionID?: number }>;
   latestSentActionID?: number;
   deliveringActionResultID?: number;
   script: ScriptedAction[];
@@ -197,6 +205,8 @@ class VirtualNetwork {
       deliveredStateMessages: [],
       deliveryCounter: 0,
       lastSyncSeq: -1,
+      syncDeliverySeqs: [],
+      syncRequests: [],
       script: [],
       scriptIndex: 0,
     } as unknown as VirtualClient;
@@ -214,7 +224,13 @@ class VirtualNetwork {
           connect: () => record.clientToMaster.push({ type: 'sync' }),
           disconnect() {},
           subscribeToConnectionStatus() {},
-          requestSync: () => record.clientToMaster.push({ type: 'sync' }),
+          requestSync: () => {
+            record.syncRequests.push({
+              seq: record.deliveryCounter,
+              actionID: record.deliveringActionResultID,
+            });
+            record.clientToMaster.push({ type: 'sync' });
+          },
           sendAction: (state, action, actionID) => {
             if (actionID === undefined) {
               throw new Error(`missing actionID for player ${playerID}`);
@@ -383,7 +399,10 @@ class VirtualNetwork {
       message.data.type === 'patch'
     ) {
       client.deliveredStateMessages.push(message.data);
-      if (message.data.type === 'sync') client.lastSyncSeq = seq;
+      if (message.data.type === 'sync') {
+        client.lastSyncSeq = seq;
+        client.syncDeliverySeqs.push(seq);
+      }
     }
 
     const stateBefore = client.client.getState()?._stateID;
@@ -641,11 +660,29 @@ function collectInvariantViolations(seed: number, network: VirtualNetwork) {
     const highestResult = client.results.find(
       ({ actionID }) => actionID === highestSent?.actionID,
     );
-    // A sync delivered after the result clears lastActionError.
-    const expectedError =
-      highestResult !== undefined && client.lastSyncSeq > highestResult.seq
-        ? undefined
-        : highestResult?.result.error;
+    // An unsolicited sync delivered after the result clears lastActionError. A
+    // repair sync the client asked for while handling a rejection does not:
+    // erasing the error there would discard the rejection the repair exists to
+    // explain. Replay that rule over the delivery timeline, since each pending
+    // repair absorbs exactly one sync.
+    const repairRequestSeqs = new Set(
+      client.syncRequests
+        .filter(({ actionID }) => actionID !== undefined)
+        .map(({ seq }) => seq),
+    );
+    let repairPending = false;
+    let clearedAfterResult = false;
+    for (let seq = 1; seq <= client.deliveryCounter; seq++) {
+      if (repairRequestSeqs.has(seq)) repairPending = true;
+      if (!client.syncDeliverySeqs.includes(seq)) continue;
+      if (repairPending) repairPending = false;
+      else if (highestResult !== undefined && seq > highestResult.seq) {
+        clearedAfterResult = true;
+      }
+    }
+    const expectedError = clearedAfterResult
+      ? undefined
+      : highestResult?.result.error;
     if (!isDeepStrictEqual(client.client.lastActionError, expectedError)) {
       violations.push(
         `player ${client.playerID} lastActionError ${JSON.stringify(
@@ -962,8 +999,68 @@ describe('directed action-result interleavings', () => {
       'action/invalid_move',
     ]);
     expect(observed.errorEvents).toBe(1);
-    expect(observed.lastActionError).toBeUndefined();
+    // The repair rolls the three optimistic moves back without erasing the
+    // rejection that asked for it.
+    expect(observed.lastActionError).toEqual({
+      type: 'action/invalid_move',
+      payload: { code: 'TAKEN', cell: 3 },
+    });
     expect(observed.healSyncs).toBe(1);
+  });
+
+  test('a rejection arriving behind a repair sync is still reported', async () => {
+    const network = new VirtualNetwork();
+    await network.syncAll();
+    const actor = network.clients[0];
+    actor.notifications = [];
+
+    // p1 moves twice so p0's view of the authoritative state falls behind.
+    network.dispatch('1', { type: 'take', cell: 3 });
+    network.dispatch('1', { type: 'take', cell: 4 });
+    await network.deliverToMaster('1');
+    await network.deliverToMaster('1');
+
+    // p0 acts on its stale view: locally valid, rejected by the master, so p0
+    // is optimistically ahead and its result triggers a repair sync.
+    network.dispatch('0', { type: 'take', cell: 5 });
+    await network.deliverToMaster('0');
+    await network.deliverToClientByType('0', 'actionResult');
+    const errorAfterFirst = actor.client.lastActionError;
+
+    // p0 acts again before the repair lands. Channels are FIFO, so the sync is
+    // delivered ahead of the second action's result.
+    network.dispatch('0', { type: 'take', cell: 6 });
+    await network.deliverToMaster('0'); // the repair sync request
+    await network.deliverToMaster('0'); // the second action
+    await network.deliverToClientByType('0', 'sync');
+    await network.deliverToClientByType('0', 'actionResult');
+
+    const observed = {
+      resultErrors: actor.results.map(({ result }) => result.error?.type),
+      errorEvents: actor.notifications
+        .map(({ error }) => error?.type)
+        .filter(Boolean),
+      lastActionError: actor.client.lastActionError,
+    };
+    await network.drain();
+    expectConverged(network, ['0', '1']);
+    network.stop();
+
+    expect(errorAfterFirst).toBeDefined();
+    expect(observed.resultErrors).toEqual([
+      'action/stale_state_id',
+      'action/stale_state_id',
+    ]);
+    // Without the repair keeping the correlation ID alive, the second result
+    // matches nothing and is dropped in silence.
+    expect(observed.errorEvents).toEqual([
+      'action/stale_state_id',
+      'action/stale_state_id',
+    ]);
+    expect(observed.lastActionError).toEqual({
+      type: 'action/stale_state_id',
+      payload: undefined,
+    });
   });
 
   test('an error subscriber can synchronously dispatch the next action', async () => {

--- a/src/client/react.test.tsx
+++ b/src/client/react.test.tsx
@@ -13,6 +13,7 @@ import type { BoardProps } from './react';
 import { Client } from './react';
 import { Local } from './transport/local';
 import { SocketIO } from './transport/socketio';
+import { Invalid } from '../core/constants';
 
 let lastBoardProps: (BoardProps & { doStuff?; extraValue? }) | null = null;
 
@@ -51,6 +52,28 @@ test('board props', () => {
   render(<Board />);
   expect(lastBoardProps.isMultiplayer).toEqual(false);
   expect(lastBoardProps.isActive).toBe(true);
+});
+
+test('board receives and clears lastActionError', () => {
+  const Board = Client({
+    game: {
+      moves: {
+        reject: () => Invalid({ reason: 'not allowed' }),
+      },
+    },
+    board: TestBoard,
+  });
+  render(<Board />);
+  expect(lastBoardProps.lastActionError).toBeUndefined();
+
+  act(() => lastBoardProps.moves.reject());
+  expect(lastBoardProps.lastActionError).toEqual({
+    type: 'action/invalid_move',
+    payload: { reason: 'not allowed' },
+  });
+
+  act(() => lastBoardProps.reset());
+  expect(lastBoardProps.lastActionError).toBeUndefined();
 });
 
 test('can pass extra props to Client', () => {

--- a/src/client/react.test.tsx
+++ b/src/client/react.test.tsx
@@ -76,6 +76,36 @@ test('board receives and clears lastActionError', () => {
   expect(lastBoardProps.lastActionError).toBeUndefined();
 });
 
+test('board receives lastActionError for a master-rejected optimistic move', () => {
+  const Board = Client({
+    game: {
+      setup: () => ({ secret: 'blocked', played: 0 }),
+      playerView: ({ G }) => ({ ...G, secret: null }),
+      moves: {
+        // Valid against the filtered view the client holds, rejected by the
+        // master, so the client applies it optimistically and then heals.
+        play: ({ G }) => {
+          if (G.secret === 'blocked') return Invalid({ reason: 'no' });
+          G.played++;
+        },
+      },
+    },
+    board: TestBoard,
+    multiplayer: Local(),
+    numPlayers: 2,
+    debug: false,
+  });
+  render(<Board playerID="0" />);
+
+  act(() => lastBoardProps.moves.play());
+
+  expect(lastBoardProps.G.played).toBe(0);
+  expect(lastBoardProps.lastActionError).toEqual({
+    type: 'action/invalid_move',
+    payload: { reason: 'no' },
+  });
+});
+
 test('can pass extra props to Client', () => {
   const Board = Client({
     game: {},

--- a/src/client/react.tsx
+++ b/src/client/react.tsx
@@ -31,6 +31,7 @@ type ExposedClientProps<G extends any = any> = Pick<
   | 'matchData'
   | 'sendChatMessage'
   | 'chatMessages'
+  | 'lastActionError'
 >;
 
 export type BoardProps<G extends any = any> = ClientState<G> &
@@ -183,6 +184,7 @@ export function Client<
           matchData: this.client.matchData,
           sendChatMessage: this.client.sendChatMessage,
           chatMessages: this.client.chatMessages,
+          lastActionError: this.client.lastActionError,
         });
       }
 

--- a/src/client/transport/local.ts
+++ b/src/client/transport/local.ts
@@ -158,8 +158,18 @@ export class LocalTransport extends Transport {
     this.master.onChatMessage(...args);
   }
 
-  sendAction(state: State, action: CredentialedActionShape.Any): void {
-    this.master.onUpdate(action, state._stateID, this.matchID, this.playerID);
+  sendAction(
+    state: State,
+    action: CredentialedActionShape.Any,
+    actionID?: number,
+  ): void {
+    this.master.onUpdate(
+      action,
+      state._stateID,
+      this.matchID,
+      this.playerID,
+      actionID,
+    );
   }
 
   requestSync(): void {

--- a/src/client/transport/socketio.test.ts
+++ b/src/client/transport/socketio.test.ts
@@ -12,6 +12,7 @@ import { makeMove } from '../../core/action-creators';
 import type { Master } from '../../master/master';
 import type { ChatMessage, State } from '../../types';
 import { ProcessGameConfig } from '../../core/game';
+import { ActionErrorType } from '../../core/errors';
 
 jest.mock('../../core/logger', () => ({
   info: jest.fn(),
@@ -22,7 +23,7 @@ type UpdateArgs = Parameters<Master['onUpdate']>;
 type SyncArgs = Parameters<Master['onSync']>;
 
 class MockSocket {
-  callbacks: Record<string, (arg0?: any, arg1?: any) => void>;
+  callbacks: Record<string, (...args: any[]) => void>;
   emit: jest.Mock;
 
   constructor() {
@@ -34,7 +35,7 @@ class MockSocket {
     this.callbacks[type](...args);
   }
 
-  on(type: string, callback: (arg0?: any, arg1?: any) => void) {
+  on(type: string, callback: (...args: any[]) => void) {
     this.callbacks[type] = callback;
   }
 
@@ -198,8 +199,8 @@ describe('multiplayer', () => {
   test('send update', () => {
     const action = makeMove(undefined, undefined, undefined);
     const state = { _stateID: 0 } as State;
-    transport.sendAction(state, action);
-    const args: UpdateArgs = [action, state._stateID, 'default', null];
+    transport.sendAction(state, action, 7);
+    const args: UpdateArgs = [action, state._stateID, 'default', null, 7];
     expect(mockSocket.emit).toHaveBeenLastCalledWith('update', ...args);
   });
 
@@ -209,6 +210,20 @@ describe('multiplayer', () => {
     expect(transportDataCallback).toHaveBeenCalledWith({
       type: 'chat',
       args: ['default', chatData],
+    });
+  });
+
+  test('receive action result', () => {
+    const result = {
+      error: {
+        type: ActionErrorType.InvalidMove,
+        payload: { reason: 'not allowed' },
+      },
+    };
+    mockSocket.receive('actionResult', 'default', 7, result);
+    expect(transportDataCallback).toHaveBeenCalledWith({
+      type: 'actionResult',
+      args: ['default', 7, result],
     });
   });
 

--- a/src/client/transport/socketio.ts
+++ b/src/client/transport/socketio.ts
@@ -15,6 +15,7 @@ import { Transport } from './transport';
 import type { Operation } from 'rfc6902';
 import type { TransportOpts } from './transport';
 import type {
+  ActionError,
   CredentialedActionShape,
   FilteredMetadata,
   LogEntry,
@@ -153,6 +154,12 @@ export class SocketIOTransport extends Transport {
 
     this.socket.on('chat', (matchID: string, chatMessage: ChatMessage) => {
       this.notifyClient({ type: 'chat', args: [matchID, chatMessage] });
+    });
+
+    // Called when an action this client sent was rejected by the master.
+    // Delivered only to the acting client.
+    this.socket.on('actionError', (matchID: string, error: ActionError) => {
+      this.notifyClient({ type: 'actionError', args: [matchID, error] });
     });
 
     // Keep track of connection status.

--- a/src/client/transport/socketio.ts
+++ b/src/client/transport/socketio.ts
@@ -10,12 +10,11 @@ import * as ioNamespace from 'socket.io-client';
 
 const io = ioNamespace.default;
 
-import type { Master } from '../../master/master';
+import type { Master, TransportActionResult } from '../../master/master';
 import { Transport } from './transport';
 import type { Operation } from 'rfc6902';
 import type { TransportOpts } from './transport';
 import type {
-  ActionError,
   CredentialedActionShape,
   FilteredMetadata,
   LogEntry,
@@ -69,12 +68,17 @@ export class SocketIOTransport extends Transport {
     this.socketOpts = socketOpts;
   }
 
-  sendAction(state: State, action: CredentialedActionShape.Any): void {
+  sendAction(
+    state: State,
+    action: CredentialedActionShape.Any,
+    actionID?: number,
+  ): void {
     const args: Parameters<Master['onUpdate']> = [
       action,
       state._stateID,
       this.matchID,
       this.playerID,
+      actionID,
     ];
     this.socket.emit('update', ...args);
   }
@@ -156,10 +160,16 @@ export class SocketIOTransport extends Transport {
       this.notifyClient({ type: 'chat', args: [matchID, chatMessage] });
     });
 
-    // Called when an action this client sent was rejected by the master.
-    this.socket.on('actionError', (matchID: string, error: ActionError) => {
-      this.notifyClient({ type: 'actionError', args: [matchID, error] });
-    });
+    // Called with the authoritative result of an action this client sent.
+    this.socket.on(
+      'actionResult',
+      (matchID: string, actionID: number, result: TransportActionResult) => {
+        this.notifyClient({
+          type: 'actionResult',
+          args: [matchID, actionID, result],
+        });
+      },
+    );
 
     // Keep track of connection status.
     this.socket.on('connect', () => {

--- a/src/client/transport/socketio.ts
+++ b/src/client/transport/socketio.ts
@@ -157,7 +157,6 @@ export class SocketIOTransport extends Transport {
     });
 
     // Called when an action this client sent was rejected by the master.
-    // Delivered only to the acting client.
     this.socket.on('actionError', (matchID: string, error: ActionError) => {
       this.notifyClient({ type: 'actionError', args: [matchID, error] });
     });

--- a/src/client/transport/socketio.ts
+++ b/src/client/transport/socketio.ts
@@ -10,7 +10,7 @@ import * as ioNamespace from 'socket.io-client';
 
 const io = ioNamespace.default;
 
-import type { Master } from '../../master/master';
+import type { Master, TransportActionResult } from '../../master/master';
 import { Transport } from './transport';
 import type { Operation } from 'rfc6902';
 import type { TransportOpts } from './transport';
@@ -68,12 +68,17 @@ export class SocketIOTransport extends Transport {
     this.socketOpts = socketOpts;
   }
 
-  sendAction(state: State, action: CredentialedActionShape.Any): void {
+  sendAction(
+    state: State,
+    action: CredentialedActionShape.Any,
+    actionID?: number,
+  ): void {
     const args: Parameters<Master['onUpdate']> = [
       action,
       state._stateID,
       this.matchID,
       this.playerID,
+      actionID,
     ];
     this.socket.emit('update', ...args);
   }
@@ -154,6 +159,17 @@ export class SocketIOTransport extends Transport {
     this.socket.on('chat', (matchID: string, chatMessage: ChatMessage) => {
       this.notifyClient({ type: 'chat', args: [matchID, chatMessage] });
     });
+
+    // Called with the authoritative result of an action this client sent.
+    this.socket.on(
+      'actionResult',
+      (matchID: string, actionID: number, result: TransportActionResult) => {
+        this.notifyClient({
+          type: 'actionResult',
+          args: [matchID, actionID, result],
+        });
+      },
+    );
 
     // Keep track of connection status.
     this.socket.on('connect', () => {

--- a/src/client/transport/transport.ts
+++ b/src/client/transport/transport.ts
@@ -81,7 +81,11 @@ export abstract class Transport {
   /** Called by the client to disconnect the transport. */
   abstract disconnect(): void;
   /** Called by the client to dispatch an action via the transport. */
-  abstract sendAction(state: State, action: CredentialedActionShape.Any): void;
+  abstract sendAction(
+    state: State,
+    action: CredentialedActionShape.Any,
+    actionID?: number,
+  ): void;
   /** Called by the client to dispatch a chat message via the transport. */
   abstract sendChatMessage(matchID: string, chatMessage: ChatMessage): void;
   /** Called by the client to request a sync action from the transport. */

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -22,7 +22,8 @@ export interface InvalidMoveResult<Payload = any> {
  * Moves can return `Invalid(payload)` instead of the bare `INVALID_MOVE`
  * constant to attach a payload (e.g. a rejection reason) to the invalid
  * move. The payload is delivered to the acting client on the action
- * error and is never merged into game state.
+ * error and is never merged into game state. Payloads must be
+ * JSON-serializable.
  */
 export const Invalid = <Payload>(
   payload?: Payload,

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -4,3 +4,46 @@
  * the move ought to be discarded.
  */
 export const INVALID_MOVE = 'INVALID_MOVE';
+
+// Must be a registry symbol: each subpath bundle gets its own copy of this
+// module, and a per-module Symbol() would not match across them. Symbols
+// cannot occur in JSON, so game data cannot collide with this tag.
+const InvalidMoveTag = Symbol.for('boardgame.io/INVALID_MOVE');
+
+// Type-level brand only — never present at runtime.
+declare const InvalidMoveBrand: unique symbol;
+
+export interface InvalidMoveResult<Payload = any> {
+  readonly [InvalidMoveBrand]: true;
+  payload: Payload;
+}
+
+/**
+ * Moves can return `Invalid(payload)` instead of the bare `INVALID_MOVE`
+ * constant to attach a payload (e.g. a rejection reason) to the invalid
+ * move. The payload is delivered to the acting client on the action
+ * error and is never merged into game state. Payloads must be
+ * JSON-serializable.
+ */
+export const Invalid = <Payload>(
+  payload?: Payload,
+): InvalidMoveResult<Payload> =>
+  ({
+    [InvalidMoveTag]: true,
+    payload,
+  }) as unknown as InvalidMoveResult<Payload>;
+
+const hasInvalidMoveTag = (result: unknown): boolean =>
+  typeof result === 'object' &&
+  result !== null &&
+  (result as Record<symbol, unknown>)[InvalidMoveTag] === true;
+
+/** Check whether a move result declared the move invalid. */
+export const isInvalidMoveResult = (
+  result: unknown,
+): result is typeof INVALID_MOVE | InvalidMoveResult =>
+  result === INVALID_MOVE || hasInvalidMoveTag(result);
+
+/** Extract the payload from an invalid move result, if any. */
+export const getInvalidMovePayload = (result: unknown): unknown =>
+  hasInvalidMoveTag(result) ? (result as InvalidMoveResult).payload : undefined;

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -14,7 +14,7 @@ const InvalidMoveTag = Symbol.for('boardgame.io/INVALID_MOVE');
 declare const InvalidMoveBrand: unique symbol;
 
 export interface InvalidMoveResult<Payload = any> {
-  [InvalidMoveBrand]?: never;
+  readonly [InvalidMoveBrand]: true;
   payload: Payload;
 }
 
@@ -27,7 +27,10 @@ export interface InvalidMoveResult<Payload = any> {
 export const Invalid = <Payload>(
   payload?: Payload,
 ): InvalidMoveResult<Payload> =>
-  ({ [InvalidMoveTag]: true, payload }) as InvalidMoveResult<Payload>;
+  ({
+    [InvalidMoveTag]: true,
+    payload,
+  }) as unknown as InvalidMoveResult<Payload>;
 
 const hasInvalidMoveTag = (result: unknown): boolean =>
   typeof result === 'object' &&

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -4,3 +4,46 @@
  * the move ought to be discarded.
  */
 export const INVALID_MOVE = 'INVALID_MOVE';
+
+/**
+ * Brand for invalid-move results carrying a payload.
+ * A module-private Symbol so that no value a move could
+ * legitimately return as game state can collide with it.
+ * (Same approach as immer's `nothing` sentinel.)
+ */
+const InvalidMoveTag = Symbol('INVALID_MOVE');
+
+export interface InvalidMoveResult<Payload = any> {
+  [InvalidMoveTag]: true;
+  payload: Payload;
+}
+
+/**
+ * Moves can return `Invalid(payload)` instead of the bare `INVALID_MOVE`
+ * constant to attach a payload (e.g. a rejection reason) to the invalid
+ * move. The payload is delivered to the acting client on the action
+ * error and is never merged into game state.
+ */
+export const Invalid = <Payload>(
+  payload?: Payload,
+): InvalidMoveResult<Payload> => ({
+  [InvalidMoveTag]: true,
+  payload,
+});
+
+/** Check whether a move result declared the move invalid. */
+export const isInvalidMoveResult = (
+  result: unknown,
+): result is typeof INVALID_MOVE | InvalidMoveResult =>
+  result === INVALID_MOVE ||
+  (typeof result === 'object' &&
+    result !== null &&
+    (result as InvalidMoveResult)[InvalidMoveTag] === true);
+
+/** Extract the payload from an invalid move result, if any. */
+export const getInvalidMovePayload = (result: unknown): unknown =>
+  typeof result === 'object' &&
+  result !== null &&
+  (result as InvalidMoveResult)[InvalidMoveTag] === true
+    ? (result as InvalidMoveResult).payload
+    : undefined;

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -5,16 +5,16 @@
  */
 export const INVALID_MOVE = 'INVALID_MOVE';
 
-/**
- * Brand for invalid-move results carrying a payload.
- * A module-private Symbol so that no value a move could
- * legitimately return as game state can collide with it.
- * (Same approach as immer's `nothing` sentinel.)
- */
-const InvalidMoveTag = Symbol('INVALID_MOVE');
+// Must be a registry symbol: each subpath bundle gets its own copy of this
+// module, and a per-module Symbol() would not match across them. Symbols
+// cannot occur in JSON, so game data cannot collide with this tag.
+const InvalidMoveTag = Symbol.for('boardgame.io/INVALID_MOVE');
+
+// Type-level brand only — never present at runtime.
+declare const InvalidMoveBrand: unique symbol;
 
 export interface InvalidMoveResult<Payload = any> {
-  [InvalidMoveTag]: true;
+  [InvalidMoveBrand]?: never;
   payload: Payload;
 }
 
@@ -26,24 +26,20 @@ export interface InvalidMoveResult<Payload = any> {
  */
 export const Invalid = <Payload>(
   payload?: Payload,
-): InvalidMoveResult<Payload> => ({
-  [InvalidMoveTag]: true,
-  payload,
-});
+): InvalidMoveResult<Payload> =>
+  ({ [InvalidMoveTag]: true, payload }) as InvalidMoveResult<Payload>;
+
+const hasInvalidMoveTag = (result: unknown): boolean =>
+  typeof result === 'object' &&
+  result !== null &&
+  (result as Record<symbol, unknown>)[InvalidMoveTag] === true;
 
 /** Check whether a move result declared the move invalid. */
 export const isInvalidMoveResult = (
   result: unknown,
 ): result is typeof INVALID_MOVE | InvalidMoveResult =>
-  result === INVALID_MOVE ||
-  (typeof result === 'object' &&
-    result !== null &&
-    (result as InvalidMoveResult)[InvalidMoveTag] === true);
+  result === INVALID_MOVE || hasInvalidMoveTag(result);
 
 /** Extract the payload from an invalid move result, if any. */
 export const getInvalidMovePayload = (result: unknown): unknown =>
-  typeof result === 'object' &&
-  result !== null &&
-  (result as InvalidMoveResult)[InvalidMoveTag] === true
-    ? (result as InvalidMoveResult).payload
-    : undefined;
+  hasInvalidMoveTag(result) ? (result as InvalidMoveResult).payload : undefined;

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -8,7 +8,7 @@
 
 import * as plugins from '../plugins/main';
 import { Flow } from './flow';
-import type { INVALID_MOVE } from './constants';
+import type { INVALID_MOVE, InvalidMoveResult } from './constants';
 import type { ActionPayload, Game, Move, LongFormMove, State } from '../types';
 import * as logging from './logger';
 import { GameMethod } from './game-methods';
@@ -20,7 +20,7 @@ type ProcessedGame = Game & {
   processMove: (
     state: State,
     action: ActionPayload.MakeMove,
-  ) => State | typeof INVALID_MOVE;
+  ) => State | typeof INVALID_MOVE | InvalidMoveResult;
   processPlayerLeave: (state: State, playerID: string) => State['G'];
 };
 

--- a/src/core/reducer.test.ts
+++ b/src/core/reducer.test.ts
@@ -6,7 +6,7 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { INVALID_MOVE } from './constants';
+import { INVALID_MOVE, Invalid } from './constants';
 import { applyMiddleware, createStore } from 'redux';
 import { CreateGameReducer, TransientHandlingMiddleware } from './reducer';
 import { InitializeGame } from './initialize';
@@ -59,6 +59,40 @@ test('move returns INVALID_MOVE', () => {
   const state = reducer(initialState, makeMove('A'));
   expect(error).toHaveBeenCalledWith('invalid move: A args: undefined');
   expect(state._stateID).toBe(0);
+  expect(state['transients'].error).toEqual({
+    type: 'action/invalid_move',
+    payload: undefined,
+  });
+});
+
+test('move returns Invalid() with a payload', () => {
+  const game: Game = {
+    moves: {
+      A: () => Invalid({ reason: 'not enough gold' }),
+      B: ({ G }) => {
+        G.mutated = true;
+        return Invalid({ reason: 'mutated then rejected' });
+      },
+    },
+  };
+  const reducer = CreateGameReducer({ game });
+
+  let state = reducer(initialState, makeMove('A'));
+  expect(error).toHaveBeenCalledWith('invalid move: A args: undefined');
+  expect(state._stateID).toBe(0);
+  expect(state['transients'].error).toEqual({
+    type: 'action/invalid_move',
+    payload: { reason: 'not enough gold' },
+  });
+
+  // Draft mutations made before returning Invalid() are discarded.
+  state = reducer(initialState, makeMove('B'));
+  expect(state._stateID).toBe(0);
+  expect(state.G.mutated).toBeUndefined();
+  expect(state['transients'].error).toEqual({
+    type: 'action/invalid_move',
+    payload: { reason: 'mutated then rejected' },
+  });
 });
 
 test('makeMove', () => {

--- a/src/core/reducer.test.ts
+++ b/src/core/reducer.test.ts
@@ -6,7 +6,7 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { INVALID_MOVE } from './constants';
+import { INVALID_MOVE, Invalid } from './constants';
 import { applyMiddleware, createStore } from 'redux';
 import { CreateGameReducer, TransientHandlingMiddleware } from './reducer';
 import { InitializeGame } from './initialize';
@@ -59,6 +59,81 @@ test('move returns INVALID_MOVE', () => {
   const state = reducer(initialState, makeMove('A'));
   expect(error).toHaveBeenCalledWith('invalid move: A args: undefined');
   expect(state._stateID).toBe(0);
+  expect(state['transients'].error).toEqual({
+    type: 'action/invalid_move',
+    payload: undefined,
+  });
+});
+
+test('move returns Invalid() with a payload', () => {
+  const game: Game = {
+    moves: {
+      A: () => Invalid({ reason: 'not enough gold' }),
+      B: ({ G }) => {
+        G.mutated = true;
+        return Invalid({ reason: 'mutated then rejected' });
+      },
+    },
+  };
+  const reducer = CreateGameReducer({ game });
+
+  let state = reducer(initialState, makeMove('A'));
+  expect(error).toHaveBeenCalledWith('invalid move: A args: undefined');
+  expect(state._stateID).toBe(0);
+  expect(state['transients'].error).toEqual({
+    type: 'action/invalid_move',
+    payload: { reason: 'not enough gold' },
+  });
+
+  // Draft mutations made before returning Invalid() are discarded.
+  state = reducer(initialState, makeMove('B'));
+  expect(state._stateID).toBe(0);
+  expect(state.G.mutated).toBeUndefined();
+  expect(state['transients'].error).toEqual({
+    type: 'action/invalid_move',
+    payload: { reason: 'mutated then rejected' },
+  });
+});
+
+test('move returns Invalid() with empty and primitive payloads', () => {
+  const game: Game = {
+    moves: {
+      Empty: () => Invalid(),
+      String: () => Invalid('not enough gold'),
+      Null: () => Invalid(null),
+    },
+  };
+  const reducer = CreateGameReducer({ game });
+
+  expect(
+    reducer(initialState, makeMove('Empty'))['transients'].error.payload,
+  ).toBeUndefined();
+  expect(
+    reducer(initialState, makeMove('String'))['transients'].error.payload,
+  ).toBe('not enough gold');
+  expect(
+    reducer(initialState, makeMove('Null'))['transients'].error.payload,
+  ).toBeNull();
+});
+
+test('recognizes an Invalid result created by another bundle', () => {
+  const game: Game = {
+    moves: {
+      A: () =>
+        ({
+          [Symbol.for('boardgame.io/INVALID_MOVE')]: true,
+          payload: { reason: 'other-bundle' },
+        }) as any,
+    },
+  };
+  const reducer = CreateGameReducer({ game });
+  const state = reducer(initialState, makeMove('A'));
+  expect(state._stateID).toBe(0);
+  expect(state.G).toEqual(initialState.G);
+  expect(state['transients'].error).toEqual({
+    type: 'action/invalid_move',
+    payload: { reason: 'other-bundle' },
+  });
 });
 
 test('makeMove', () => {

--- a/src/core/reducer.test.ts
+++ b/src/core/reducer.test.ts
@@ -95,6 +95,26 @@ test('move returns Invalid() with a payload', () => {
   });
 });
 
+test('recognizes an Invalid result created by another bundle', () => {
+  const game: Game = {
+    moves: {
+      A: () =>
+        ({
+          [Symbol.for('boardgame.io/INVALID_MOVE')]: true,
+          payload: { reason: 'other-bundle' },
+        }) as any,
+    },
+  };
+  const reducer = CreateGameReducer({ game });
+  const state = reducer(initialState, makeMove('A'));
+  expect(state._stateID).toBe(0);
+  expect(state.G).toEqual(initialState.G);
+  expect(state['transients'].error).toEqual({
+    type: 'action/invalid_move',
+    payload: { reason: 'other-bundle' },
+  });
+});
+
 test('makeMove', () => {
   let state = initialState;
   expect(state._stateID).toBe(0);

--- a/src/core/reducer.test.ts
+++ b/src/core/reducer.test.ts
@@ -95,6 +95,27 @@ test('move returns Invalid() with a payload', () => {
   });
 });
 
+test('move returns Invalid() with empty and primitive payloads', () => {
+  const game: Game = {
+    moves: {
+      Empty: () => Invalid(),
+      String: () => Invalid('not enough gold'),
+      Null: () => Invalid(null),
+    },
+  };
+  const reducer = CreateGameReducer({ game });
+
+  expect(
+    reducer(initialState, makeMove('Empty'))['transients'].error.payload,
+  ).toBeUndefined();
+  expect(
+    reducer(initialState, makeMove('String'))['transients'].error.payload,
+  ).toBe('not enough gold');
+  expect(
+    reducer(initialState, makeMove('Null'))['transients'].error.payload,
+  ).toBeNull();
+});
+
 test('recognizes an Invalid result created by another bundle', () => {
   const game: Game = {
     moves: {

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -10,7 +10,7 @@ import * as Actions from './action-types';
 import * as plugins from '../plugins/main';
 import { ProcessGameConfig } from './game';
 import { error } from './logger';
-import { INVALID_MOVE } from './constants';
+import { isInvalidMoveResult, getInvalidMovePayload } from './constants';
 import type { Dispatch } from 'redux';
 import type {
   ActionShape,
@@ -390,12 +390,15 @@ export function CreateGameReducer({
         const G = game.processMove(state, action.payload);
 
         // The game declared the move as invalid.
-        if (G === INVALID_MOVE) {
+        if (isInvalidMoveResult(G)) {
           error(
             `invalid move: ${action.payload.type} args: ${action.payload.args}`,
           );
-          // TODO(#723): Marshal a nice error payload with the processed move.
-          return WithError(state, ActionErrorType.InvalidMove);
+          return WithError(
+            state,
+            ActionErrorType.InvalidMove,
+            getInvalidMovePayload(G),
+          );
         }
 
         const newState = { ...state, G };

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -10,7 +10,7 @@ import * as Actions from './action-types';
 import * as plugins from '../plugins/main';
 import { ProcessGameConfig } from './game';
 import { error } from './logger';
-import { INVALID_MOVE } from './constants';
+import { isInvalidMoveResult, getInvalidMovePayload } from './constants';
 import type { Dispatch } from 'redux';
 import type {
   ActionShape,
@@ -506,12 +506,15 @@ export function CreateGameReducer({
         const G = game.processMove(state, action.payload);
 
         // The game declared the move as invalid.
-        if (G === INVALID_MOVE) {
+        if (isInvalidMoveResult(G)) {
           error(
             `invalid move: ${action.payload.type} args: ${action.payload.args}`,
           );
-          // TODO(#723): Marshal a nice error payload with the processed move.
-          return WithError(state, ActionErrorType.InvalidMove);
+          return WithError(
+            state,
+            ActionErrorType.InvalidMove,
+            getInvalidMovePayload(G),
+          );
         }
 
         const newState = { ...state, G };

--- a/src/master/master.test.ts
+++ b/src/master/master.test.ts
@@ -20,7 +20,7 @@ import { Auth } from '../server/auth';
 import * as StorageAPI from '../server/db/base';
 import * as dateMock from 'jest-date-mock';
 import { PlayerView } from '../core/player-view';
-import { INVALID_MOVE } from '../core/constants';
+import { INVALID_MOVE, Invalid } from '../core/constants';
 
 jest.mock('../core/logger', () => ({
   info: jest.fn(),
@@ -596,6 +596,150 @@ describe('update', () => {
     ({ state, metadata } = await db.fetch(id, { state: true, metadata: true }));
     expect(state.ctx.turn).toBe(2);
     expect(metadata).toBeUndefined();
+  });
+});
+
+describe('action results', () => {
+  const send = jest.fn();
+  const sendAll = jest.fn();
+  const game: Game = {
+    moves: {
+      valid: () => ({ moved: true }),
+      rejected: () => Invalid({ reason: 'not allowed' }),
+      rejectedBare: () => INVALID_MOVE,
+    },
+  };
+  let db;
+  let master;
+
+  beforeEach(async () => {
+    db = new InMemory();
+    master = new Master(game, db, TransportAPI(send, sendAll));
+    await master.onSync('matchID', '0', undefined, 2);
+    jest.clearAllMocks();
+  });
+
+  test('invalid move sends its result to the acting client only', async () => {
+    await master.onUpdate(
+      ActionCreators.makeMove('rejected'),
+      0,
+      'matchID',
+      '0',
+      1,
+    );
+    // The rollback broadcast still goes out to everyone.
+    expect(sendAll).toHaveBeenCalled();
+    expect(send).toHaveBeenCalledWith({
+      playerID: '0',
+      type: 'actionResult',
+      args: [
+        'matchID',
+        1,
+        {
+          error: {
+            type: 'action/invalid_move',
+            payload: { reason: 'not allowed' },
+          },
+        },
+      ],
+    });
+  });
+
+  test('bare INVALID_MOVE sends a result without a payload', async () => {
+    await master.onUpdate(
+      ActionCreators.makeMove('rejectedBare'),
+      0,
+      'matchID',
+      '0',
+      2,
+    );
+    expect(send).toHaveBeenCalledWith({
+      playerID: '0',
+      type: 'actionResult',
+      args: [
+        'matchID',
+        2,
+        {
+          error: { type: 'action/invalid_move', payload: undefined },
+        },
+      ],
+    });
+  });
+
+  test('valid move sends a successful result', async () => {
+    await master.onUpdate(
+      ActionCreators.makeMove('valid'),
+      0,
+      'matchID',
+      '0',
+      3,
+    );
+    expect(sendAll).toHaveBeenCalled();
+    expect(send).toHaveBeenCalledWith({
+      playerID: '0',
+      type: 'actionResult',
+      args: ['matchID', 3, {}],
+    });
+  });
+
+  test('old clients without an action ID receive no action result', async () => {
+    await master.onUpdate(ActionCreators.makeMove('valid'), 0, 'matchID', '0');
+    expect(sendAll).toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  test('pre-dispatch rejection sends a correlated result', async () => {
+    await master.onUpdate(
+      ActionCreators.makeMove('valid'),
+      100,
+      'matchID',
+      '0',
+      4,
+    );
+    expect(sendAll).not.toHaveBeenCalled();
+    expect(send).toHaveBeenCalledWith({
+      playerID: '0',
+      type: 'actionResult',
+      args: ['matchID', 4, { error: { type: 'action/stale_state_id' } }],
+    });
+  });
+
+  test.each([
+    {
+      name: 'unavailable move',
+      action: ActionCreators.makeMove('missing'),
+      matchID: 'matchID',
+      playerID: '0',
+      type: 'action/unavailable_move',
+    },
+    {
+      name: 'inactive player',
+      action: ActionCreators.makeMove('valid'),
+      matchID: 'matchID',
+      playerID: '1',
+      type: 'action/inactive_player',
+    },
+    {
+      name: 'missing match',
+      action: ActionCreators.makeMove('valid'),
+      matchID: 'missing',
+      playerID: '0',
+      type: 'update/match_not_found',
+    },
+  ])('$name sends a correlated result', async (testCase) => {
+    await master.onUpdate(
+      testCase.action,
+      0,
+      testCase.matchID,
+      testCase.playerID,
+      5,
+    );
+    expect(sendAll).not.toHaveBeenCalled();
+    expect(send).toHaveBeenCalledWith({
+      playerID: testCase.playerID,
+      type: 'actionResult',
+      args: [testCase.matchID, 5, { error: { type: testCase.type } }],
+    });
   });
 });
 

--- a/src/master/master.test.ts
+++ b/src/master/master.test.ts
@@ -682,6 +682,12 @@ describe('action results', () => {
     });
   });
 
+  test('old clients without an action ID receive no action result', async () => {
+    await master.onUpdate(ActionCreators.makeMove('valid'), 0, 'matchID', '0');
+    expect(sendAll).toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
   test('pre-dispatch rejection sends a correlated result', async () => {
     await master.onUpdate(
       ActionCreators.makeMove('valid'),
@@ -695,6 +701,44 @@ describe('action results', () => {
       playerID: '0',
       type: 'actionResult',
       args: ['matchID', 4, { error: { type: 'action/stale_state_id' } }],
+    });
+  });
+
+  test.each([
+    {
+      name: 'unavailable move',
+      action: ActionCreators.makeMove('missing'),
+      matchID: 'matchID',
+      playerID: '0',
+      type: 'action/unavailable_move',
+    },
+    {
+      name: 'inactive player',
+      action: ActionCreators.makeMove('valid'),
+      matchID: 'matchID',
+      playerID: '1',
+      type: 'action/inactive_player',
+    },
+    {
+      name: 'missing match',
+      action: ActionCreators.makeMove('valid'),
+      matchID: 'missing',
+      playerID: '0',
+      type: 'update/match_not_found',
+    },
+  ])('$name sends a correlated result', async (testCase) => {
+    await master.onUpdate(
+      testCase.action,
+      0,
+      testCase.matchID,
+      testCase.playerID,
+      5,
+    );
+    expect(sendAll).not.toHaveBeenCalled();
+    expect(send).toHaveBeenCalledWith({
+      playerID: testCase.playerID,
+      type: 'actionResult',
+      args: [testCase.matchID, 5, { error: { type: testCase.type } }],
     });
   });
 });

--- a/src/master/master.test.ts
+++ b/src/master/master.test.ts
@@ -599,7 +599,7 @@ describe('update', () => {
   });
 });
 
-describe('action errors', () => {
+describe('action results', () => {
   const send = jest.fn();
   const sendAll = jest.fn();
   const game: Game = {
@@ -619,46 +619,83 @@ describe('action errors', () => {
     jest.clearAllMocks();
   });
 
-  test('invalid move sends actionError to the acting client only', async () => {
+  test('invalid move sends its result to the acting client only', async () => {
     await master.onUpdate(
       ActionCreators.makeMove('rejected'),
       0,
       'matchID',
       '0',
+      1,
     );
     // The rollback broadcast still goes out to everyone.
     expect(sendAll).toHaveBeenCalled();
     expect(send).toHaveBeenCalledWith({
       playerID: '0',
-      type: 'actionError',
+      type: 'actionResult',
       args: [
         'matchID',
-        { type: 'action/invalid_move', payload: { reason: 'not allowed' } },
+        1,
+        {
+          error: {
+            type: 'action/invalid_move',
+            payload: { reason: 'not allowed' },
+          },
+        },
       ],
     });
   });
 
-  test('bare INVALID_MOVE sends actionError without payload', async () => {
+  test('bare INVALID_MOVE sends a result without a payload', async () => {
     await master.onUpdate(
       ActionCreators.makeMove('rejectedBare'),
       0,
       'matchID',
       '0',
+      2,
     );
     expect(send).toHaveBeenCalledWith({
       playerID: '0',
-      type: 'actionError',
-      args: ['matchID', { type: 'action/invalid_move', payload: undefined }],
+      type: 'actionResult',
+      args: [
+        'matchID',
+        2,
+        {
+          error: { type: 'action/invalid_move', payload: undefined },
+        },
+      ],
     });
   });
 
-  test('valid move sends no actionError', async () => {
-    await master.onUpdate(ActionCreators.makeMove('valid'), 0, 'matchID', '0');
-    expect(sendAll).toHaveBeenCalled();
-    const actionErrorCalls = send.mock.calls.filter(
-      ([data]) => data.type === 'actionError',
+  test('valid move sends a successful result', async () => {
+    await master.onUpdate(
+      ActionCreators.makeMove('valid'),
+      0,
+      'matchID',
+      '0',
+      3,
     );
-    expect(actionErrorCalls).toHaveLength(0);
+    expect(sendAll).toHaveBeenCalled();
+    expect(send).toHaveBeenCalledWith({
+      playerID: '0',
+      type: 'actionResult',
+      args: ['matchID', 3, {}],
+    });
+  });
+
+  test('pre-dispatch rejection sends a correlated result', async () => {
+    await master.onUpdate(
+      ActionCreators.makeMove('valid'),
+      100,
+      'matchID',
+      '0',
+      4,
+    );
+    expect(sendAll).not.toHaveBeenCalled();
+    expect(send).toHaveBeenCalledWith({
+      playerID: '0',
+      type: 'actionResult',
+      args: ['matchID', 4, { error: { type: 'action/stale_state_id' } }],
+    });
   });
 });
 

--- a/src/master/master.test.ts
+++ b/src/master/master.test.ts
@@ -20,7 +20,7 @@ import { Auth } from '../server/auth';
 import * as StorageAPI from '../server/db/base';
 import * as dateMock from 'jest-date-mock';
 import { PlayerView } from '../core/player-view';
-import { INVALID_MOVE } from '../core/constants';
+import { INVALID_MOVE, Invalid } from '../core/constants';
 
 jest.mock('../core/logger', () => ({
   info: jest.fn(),
@@ -596,6 +596,69 @@ describe('update', () => {
     ({ state, metadata } = await db.fetch(id, { state: true, metadata: true }));
     expect(state.ctx.turn).toBe(2);
     expect(metadata).toBeUndefined();
+  });
+});
+
+describe('action errors', () => {
+  const send = jest.fn();
+  const sendAll = jest.fn();
+  const game: Game = {
+    moves: {
+      valid: () => ({ moved: true }),
+      rejected: () => Invalid({ reason: 'not allowed' }),
+      rejectedBare: () => INVALID_MOVE,
+    },
+  };
+  let db;
+  let master;
+
+  beforeEach(async () => {
+    db = new InMemory();
+    master = new Master(game, db, TransportAPI(send, sendAll));
+    await master.onSync('matchID', '0', undefined, 2);
+    jest.clearAllMocks();
+  });
+
+  test('invalid move sends actionError to the acting client only', async () => {
+    await master.onUpdate(
+      ActionCreators.makeMove('rejected'),
+      0,
+      'matchID',
+      '0',
+    );
+    // The rollback broadcast still goes out to everyone.
+    expect(sendAll).toHaveBeenCalled();
+    expect(send).toHaveBeenCalledWith({
+      playerID: '0',
+      type: 'actionError',
+      args: [
+        'matchID',
+        { type: 'action/invalid_move', payload: { reason: 'not allowed' } },
+      ],
+    });
+  });
+
+  test('bare INVALID_MOVE sends actionError without payload', async () => {
+    await master.onUpdate(
+      ActionCreators.makeMove('rejectedBare'),
+      0,
+      'matchID',
+      '0',
+    );
+    expect(send).toHaveBeenCalledWith({
+      playerID: '0',
+      type: 'actionError',
+      args: ['matchID', { type: 'action/invalid_move', payload: undefined }],
+    });
+  });
+
+  test('valid move sends no actionError', async () => {
+    await master.onUpdate(ActionCreators.makeMove('valid'), 0, 'matchID', '0');
+    expect(sendAll).toHaveBeenCalled();
+    const actionErrorCalls = send.mock.calls.filter(
+      ([data]) => data.type === 'actionError',
+    );
+    expect(actionErrorCalls).toHaveLength(0);
   });
 });
 

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -21,6 +21,7 @@ import {
 import { playerLeave } from '../core/action-creators';
 import { createStore, applyMiddleware } from 'redux';
 import * as logging from '../core/logger';
+import { ActionErrorType, UpdateErrorType } from '../core/errors';
 import type {
   SyncInfo,
   FilteredMetadata,
@@ -32,6 +33,8 @@ import type {
   LogEntry,
   PlayerID,
   ChatMessage,
+  ActionError,
+  TransientMetadata,
 } from '../types';
 import { createMatch } from '../server/util';
 import type { Auth } from '../server/auth';
@@ -39,11 +42,7 @@ import * as StorageAPI from '../server/db/base';
 import type { Operation } from 'rfc6902';
 
 type DispatchResultWithTransients = {
-  transients?: {
-    error?: {
-      type: string;
-    };
-  };
+  transients?: TransientMetadata;
 };
 
 /**
@@ -73,6 +72,10 @@ type CallbackFn = (arg: {
   action?: ActionShape.Any | CredentialedActionShape.Any;
 }) => void;
 
+export interface TransportActionResult {
+  error?: ActionError;
+}
+
 /**
  * Data types that are shared across `TransportData` and `IntermediateTransportData`.
  */
@@ -88,6 +91,10 @@ type CommonTransportData =
   | {
       type: 'chat';
       args: [string, ChatMessage];
+    }
+  | {
+      type: 'actionResult';
+      args: [string, number, TransportActionResult];
     };
 
 /**
@@ -169,22 +176,36 @@ export class Master {
     stateID: number,
     matchID: string,
     playerID: string,
+    actionID?: number,
   ): Promise<void | { error: string }> {
+    const sendActionResult = (error?: ActionError) => {
+      if (actionID === undefined) return;
+      this.transportAPI.send({
+        playerID,
+        type: 'actionResult',
+        args: [matchID, actionID, error === undefined ? {} : { error }],
+      });
+    };
+
     if (!credAction || !credAction.type) {
+      sendActionResult({ type: ActionErrorType.ActionInvalid });
       return { error: 'missing action or action payload' };
     }
 
     if (!isPublicClientAction(credAction)) {
       logging.error(`unauthorized action type: ${credAction.type}`);
+      sendActionResult({ type: UpdateErrorType.UnauthorizedAction });
       return { error: 'unauthorized action' };
     }
 
     if (!credAction.payload) {
+      sendActionResult({ type: ActionErrorType.ActionInvalid });
       return { error: 'missing action or action payload' };
     }
 
     if ('automatic' in credAction && credAction.automatic === true) {
       logging.error(`unauthorized automatic action: ${credAction.type}`);
+      sendActionResult({ type: UpdateErrorType.UnauthorizedAction });
       return { error: 'unauthorized action' };
     }
 
@@ -202,6 +223,7 @@ export class Master {
         metadata,
       });
       if (!isAuthentic) {
+        sendActionResult({ type: UpdateErrorType.UnauthorizedAction });
         return { error: 'unauthorized action' };
       }
     }
@@ -214,6 +236,7 @@ export class Master {
       !this.game.flow.enabledEventNames.includes(action.payload.type)
     ) {
       logging.error(`unauthorized game event: ${action.payload.type}`);
+      sendActionResult({ type: UpdateErrorType.UnauthorizedAction });
       return { error: 'unauthorized action' };
     }
 
@@ -226,6 +249,7 @@ export class Master {
 
     if (state === undefined) {
       logging.error(`game not found, matchID=[${key}]`);
+      sendActionResult({ type: UpdateErrorType.MatchNotFound });
       return { error: 'game not found' };
     }
 
@@ -234,6 +258,7 @@ export class Master {
         `game over - matchID=[${key}] - playerID=[${playerID}]` +
           ` - action[${action.payload.type}]`,
       );
+      sendActionResult({ type: ActionErrorType.GameOver });
       return;
     }
 
@@ -259,6 +284,7 @@ export class Master {
             Object.keys(state.ctx.activePlayers).length > 1))
       ) {
         logging.error(`playerID=[${playerID}] cannot undo / redo right now`);
+        sendActionResult({ type: ActionErrorType.ActionInvalid });
         return;
       }
     }
@@ -269,6 +295,7 @@ export class Master {
         `player not active - playerID=[${playerID}]` +
           ` - action[${action.payload.type}]`,
       );
+      sendActionResult({ type: ActionErrorType.InactivePlayer });
       return;
     }
 
@@ -284,6 +311,7 @@ export class Master {
         `move not processed - canPlayerMakeMove=false - playerID=[${playerID}]` +
           ` - action[${action.payload.type}]`,
       );
+      sendActionResult({ type: ActionErrorType.UnavailableMove });
       return;
     }
 
@@ -297,13 +325,16 @@ export class Master {
         `invalid stateID, was=[${stateID}], expected=[${state._stateID}]` +
           ` - playerID=[${playerID}] - action[${action.payload.type}]`,
       );
+      sendActionResult({ type: ActionErrorType.StaleStateId });
       return;
     }
 
     const prevState = store.getState();
 
     // Update server's version of the store.
-    store.dispatch(action);
+    const dispatchResult = store.dispatch(
+      action,
+    ) as DispatchResultWithTransients;
     state = store.getState();
 
     this.subscribeCallback({
@@ -323,6 +354,10 @@ export class Master {
         args: [matchID, state],
       });
     }
+
+    // The broadcast above updates everyone; only the actor receives the
+    // correlated outcome of this action.
+    sendActionResult(dispatchResult?.transients?.error);
 
     const { deltalog, ...stateWithoutDeltalog } = state;
 

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -32,6 +32,8 @@ import type {
   LogEntry,
   PlayerID,
   ChatMessage,
+  ActionError,
+  TransientMetadata,
 } from '../types';
 import { createMatch } from '../server/util';
 import type { Auth } from '../server/auth';
@@ -39,11 +41,7 @@ import * as StorageAPI from '../server/db/base';
 import type { Operation } from 'rfc6902';
 
 type DispatchResultWithTransients = {
-  transients?: {
-    error?: {
-      type: string;
-    };
-  };
+  transients?: TransientMetadata;
 };
 
 /**
@@ -88,6 +86,10 @@ type CommonTransportData =
   | {
       type: 'chat';
       args: [string, ChatMessage];
+    }
+  | {
+      type: 'actionError';
+      args: [string, ActionError];
     };
 
 /**
@@ -303,7 +305,9 @@ export class Master {
     const prevState = store.getState();
 
     // Update server's version of the store.
-    store.dispatch(action);
+    const dispatchResult = store.dispatch(
+      action,
+    ) as DispatchResultWithTransients;
     state = store.getState();
 
     this.subscribeCallback({
@@ -321,6 +325,17 @@ export class Master {
       this.transportAPI.sendAll({
         type: 'update',
         args: [matchID, state],
+      });
+    }
+
+    // Deliver any action error to the acting client only. The state
+    // broadcast above already rolls back optimistic updates; this
+    // tells the player *why* their action was rejected.
+    if (dispatchResult?.transients?.error) {
+      this.transportAPI.send({
+        playerID,
+        type: 'actionError',
+        args: [matchID, dispatchResult.transients.error],
       });
     }
 

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -21,6 +21,7 @@ import {
 import { playerLeave } from '../core/action-creators';
 import { createStore, applyMiddleware } from 'redux';
 import * as logging from '../core/logger';
+import { ActionErrorType, UpdateErrorType } from '../core/errors';
 import type {
   SyncInfo,
   FilteredMetadata,
@@ -71,6 +72,10 @@ type CallbackFn = (arg: {
   action?: ActionShape.Any | CredentialedActionShape.Any;
 }) => void;
 
+export interface TransportActionResult {
+  error?: ActionError;
+}
+
 /**
  * Data types that are shared across `TransportData` and `IntermediateTransportData`.
  */
@@ -88,8 +93,8 @@ type CommonTransportData =
       args: [string, ChatMessage];
     }
   | {
-      type: 'actionError';
-      args: [string, ActionError];
+      type: 'actionResult';
+      args: [string, number, TransportActionResult];
     };
 
 /**
@@ -171,22 +176,36 @@ export class Master {
     stateID: number,
     matchID: string,
     playerID: string,
+    actionID?: number,
   ): Promise<void | { error: string }> {
+    const sendActionResult = (error?: ActionError) => {
+      if (actionID === undefined) return;
+      this.transportAPI.send({
+        playerID,
+        type: 'actionResult',
+        args: [matchID, actionID, error === undefined ? {} : { error }],
+      });
+    };
+
     if (!credAction || !credAction.type) {
+      sendActionResult({ type: ActionErrorType.ActionInvalid });
       return { error: 'missing action or action payload' };
     }
 
     if (!isPublicClientAction(credAction)) {
       logging.error(`unauthorized action type: ${credAction.type}`);
+      sendActionResult({ type: UpdateErrorType.UnauthorizedAction });
       return { error: 'unauthorized action' };
     }
 
     if (!credAction.payload) {
+      sendActionResult({ type: ActionErrorType.ActionInvalid });
       return { error: 'missing action or action payload' };
     }
 
     if ('automatic' in credAction && credAction.automatic === true) {
       logging.error(`unauthorized automatic action: ${credAction.type}`);
+      sendActionResult({ type: UpdateErrorType.UnauthorizedAction });
       return { error: 'unauthorized action' };
     }
 
@@ -204,6 +223,7 @@ export class Master {
         metadata,
       });
       if (!isAuthentic) {
+        sendActionResult({ type: UpdateErrorType.UnauthorizedAction });
         return { error: 'unauthorized action' };
       }
     }
@@ -216,6 +236,7 @@ export class Master {
       !this.game.flow.enabledEventNames.includes(action.payload.type)
     ) {
       logging.error(`unauthorized game event: ${action.payload.type}`);
+      sendActionResult({ type: UpdateErrorType.UnauthorizedAction });
       return { error: 'unauthorized action' };
     }
 
@@ -228,6 +249,7 @@ export class Master {
 
     if (state === undefined) {
       logging.error(`game not found, matchID=[${key}]`);
+      sendActionResult({ type: UpdateErrorType.MatchNotFound });
       return { error: 'game not found' };
     }
 
@@ -236,6 +258,7 @@ export class Master {
         `game over - matchID=[${key}] - playerID=[${playerID}]` +
           ` - action[${action.payload.type}]`,
       );
+      sendActionResult({ type: ActionErrorType.GameOver });
       return;
     }
 
@@ -261,6 +284,7 @@ export class Master {
             Object.keys(state.ctx.activePlayers).length > 1))
       ) {
         logging.error(`playerID=[${playerID}] cannot undo / redo right now`);
+        sendActionResult({ type: ActionErrorType.ActionInvalid });
         return;
       }
     }
@@ -271,6 +295,7 @@ export class Master {
         `player not active - playerID=[${playerID}]` +
           ` - action[${action.payload.type}]`,
       );
+      sendActionResult({ type: ActionErrorType.InactivePlayer });
       return;
     }
 
@@ -286,6 +311,7 @@ export class Master {
         `move not processed - canPlayerMakeMove=false - playerID=[${playerID}]` +
           ` - action[${action.payload.type}]`,
       );
+      sendActionResult({ type: ActionErrorType.UnavailableMove });
       return;
     }
 
@@ -299,6 +325,7 @@ export class Master {
         `invalid stateID, was=[${stateID}], expected=[${state._stateID}]` +
           ` - playerID=[${playerID}] - action[${action.payload.type}]`,
       );
+      sendActionResult({ type: ActionErrorType.StaleStateId });
       return;
     }
 
@@ -328,14 +355,9 @@ export class Master {
       });
     }
 
-    // The sendAll above rolls everyone back; only the actor learns why.
-    if (dispatchResult?.transients?.error) {
-      this.transportAPI.send({
-        playerID,
-        type: 'actionError',
-        args: [matchID, dispatchResult.transients.error],
-      });
-    }
+    // The broadcast above updates everyone; only the actor receives the
+    // correlated outcome of this action.
+    sendActionResult(dispatchResult?.transients?.error);
 
     const { deltalog, ...stateWithoutDeltalog } = state;
 

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -328,9 +328,7 @@ export class Master {
       });
     }
 
-    // Deliver any action error to the acting client only. The state
-    // broadcast above already rolls back optimistic updates; this
-    // tells the player *why* their action was rejected.
+    // The sendAll above rolls everyone back; only the actor learns why.
     if (dispatchResult?.transients?.error) {
       this.transportAPI.send({
         playerID,

--- a/src/plugins/plugin-immer.test.ts
+++ b/src/plugins/plugin-immer.test.ts
@@ -8,17 +8,31 @@
 
 import { Client } from '../client/client';
 import type { _ClientImpl } from '../client/client';
-import { INVALID_MOVE } from '../core/constants';
+import { Invalid, INVALID_MOVE } from '../core/constants';
 
 // Surpress invalid move error logging
 jest.mock('../core/logger');
 
+interface TestGameState {
+  deck: Array<{ id: string; details: { suit: string } }>;
+  moveBody?: boolean;
+  madeInvalidMove?: boolean;
+  onPhaseBegin?: boolean;
+  onPhaseEnd?: boolean;
+  onTurnBegin?: boolean;
+  onTurnEnd?: boolean;
+  onMove?: boolean;
+}
+
 describe('immer', () => {
-  let client: _ClientImpl;
+  let client: _ClientImpl<TestGameState>;
 
   beforeAll(() => {
-    client = Client({
+    client = Client<TestGameState>({
       game: {
+        setup: () => ({
+          deck: [{ id: 'ace', details: { suit: 'spades' } }],
+        }),
         moves: {
           A: ({ G }) => {
             G.moveBody = true;
@@ -27,6 +41,12 @@ describe('immer', () => {
             G.madeInvalidMove = true;
             return INVALID_MOVE;
           },
+          invalidWithDraftPayload: ({ G }) =>
+            Invalid({
+              card: G.deck[0],
+              cards: [G.deck[0]],
+              count: G.deck.length,
+            }),
         },
 
         phases: {
@@ -82,5 +102,15 @@ describe('immer', () => {
   test('invalid move', () => {
     client.moves.invalid();
     expect(client.getState().G.madeInvalidMove).toBeUndefined();
+  });
+
+  test('invalid move snapshots drafts in its payload', () => {
+    client.moves.invalidWithDraftPayload();
+    expect(client.lastActionError.payload).toEqual({
+      card: { id: 'ace', details: { suit: 'spades' } },
+      cards: [{ id: 'ace', details: { suit: 'spades' } }],
+      count: 1,
+    });
+    expect(() => JSON.stringify(client.lastActionError.payload)).not.toThrow();
   });
 });

--- a/src/plugins/plugin-immer.ts
+++ b/src/plugins/plugin-immer.ts
@@ -8,7 +8,8 @@
 
 import { produce } from 'immer';
 import type { Plugin } from '../types';
-import { INVALID_MOVE } from '../core/constants';
+import { isInvalidMoveResult } from '../core/constants';
+import type { INVALID_MOVE, InvalidMoveResult } from '../core/constants';
 
 /**
  * Plugin that allows using Immer to make immutable changes
@@ -20,16 +21,16 @@ const ImmerPlugin: Plugin = {
   fnWrap:
     (move) =>
     (context, ...args) => {
-      let isInvalid = false;
+      let invalidResult: typeof INVALID_MOVE | InvalidMoveResult | undefined;
       const newG = produce(context.G, (G) => {
         const result = move({ ...context, G }, ...args);
-        if (result === INVALID_MOVE) {
-          isInvalid = true;
+        if (isInvalidMoveResult(result)) {
+          invalidResult = result;
           return;
         }
         return result;
       });
-      if (isInvalid) return INVALID_MOVE;
+      if (invalidResult !== undefined) return invalidResult;
       return newG;
     },
 };

--- a/src/plugins/plugin-immer.ts
+++ b/src/plugins/plugin-immer.ts
@@ -6,10 +6,23 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { produce } from 'immer';
+import { current, isDraft, produce } from 'immer';
+import isPlainObject from 'lodash.isplainobject';
 import type { Plugin } from '../types';
-import { isInvalidMoveResult } from '../core/constants';
-import type { INVALID_MOVE, InvalidMoveResult } from '../core/constants';
+import { Invalid, INVALID_MOVE, isInvalidMoveResult } from '../core/constants';
+import type { InvalidMoveResult } from '../core/constants';
+
+/** Snapshot any Immer drafts nested in a JSON-like payload. */
+const snapshotDrafts = (value: unknown): unknown => {
+  if (isDraft(value)) return current(value);
+  if (Array.isArray(value)) return value.map((item) => snapshotDrafts(item));
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, snapshotDrafts(item)]),
+    );
+  }
+  return value;
+};
 
 /**
  * Plugin that allows using Immer to make immutable changes
@@ -25,7 +38,10 @@ const ImmerPlugin: Plugin = {
       const newG = produce(context.G, (G) => {
         const result = move({ ...context, G }, ...args);
         if (isInvalidMoveResult(result)) {
-          invalidResult = result;
+          invalidResult =
+            result === INVALID_MOVE
+              ? result
+              : Invalid(snapshotDrafts(result.payload));
           return;
         }
         return result;

--- a/src/plugins/plugin-immer.ts
+++ b/src/plugins/plugin-immer.ts
@@ -6,9 +6,23 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { produce } from 'immer';
+import { current, isDraft, produce } from 'immer';
+import isPlainObject from 'lodash.isplainobject';
 import type { Plugin } from '../types';
-import { INVALID_MOVE } from '../core/constants';
+import { Invalid, INVALID_MOVE, isInvalidMoveResult } from '../core/constants';
+import type { InvalidMoveResult } from '../core/constants';
+
+/** Snapshot any Immer drafts nested in a JSON-like payload. */
+const snapshotDrafts = (value: unknown): unknown => {
+  if (isDraft(value)) return current(value);
+  if (Array.isArray(value)) return value.map((item) => snapshotDrafts(item));
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, snapshotDrafts(item)]),
+    );
+  }
+  return value;
+};
 
 /**
  * Plugin that allows using Immer to make immutable changes
@@ -20,16 +34,19 @@ const ImmerPlugin: Plugin = {
   fnWrap:
     (move) =>
     (context, ...args) => {
-      let isInvalid = false;
+      let invalidResult: typeof INVALID_MOVE | InvalidMoveResult | undefined;
       const newG = produce(context.G, (G) => {
         const result = move({ ...context, G }, ...args);
-        if (result === INVALID_MOVE) {
-          isInvalid = true;
+        if (isInvalidMoveResult(result)) {
+          invalidResult =
+            result === INVALID_MOVE
+              ? result
+              : Invalid(snapshotDrafts(result.payload));
           return;
         }
         return result;
       });
-      if (isInvalid) return INVALID_MOVE;
+      if (invalidResult !== undefined) return invalidResult;
       return newG;
     },
 };

--- a/src/server/transport/socketio-stress.test.ts
+++ b/src/server/transport/socketio-stress.test.ts
@@ -1,0 +1,637 @@
+/**
+ * @jest-environment node
+ */
+
+/*
+ * Copyright 2026 The boardgame.io Authors
+ *
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+import { isDeepStrictEqual } from 'node:util';
+import { io as ioClient, type Socket } from 'socket.io-client';
+import { Client } from '../../client/client';
+import {
+  SocketIO as ClientSocketIO,
+  type SocketIOTransport,
+} from '../../client/transport/socketio';
+import * as ActionCreators from '../../core/action-creators';
+import { Invalid } from '../../core/constants';
+import { ActivePlayers } from '../../core/turn-order';
+import type {
+  ActionError,
+  CredentialedActionShape,
+  Game,
+  State,
+} from '../../types';
+import { Server } from '../index';
+
+jest.mock('../../core/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.setTimeout(30_000);
+
+type StressG = {
+  cells: Array<string | null>;
+  counter: number;
+};
+
+const game: Game<StressG> = {
+  name: 'socketio-stress',
+  setup: () => ({
+    cells: Array.from({ length: 10 }, (): string | null => null),
+    counter: 0,
+  }),
+  turn: { activePlayers: ActivePlayers.ALL },
+  moves: {
+    take: ({ G, playerID }, cell: number) => {
+      if (G.cells[cell] !== null) return Invalid({ code: 'TAKEN', cell });
+      G.cells[cell] = playerID;
+    },
+    gift: ({ G }) => {
+      G.counter += 1;
+    },
+    reject: () => Invalid({ code: 'NO' }),
+  },
+};
+
+type BurstAction =
+  { type: 'take'; cell: number } | { type: 'gift' } | { type: 'reject' };
+
+type WireMessage = {
+  type: 'sync' | 'update' | 'patch' | 'matchData' | 'actionResult';
+  matchID: string;
+};
+
+type SentAction = {
+  actionID?: number;
+  stateID: number;
+  action: CredentialedActionShape.Any;
+};
+
+type TrackedClient = {
+  matchID: string;
+  playerID: string;
+  client: ReturnType<typeof Client>;
+  transport: SocketIOTransport;
+  sent: SentAction[];
+  notifications: Array<{ state: State<StressG> | null; error?: ActionError }>;
+  wireMessages: WireMessage[];
+  actionResults: Array<{
+    matchID: string;
+    actionID: number;
+    result: { error?: ActionError };
+  }>;
+  updates: Array<{ matchID: string; state: State<StressG> }>;
+  stopped: boolean;
+};
+
+function mulberry32(seed: number) {
+  let value = seed >>> 0;
+  return () => {
+    value = (value + 0x6d_2b_79_f5) >>> 0;
+    let result = value;
+    result = Math.imul(result ^ (result >>> 15), result | 1);
+    result ^= result + Math.imul(result ^ (result >>> 7), result | 61);
+    return ((result ^ (result >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+const wait = (milliseconds: number) =>
+  new Promise<void>((resolve) => void setTimeout(resolve, milliseconds));
+
+async function pollUntil(
+  predicate: () => boolean | Promise<boolean>,
+  label: string,
+  attempts = 400,
+  interval = 10,
+) {
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (await predicate()) return;
+    await wait(interval);
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+const dispatch = (tracked: TrackedClient, action: BurstAction) => {
+  switch (action.type) {
+    case 'take': {
+      tracked.client.moves.take(action.cell);
+      break;
+    }
+    case 'gift': {
+      tracked.client.moves.gift();
+      break;
+    }
+    case 'reject': {
+      tracked.client.moves.reject();
+      break;
+    }
+  }
+};
+
+const createMixedBurst = (seed: number, length: number): BurstAction[] => {
+  const random = mulberry32(seed);
+  const actions = Array.from({ length }, (_, index): BurstAction => {
+    if (index === length - 1) return { type: 'reject' };
+    const choice = random();
+    if (choice < 0.58) {
+      return { type: 'take', cell: Math.floor(random() * 6) };
+    }
+    if (choice < 0.8) return { type: 'gift' };
+    return { type: 'reject' };
+  });
+  actions[0] = { type: 'take', cell: 0 };
+  actions[1] = { type: 'take', cell: 1 };
+  return actions;
+};
+
+const dispatchBurst = async (
+  tracked: TrackedClient,
+  actions: BurstAction[],
+  seed: number,
+  maxJitter: number,
+) => {
+  const random = mulberry32(seed);
+  for (const action of actions) {
+    dispatch(tracked, action);
+    if (maxJitter > 0) {
+      await wait(Math.floor(random() * maxJitter));
+    }
+  }
+};
+
+describe('real Socket.IO action-result stress', () => {
+  let server: ReturnType<typeof Server>;
+  let running: Awaited<ReturnType<ReturnType<typeof Server>['run']>>;
+  let serverURL: string;
+  const trackedClients: TrackedClient[] = [];
+  const rawSockets: Socket[] = [];
+
+  const fetchMatch = async (matchID: string, opts: any) =>
+    await server.db.fetch(matchID, opts);
+
+  const waitForQueueIdle = async (matchID: string) => {
+    await server.transport.getMatchQueue(matchID).onIdle();
+  };
+
+  const createClient = (
+    matchID: string,
+    playerID: string,
+    credentials?: string,
+  ) => {
+    const sent: SentAction[] = [];
+    const notifications: TrackedClient['notifications'] = [];
+    const wireMessages: WireMessage[] = [];
+    const actionResults: TrackedClient['actionResults'] = [];
+    const updates: TrackedClient['updates'] = [];
+    let transport: SocketIOTransport;
+    const socketFactory = ClientSocketIO({
+      server: serverURL,
+      socketOpts: {
+        transports: ['websocket'],
+        forceNew: true,
+        reconnection: false,
+      },
+    });
+
+    const client = Client<StressG>({
+      game,
+      matchID,
+      playerID,
+      credentials,
+      numPlayers: 3,
+      debug: false,
+      multiplayer: (opts) => {
+        transport = socketFactory(opts);
+        const sendAction = transport.sendAction.bind(transport);
+        transport.sendAction = (state, action, actionID) => {
+          sent.push({ actionID, stateID: state._stateID, action });
+          sendAction(state, action, actionID);
+        };
+        return transport;
+      },
+    });
+
+    client.subscribe((state, error) => {
+      notifications.push({ state: state as State<StressG> | null, error });
+    });
+    client.start();
+
+    const socket = transport.socket;
+    socket.on('sync', (receivedMatchID: string) => {
+      wireMessages.push({ type: 'sync', matchID: receivedMatchID });
+    });
+    socket.on('update', (receivedMatchID: string, state: State<StressG>) => {
+      wireMessages.push({ type: 'update', matchID: receivedMatchID });
+      updates.push({ matchID: receivedMatchID, state });
+    });
+    socket.on('patch', (receivedMatchID: string) => {
+      wireMessages.push({ type: 'patch', matchID: receivedMatchID });
+    });
+    socket.on('matchData', (receivedMatchID: string) => {
+      wireMessages.push({ type: 'matchData', matchID: receivedMatchID });
+    });
+    socket.on(
+      'actionResult',
+      (
+        receivedMatchID: string,
+        actionID: number,
+        result: { error?: ActionError },
+      ) => {
+        wireMessages.push({
+          type: 'actionResult',
+          matchID: receivedMatchID,
+        });
+        actionResults.push({ matchID: receivedMatchID, actionID, result });
+      },
+    );
+
+    const tracked: TrackedClient = {
+      matchID,
+      playerID,
+      client,
+      transport,
+      sent,
+      notifications,
+      wireMessages,
+      actionResults,
+      updates,
+      stopped: false,
+    };
+    trackedClients.push(tracked);
+    return tracked;
+  };
+
+  const stopClient = (tracked: TrackedClient) => {
+    if (tracked.stopped) return;
+    tracked.client.stop();
+    tracked.stopped = true;
+  };
+
+  const waitForSynced = async (clients: TrackedClient[]) => {
+    await pollUntil(
+      () =>
+        clients.every(
+          ({ client }) =>
+            client.getState() !== null && client.getState()?.isConnected,
+        ),
+      `clients to sync for ${clients.map(({ matchID }) => matchID).join(', ')}`,
+    );
+    await Promise.all(
+      [...new Set(clients.map(({ matchID }) => matchID))].map((matchID) =>
+        waitForQueueIdle(matchID),
+      ),
+    );
+    await wait(20);
+  };
+
+  const clearActivity = (clients: TrackedClient[]) => {
+    for (const client of clients) {
+      client.notifications.length = 0;
+      client.wireMessages.length = 0;
+      client.actionResults.length = 0;
+      client.updates.length = 0;
+    }
+  };
+
+  const waitForConvergence = async (
+    matchID: string,
+    clients: TrackedClient[],
+  ): Promise<State<StressG>> => {
+    await waitForQueueIdle(matchID);
+    let stableChecks = 0;
+    let previousStateID: number | undefined;
+    let latestServerState: State<StressG>;
+
+    for (let attempt = 0; attempt < 500; attempt++) {
+      const fetchResult = await fetchMatch(matchID, { state: true });
+      latestServerState = fetchResult.state;
+      const converged = clients.every(({ client }) => {
+        const state = client.getState();
+        return (
+          state !== null &&
+          state._stateID === latestServerState._stateID &&
+          isDeepStrictEqual(state.G, latestServerState.G) &&
+          state.ctx.turn === latestServerState.ctx.turn &&
+          state.ctx.currentPlayer === latestServerState.ctx.currentPlayer
+        );
+      });
+      if (converged && previousStateID === latestServerState._stateID) {
+        stableChecks++;
+        if (stableChecks >= 5) return latestServerState;
+      } else {
+        stableChecks = 0;
+      }
+      previousStateID = latestServerState._stateID;
+      await wait(10);
+    }
+
+    const clientStates = clients.map(({ playerID, client }) => ({
+      playerID,
+      state: client.getState(),
+    }));
+    throw new Error(
+      `clients did not converge for ${matchID}: server=${JSON.stringify(
+        latestServerState,
+      )} clients=${JSON.stringify(clientStates)}`,
+    );
+  };
+
+  const expectWireIsolation = (clients: TrackedClient[]) => {
+    for (const client of clients) {
+      expect(client.wireMessages.length).toBeGreaterThan(0);
+      expect(
+        new Set(client.wireMessages.map(({ matchID }) => matchID)),
+      ).toEqual(new Set([client.matchID]));
+    }
+  };
+
+  const ensureContestedCell = async (
+    matchID: string,
+    clients: TrackedClient[],
+    cell: number,
+  ) => {
+    let state = await waitForConvergence(matchID, clients);
+    if (state.G.cells[cell] === null) {
+      clients[1].client.moves.take(cell);
+      clients[2].client.moves.take(cell);
+      state = await waitForConvergence(matchID, clients);
+    }
+    return state;
+  };
+
+  beforeAll(async () => {
+    server = Server({
+      games: [game],
+      origins: ['http://localhost:3000'],
+    });
+    running = await server.run(0);
+    const address = running.appServer.address();
+    if (address === null || typeof address === 'string') {
+      throw new Error('server did not expose a TCP port');
+    }
+    serverURL = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    for (const client of trackedClients.splice(0)) stopClient(client);
+    for (const socket of rawSockets.splice(0)) socket.disconnect();
+    await wait(20);
+  });
+
+  afterAll(() => {
+    server.kill(running);
+  });
+
+  test('contention burst converges and keeps action errors targeted', async () => {
+    const matchID = 'contention';
+    const clients = ['0', '1', '2'].map((playerID) =>
+      createClient(matchID, playerID),
+    );
+    await waitForSynced(clients);
+    clearActivity(clients);
+
+    const scripts: BurstAction[][] = [
+      Array.from({ length: 30 }, () => ({ type: 'gift' as const })),
+      createMixedBurst(0x12_74_01, 30),
+      createMixedBurst(0x12_74_02, 30),
+    ];
+    await Promise.all([
+      dispatchBurst(clients[0], scripts[0], 0x12_74_10, 0),
+      dispatchBurst(clients[1], scripts[1], 0x12_74_11, 3),
+      dispatchBurst(clients[2], scripts[2], 0x12_74_12, 3),
+    ]);
+
+    const finalState = await ensureContestedCell(matchID, clients, 0);
+    const { log } = await fetchMatch(matchID, { log: true });
+    const acceptedGifts = log.filter(
+      ({ action }) =>
+        action.type === 'MAKE_MOVE' && action.payload.type === 'gift',
+    );
+    const acceptedTakes = log.filter(
+      ({ action }) =>
+        action.type === 'MAKE_MOVE' && action.payload.type === 'take',
+    );
+    const takeZero = acceptedTakes.filter(
+      ({ action }) => (action.payload as any).args[0] === 0,
+    );
+
+    expect(finalState.G.counter).toBe(acceptedGifts.length);
+    expect(finalState.G.cells[0]).not.toBeNull();
+    expect(takeZero).toHaveLength(1);
+    expect(takeZero[0].action.payload.playerID).toBe(finalState.G.cells[0]);
+    const cellLedger = finalState.G.cells.map((owner, cell) => ({
+      owner,
+      successfulPlayers: acceptedTakes
+        .filter(({ action }) => (action.payload as any).args[0] === cell)
+        .map(({ action }) => action.payload.playerID),
+    }));
+    expect(cellLedger).toEqual(
+      finalState.G.cells.map((owner) => ({
+        owner,
+        successfulPlayers: owner === null ? [] : [owner],
+      })),
+    );
+    expect(
+      clients[0].notifications.filter(({ error }) => error !== undefined),
+    ).toHaveLength(0);
+    expect(
+      clients[1].notifications.filter(({ error }) => error !== undefined)
+        .length,
+    ).toBeGreaterThan(0);
+    expect(
+      clients[2].notifications.filter(({ error }) => error !== undefined)
+        .length,
+    ).toBeGreaterThan(0);
+    expectWireIsolation(clients);
+  });
+
+  test('concurrent bursts on two matches remain isolated', async () => {
+    const matchA = 'isolation-a';
+    const matchB = 'isolation-b';
+    const clientsA = ['0', '1', '2'].map((playerID) =>
+      createClient(matchA, playerID),
+    );
+    const clientsB = ['0', '1', '2'].map((playerID) =>
+      createClient(matchB, playerID),
+    );
+    await waitForSynced([...clientsA, ...clientsB]);
+    clearActivity([...clientsA, ...clientsB]);
+
+    await Promise.all([
+      dispatchBurst(
+        clientsA[0],
+        Array.from({ length: 18 }, () => ({ type: 'gift' as const })),
+        0x12_74_20,
+        0,
+      ),
+      dispatchBurst(
+        clientsA[1],
+        createMixedBurst(0x12_74_21, 18),
+        0x12_74_22,
+        3,
+      ),
+      dispatchBurst(
+        clientsA[2],
+        createMixedBurst(0x12_74_23, 18),
+        0x12_74_24,
+        3,
+      ),
+      dispatchBurst(
+        clientsB[0],
+        Array.from({ length: 22 }, () => ({ type: 'gift' as const })),
+        0x12_74_25,
+        0,
+      ),
+      dispatchBurst(
+        clientsB[1],
+        createMixedBurst(0x12_74_26, 22),
+        0x12_74_27,
+        3,
+      ),
+      dispatchBurst(
+        clientsB[2],
+        createMixedBurst(0x12_74_28, 22),
+        0x12_74_29,
+        3,
+      ),
+    ]);
+
+    await waitForConvergence(matchA, clientsA);
+    await waitForConvergence(matchB, clientsB);
+    clientsA[0].client.moves.gift();
+    clientsB[1].client.moves.take(9);
+    const finalA = await waitForConvergence(matchA, clientsA);
+    const finalB = await waitForConvergence(matchB, clientsB);
+
+    expect(finalA.G.cells[9]).toBeNull();
+    expect(finalB.G.cells[9]).toBe('1');
+    expectWireIsolation([...clientsA, ...clientsB]);
+  });
+
+  test('two tabs for one player target the result only to the sending tab', async () => {
+    const matchID = 'same-player-tabs';
+    const tabA = createClient(matchID, '0', 'shared');
+    const tabB = createClient(matchID, '0', 'shared');
+    const observer = createClient(matchID, '1');
+    await waitForSynced([tabA, tabB, observer]);
+    clearActivity([tabA, tabB, observer]);
+
+    tabA.client.moves.reject();
+    await pollUntil(
+      () =>
+        tabA.notifications.some(({ error }) => error !== undefined) &&
+        tabB.updates.length > 0,
+      'the invalid result and shared broadcast',
+    );
+    await waitForQueueIdle(matchID);
+
+    const tabAErrors = tabA.notifications
+      .map(({ error }) => error)
+      .filter((error): error is ActionError => error !== undefined);
+    expect(tabAErrors).toEqual([
+      { type: 'action/invalid_move', payload: { code: 'NO' } },
+    ]);
+    expect(tabA.actionResults).toHaveLength(1);
+    expect(tabB.actionResults).toHaveLength(0);
+    expect(
+      tabB.notifications.filter(({ error }) => error !== undefined),
+    ).toHaveLength(0);
+    expect(tabB.updates.length).toBeGreaterThan(0);
+    expectWireIsolation([tabA, tabB, observer]);
+  });
+
+  test('an old client without action IDs receives no actionResult', async () => {
+    const matchID = 'old-client';
+    const socket = ioClient(`${serverURL}/${game.name}`, {
+      transports: ['websocket'],
+      forceNew: true,
+      reconnection: false,
+    });
+    rawSockets.push(socket);
+    const actionResults: unknown[] = [];
+    const syncs: Array<{ matchID: string; state: State<StressG> }> = [];
+    const updates: Array<{ matchID: string; state: State<StressG> }> = [];
+    socket.on('actionResult', (...args) => actionResults.push(args));
+    socket.on(
+      'sync',
+      (receivedMatchID: string, info: { state: State<StressG> }) =>
+        syncs.push({ matchID: receivedMatchID, state: info.state }),
+    );
+    socket.on('update', (receivedMatchID: string, state: State<StressG>) =>
+      updates.push({ matchID: receivedMatchID, state }),
+    );
+
+    await pollUntil(() => socket.connected, 'raw socket connection');
+    socket.emit('sync', matchID, '0', undefined, 3);
+    await pollUntil(() => syncs.length === 1, 'raw client sync');
+
+    socket.emit(
+      'update',
+      ActionCreators.makeMove('gift', [], '0'),
+      syncs[0].state._stateID,
+      matchID,
+      '0',
+    );
+    await pollUntil(
+      () => updates.some(({ state }) => state.G.counter === 1),
+      'first old-client update',
+    );
+    const stateID = updates.at(-1).state._stateID;
+    socket.emit(
+      'update',
+      ActionCreators.makeMove('gift', [], '0'),
+      stateID,
+      matchID,
+      '0',
+    );
+    await pollUntil(
+      () => updates.some(({ state }) => state.G.counter === 2),
+      'follow-up old-client update',
+    );
+    await wait(300);
+
+    expect(actionResults).toHaveLength(0);
+    expect(new Set(updates.map(({ matchID }) => matchID))).toEqual(
+      new Set([matchID]),
+    );
+    const { state } = await fetchMatch(matchID, { state: true });
+    expect(state.G.counter).toBe(2);
+  });
+
+  test('disconnecting with a queued action does not break the match', async () => {
+    const matchID = 'disconnect-mid-flight';
+    const departing = createClient(matchID, '0');
+    const remaining = createClient(matchID, '1');
+    await waitForSynced([departing, remaining]);
+    clearActivity([departing, remaining]);
+
+    const queue = server.transport.getMatchQueue(matchID);
+    queue.pause();
+    departing.client.moves.gift();
+    await pollUntil(
+      () => queue.size > 0,
+      'the departing client action to queue',
+    );
+    stopClient(departing);
+    queue.start();
+    await queue.onIdle();
+    await pollUntil(
+      () =>
+        (remaining.client.getState() as State<StressG> | null)?.G.counter === 1,
+      'remaining client to receive the queued move',
+    );
+
+    remaining.client.moves.gift();
+    const finalState = await waitForConvergence(matchID, [remaining]);
+
+    expect(finalState.G.counter).toBe(2);
+    expect(remaining.client.getState()?.G).toEqual(finalState.G);
+    expectWireIsolation([remaining]);
+  });
+});

--- a/src/server/transport/socketio.ts
+++ b/src/server/transport/socketio.ts
@@ -194,7 +194,7 @@ export class SocketIO {
 
       nsp.on('connection', (socket: IOTypes.Socket) => {
         socket.on('update', async (...args: Parameters<Master['onUpdate']>) => {
-          const [action, stateID, matchID, playerID] = args;
+          const matchID = args[2];
           const master = new Master(
             game,
             app.context.db,
@@ -203,9 +203,7 @@ export class SocketIO {
           );
 
           const matchQueue = this.getMatchQueue(matchID);
-          await matchQueue.add(() =>
-            master.onUpdate(action, stateID, matchID, playerID),
-          );
+          await matchQueue.add(() => master.onUpdate(...args));
         });
 
         socket.on('sync', async (...args: Parameters<Master['onSync']>) => {

--- a/src/server/transport/socketio.ts
+++ b/src/server/transport/socketio.ts
@@ -12,7 +12,16 @@ import https from 'node:https';
 import { Server as IOServer } from 'socket.io';
 import type IOTypes from 'socket.io';
 import type { ServerOptions as HttpsOptions } from 'node:https';
-import PQueue from 'p-queue';
+import PQueueModule from 'p-queue';
+import type PQueue from 'p-queue';
+
+// p-queue@6 ships CommonJS with `exports.default`. When this file is
+// bundled to CJS the default import interops cleanly, but in the native
+// ESM server build it binds to the CJS exports object itself, making
+// `new PQueue()` throw "PQueue is not a constructor". Unwrap so both
+// builds get the class.
+const PQueueCtor = ((PQueueModule as unknown as { default?: typeof PQueue })
+  .default ?? PQueueModule) as typeof PQueue;
 import { Master } from '../../master/master';
 import type {
   TransportAPI as MasterTransport,
@@ -276,7 +285,7 @@ export class SocketIO {
   getMatchQueue(matchID: string): PQueue {
     if (!this.perMatchQueue.has(matchID)) {
       // PQueue should process only one action at a time.
-      this.perMatchQueue.set(matchID, new PQueue({ concurrency: 1 }));
+      this.perMatchQueue.set(matchID, new PQueueCtor({ concurrency: 1 }));
     }
     return this.perMatchQueue.get(matchID);
   }

--- a/src/server/transport/socketio.ts
+++ b/src/server/transport/socketio.ts
@@ -185,7 +185,7 @@ export class SocketIO {
 
       nsp.on('connection', (socket: IOTypes.Socket) => {
         socket.on('update', async (...args: Parameters<Master['onUpdate']>) => {
-          const [action, stateID, matchID, playerID] = args;
+          const matchID = args[2];
           const master = new Master(
             game,
             app.context.db,
@@ -194,9 +194,7 @@ export class SocketIO {
           );
 
           const matchQueue = this.getMatchQueue(matchID);
-          await matchQueue.add(() =>
-            master.onUpdate(action, stateID, matchID, playerID),
-          );
+          await matchQueue.add(() => master.onUpdate(...args));
         });
 
         socket.on('sync', async (...args: Parameters<Master['onSync']>) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ import type * as ActionCreators from './core/action-creators';
 import type { ActionErrorType, UpdateErrorType } from './core/errors';
 import type { Flow } from './core/flow';
 import type { CreateGameReducer } from './core/reducer';
-import type { INVALID_MOVE } from './core/constants';
+import type { INVALID_MOVE, InvalidMoveResult } from './core/constants';
 import type { GameMethod } from './core/game-methods';
 import type { Auth } from './server/auth';
 import type * as StorageAPI from './server/db/base';
@@ -203,7 +203,7 @@ export type MoveFn<
 > = (
   context: FnContext<G, PluginAPIs> & { playerID: PlayerID },
   ...args: any[]
-) => void | G | typeof INVALID_MOVE;
+) => void | G | typeof INVALID_MOVE | InvalidMoveResult;
 
 export interface LongFormMove<
   G extends any = any,
@@ -360,7 +360,7 @@ export interface Game<
   processMove?: (
     state: State<G>,
     action: ActionPayload.MakeMove,
-  ) => State<G> | typeof INVALID_MOVE;
+  ) => State<G> | typeof INVALID_MOVE | InvalidMoveResult;
   processPlayerLeave?: (state: State<G>, playerID: PlayerID) => State<G>['G'];
   flow?: ReturnType<typeof Flow>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ import type * as ActionCreators from './core/action-creators';
 import type { ActionErrorType, UpdateErrorType } from './core/errors';
 import type { Flow } from './core/flow';
 import type { CreateGameReducer } from './core/reducer';
-import type { INVALID_MOVE } from './core/constants';
+import type { INVALID_MOVE, InvalidMoveResult } from './core/constants';
 import type { GameMethod } from './core/game-methods';
 import type { Auth } from './server/auth';
 import type * as StorageAPI from './server/db/base';
@@ -203,7 +203,7 @@ export type MoveFn<
 > = (
   context: FnContext<G, PluginAPIs> & { playerID: PlayerID },
   ...args: any[]
-) => void | G | typeof INVALID_MOVE;
+) => void | G | typeof INVALID_MOVE | InvalidMoveResult;
 
 export interface LongFormMove<
   G extends any = any,
@@ -371,7 +371,7 @@ export interface Game<
   processMove?: (
     state: State<G>,
     action: ActionPayload.MakeMove,
-  ) => State<G> | typeof INVALID_MOVE;
+  ) => State<G> | typeof INVALID_MOVE | InvalidMoveResult;
   processPlayerLeave?: (state: State<G>, playerID: PlayerID) => State<G>['G'];
   flow?: ReturnType<typeof Flow>;
 }


### PR DESCRIPTION
## Problem

When an action is rejected, the acting player receives no structured result: `INVALID_MOVE` silently rolls state back, and pre-dispatch failures such as stale state or an inactive player are also silent (#723, #592). Games work around this by duplicating validation on the client.

Addresses #723. Provides the transport foundation for a promise-based call-site API in #592. Related: #292.

## What this adds

### 1. Moves can attach a rejection reason

Moves may return `Invalid(payload)` from `boardgame.io/core`:

```ts
const recruit: Move = ({ G, playerID }, count) => {
  if (G.gold[playerID] < COST * count) {
    return Invalid({ code: 'NO_GOLD', message: 'Not enough gold' });
  }
  // ...
};
```

`return INVALID_MOVE` behaves exactly as before, with an `undefined` payload.

Invalid results use a registry symbol so separately built subpackages share the same runtime identity. The public `InvalidMoveResult` type also has a required private brand, so ordinary `{ payload: ... }` objects cannot be mistaken for invalid results by TypeScript.

The payload is extracted into transient error metadata before state is persisted or sent to other players.

### 2. The master returns a correlated action result

Each multiplayer action receives a client-local action ID. The master echoes it in a targeted `actionResult` containing either success or an `ActionError`.

This covers both reducer errors, including `Invalid(payload)` and plugin validation, and pre-dispatch errors such as stale state IDs, unavailable moves, inactive players, authentication failures, and missing matches.

The normal state update or rollback broadcast is unchanged. Only the acting client receives its action result and rejection payload.

### 3. Clients expose errors without duplicate or stale notifications

Multiplayer clients wait for the authoritative master result instead of surfacing the same optimistic rejection first. Results older than the client’s latest submitted action are ignored, so a delayed rejection cannot overwrite a newer action.

```ts
client.subscribe((state, error) => {
  if (error) {
    showToast(error.payload?.message ?? 'Invalid action');
  }
});
```

The second subscriber argument is a one-time rejection event: unrelated notifications pass `undefined`. `client.lastActionError` remains available for persistent inspection and is cleared when a subsequent action succeeds. React boards receive the same value as a `lastActionError` prop.

When a rejected move had been applied optimistically, the client requests a sync to restore the authoritative state. Without this, a client that pipelined moves ahead of a rejection stayed forked: rollback broadcasts carry a stateID below the optimistic local state and are ignored. This divergence predates this PR (reproducible on `main` whenever the master rejects an optimistically applied move); the correlated result channel is what makes the repair possible. The healing sync preserves `lastActionError` and the pending action ID, so a rejection survives the rollback it explains, and an action dispatched while the repair is in flight still receives its own result. An unsolicited sync, such as one following a reconnect, still clears both.

Single-player clients use the same public contract, reading their result directly from reducer transients.

## Backwards compatibility

- Old client + new server: old clients send no action ID, so the server preserves the previous silent-result behavior.
- New client + old server: the extra update argument is ignored and no action result is delivered.
- Persisted state, storage adapters, logs, and replays are unchanged; transient errors and action IDs are not persisted.
- Existing one-argument subscribers remain compatible.
- Custom transports remain source-compatible because the new `sendAction` argument is optional, but must forward the action ID and `actionResult` message to support rejection delivery.
- Plugin authors comparing move results with `result === INVALID_MOVE` should use the exported `isInvalidMoveResult()` to also recognise `Invalid(payload)`.

## Docs

Included:

- `Invalid(payload)` in the immutability guide.
- One-time rejection events in `subscribe((state, error))`.
- `client.lastActionError` and the React `lastActionError` board prop.

## Tests and coverage

Coverage includes:

- Reducer payload threading, including Immer mutation rollback.
- Stable invalid-result identity across separately built bundles.
- Master targeting and correlated success/error results.
- Pre-dispatch rejection results.
- Local, multiplayer, synchronous-transport, and stale-result client lifecycles.
- Error clearing after a later successful move or undo.
- Socket.IO action ID forwarding and action-result delivery.
- Legacy `INVALID_MOVE` behavior.
- Seeded interleaving fuzz over a virtual per-channel FIFO network (real client, master, and storage): exactly-once targeted results, convergence with the stored master state, ledger consistency, stale-result and error-event discipline; 25 seeds in CI, `STRESS_SEEDS=<n>` to soak. Directed races cover cell contention, pipelined rejection, result-before-broadcast skew, sync racing an in-flight result, reentrant dispatch, and the optimistic self-heal.
- Real Socket.IO end-to-end stress: contention bursts, cross-match isolation, two tabs for one player, old-client compatibility, and disconnect mid-flight.


## Follow-ups

- Strongly typed error payloads (`unknown` instead of `any`; see #732).
- Promise-based call-site API for #592, layered on the correlated action-result channel.



