### PR TITLE
Fix flaky server tests: bind test servers to 127.0.0.1

### DIFF
--- a/docs/documentation/api/Server.md
+++ b/docs/documentation/api/Server.md
@@ -119,6 +119,10 @@ boardgame.io `port`.
 - `apiCallback`: Called when the Koa server is ready. Only applicable if
 `apiPort` is specified.
 
+The run config also accepts a `host` alongside `port`, which binds both the
+game server and the Lobby API server to that host. It defaults to all
+interfaces.
+
 #### With HTTPS
 
 ```js

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -26,8 +26,6 @@ import { InMemory } from './db/inmemory';
 import { Origins } from './cors';
 import type { Game, Server } from '../types';
 
-jest.setTimeout(2_000_000_000);
-
 beforeEach(() => {
   dateMock.clear();
 });

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -10,6 +10,8 @@
  * https://opensource.org/licenses/MIT.
  */
 
+import http from 'node:http';
+import { once } from 'node:events';
 import request from 'supertest';
 import Koa from 'koa';
 import Router from '@koa/router';
@@ -99,8 +101,26 @@ describe('.configureRouter', () => {
     return app;
   }
 
+  // A single suite-level server bound explicitly to 127.0.0.1. Letting
+  // supertest create a server per request would bind the wildcard address,
+  // where the kernel may allocate an ephemeral port that another local
+  // process holds on 127.0.0.1, silently routing requests to that process.
+  let currentApp: ReturnType<Koa['callback']>;
+  const httpServer = http.createServer((req, res) => currentApp(req, res));
+
+  beforeAll(async () => {
+    httpServer.listen(0, '127.0.0.1');
+    await once(httpServer, 'listening');
+  });
+
+  afterAll(async () => {
+    httpServer.close();
+    await once(httpServer, 'close');
+  });
+
   function apiCall(app: Koa) {
-    const agent = request(app.callback());
+    currentApp = app.callback();
+    const agent = request(httpServer);
     return {
       get: (path: string) => agent.get(path).set('Connection', 'close'),
       post: (path: string) => agent.post(path).set('Connection', 'close'),

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -128,8 +128,9 @@ describe('run', () => {
   test('multiple servers running', async () => {
     server = Server({ games: [game] });
     runningServer = await server.run({
-      port: 57_890,
-      lobbyConfig: { apiPort: 57_891 },
+      port: 0,
+      host: '127.0.0.1',
+      lobbyConfig: { apiPort: 0 },
     });
 
     expect(server).not.toBeUndefined();
@@ -148,7 +149,8 @@ describe('run', () => {
     const apiCallback = jest.fn();
     server = Server({ games: [game] });
     runningServer = await server.run({
-      lobbyConfig: { apiPort: 9999, apiCallback },
+      host: '127.0.0.1',
+      lobbyConfig: { apiPort: 0, apiCallback },
     });
     expect(apiCallback).toHaveBeenCalled();
   });
@@ -163,7 +165,7 @@ describe('run', () => {
     server = Server({ games: [game] });
     server.router.use('/games', usedMiddleware);
     server.router.use('/games/unused', unusedMiddleware);
-    runningServer = await server.run(8888);
+    runningServer = await server.run({ port: 0, host: '127.0.0.1' });
 
     await request(runningServer.appServer).get('/games');
     expect(usedMiddleware).toHaveBeenCalled();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -22,6 +22,8 @@ export type KoaServer = ReturnType<Koa['listen']>;
 
 interface ServerConfig {
   port?: number;
+  /** Host or IP to bind to (both game server and Lobby API). Defaults to all interfaces. */
+  host?: string;
   callback?: () => void;
   lobbyConfig?: {
     apiPort: number;
@@ -154,9 +156,9 @@ export function Server({
       await db.connect();
 
       // Lobby API
-      const lobbyConfig = serverRunConfig.lobbyConfig;
+      const { port, host, lobbyConfig } = serverRunConfig;
       let apiServer: KoaServer | undefined;
-      if (!lobbyConfig || !lobbyConfig.apiPort) {
+      if (!lobbyConfig || lobbyConfig.apiPort == null) {
         configureApp(app, router, apiOrigins);
       } else {
         // Run API in a separate Koa app.
@@ -165,7 +167,7 @@ export function Server({
         api.context.auth = auth;
         configureApp(api, router, apiOrigins);
         await new Promise<void>((resolve) => {
-          apiServer = api.listen(lobbyConfig.apiPort, () => resolve());
+          apiServer = api.listen(lobbyConfig.apiPort, host, () => resolve());
         });
         if (lobbyConfig.apiCallback) lobbyConfig.apiCallback();
         logger.info(`API serving on ${getPortFromServer(apiServer)}...`);
@@ -176,8 +178,8 @@ export function Server({
       const httpServer = transport.server;
       await new Promise<void>((resolve) => {
         appServer = httpServer
-          ? httpServer.listen(serverRunConfig.port, () => resolve())
-          : app.listen(serverRunConfig.port, () => resolve());
+          ? httpServer.listen(port, host, () => resolve())
+          : app.listen(port, host, () => resolve());
       });
       if (serverRunConfig.callback) serverRunConfig.callback();
       logger.info(`App serving on ${getPortFromServer(appServer)}...`);


### PR DESCRIPTION
## Problem

`src/server/api.test.ts` failed ~8% of local runs with `Parse Error: Expected HTTP/`, wrong statuses, or truncated bodies — a different test failing each time.

Root cause: supertest creates a server per request with host-less `listen(0)`, which binds the **wildcard** address. The kernel may hand out an ephemeral port that another local process already holds on `127.0.0.1` (observed here with IntelliJ's built-in web server and Ollama — both binds succeed and coexist). supertest then dials `127.0.0.1:port`, and the kernel routes the connection to the most-specific bind: the foreign process. Depending on who answers, you get their 404 page, an unrelated 200, or non-HTTP bytes. Nothing ever fails loudly, which is what made this a heisenbug — and why CI (no IDE listening on localhost) never saw it.

## Fix

The invariant is *bind address == dial address*:

- **api.test.ts**: one suite-level `http.Server` bound explicitly to `127.0.0.1`, delegating to the current test's Koa callback. supertest receives the already-listening server, so it never binds anything itself. (Note: the bind must be awaited — `listen(port, host)` resolves the host asynchronously, and supertest silently re-listens on the wildcard when handed a non-listening server.) Also drops a leftover `jest.setTimeout(2_000_000_000)`.
- **index.test.ts** had the same hazard plus fixed ports (8888, 9999, 57890/57891 — the last two inside the macOS ephemeral range, so any transient outgoing connection can occupy them). Tests now use ephemeral ports bound to `127.0.0.1`, enabled by two small `Server.run` changes:
  - a new optional `host` in the run config, passed to all listen calls (documented in `docs/documentation/api/Server.md`);
  - `apiPort: 0` now means "ephemeral API port" — previously the falsy check silently ignored it (`null`/`undefined` behave as before).

## Verification

- Reproduced pre-fix at 2/20 and 3/40 suite runs; instrumentation correlated failing requests to the foreign listeners by socket port.
- Post-fix: 110 consecutive clean runs across the two suites.
- Full suite green (42 suites / 883 tests), lint clean, `src/server/index.ts` stays at 100% coverage.

#### Checklist

- [x] Use a separate branch in your local repo (not `main`).
- [x] Test coverage is 100% (or you have a story for why it's ok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNK7XYPXjxHpKJUCL52kVt