### PR TITLE
docs(changelog): classify v0.43.3 serializability check as breaking

### DIFF
--- a/docs/documentation/CHANGELOG.md
+++ b/docs/documentation/CHANGELOG.md
@@ -362,9 +362,12 @@ See [the Server reference page](https://boardgame.io/documentation/#/api/Server)
 
 ### v0.43.3
 
-#### Features
+#### Breaking Changes
 
 * [[01c522c](https://github.com/boardgameio/boardgame.io/commit/01c522c)] Throw error in development if non-serializable state is used in a move ([#896](https://github.com/boardgameio/boardgame.io/pull/896))
+
+#### Features
+
 * [[ccc9ada](https://github.com/boardgameio/boardgame.io/commit/ccc9ada)] Add details to exceptions raised in LobbyClient ([#898](https://github.com/boardgameio/boardgame.io/pull/898))
 
 #### Bugfixes

--- a/docs/documentation/CHANGELOG.md
+++ b/docs/documentation/CHANGELOG.md
@@ -364,6 +364,8 @@ See [the Server reference page](https://boardgame.io/documentation/#/api/Server)
 
 #### Breaking Changes
 
+Putting non-serializable values in `G` — class instances, `Map`/`Set`, `Date`, functions — now throws in development. The check runs on the state a move returns or mutates, and also on state produced by `setup` and by turn/phase hooks. Convert such values to plain objects or arrays before storing them in `G`. Production builds are unaffected.
+
 * [[01c522c](https://github.com/boardgameio/boardgame.io/commit/01c522c)] Throw error in development if non-serializable state is used in a move ([#896](https://github.com/boardgameio/boardgame.io/pull/896))
 
 #### Features


### PR DESCRIPTION
## Summary

- classify the v0.43.3 non-serializable-state enforcement as a breaking change
- keep the LobbyClient exception-detail entry under features

Closes #1187

## Verification

- `pnpm exec prettier --check docs/documentation/CHANGELOG.md`
- `git diff --check`