### PR TITLE
test(client): assert debug panel mounts and unmounts on start/stop

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1023,10 +1023,19 @@ describe('start / stop', () => {
   test('mount on custom element', () => {
     const el = document.createElement('div');
     const client = Client({ game: {}, debug: { target: el } });
-    expect(() => {
-      client.start();
-      client.stop();
-    }).not.toThrow();
+
+    client.start();
+    expect(el.childElementCount).toBeGreaterThan(0);
+
+    client.stop();
+    expect(el.childElementCount).toBe(0);
+
+    // Restarting the client mounts the debug panel again.
+    client.start();
+    expect(el.childElementCount).toBeGreaterThan(0);
+
+    client.stop();
+    expect(el.childElementCount).toBe(0);
     expect(error).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
The `start / stop` suite's `mount on custom element` test only checked that `client.start()`/`client.stop()` don't throw. It now asserts what the suite was always meant to validate: `start()` mounts the debug panel into the target element, `stop()` unmounts it, and a subsequent restart mounts it again.

Closes #941