### PR TITLE
fix: pass the game's ai options to Debug Panel and Local bots

### DIFF
--- a/src/client/debug/ai/AI.svelte
+++ b/src/client/debug/ai/AI.svelte
@@ -44,8 +44,8 @@
   let bot;
   if (client.game.ai) {
     bot = new MCTSBot({
+      ...client.game.ai,
       game: client.game,
-      enumerate: client.game.ai.enumerate,
       iterationCallback,
     });
     bot.setOpt('async', true);
@@ -57,8 +57,8 @@
   function ChangeBot() {
     const botConstructor = bots[selectedBot];
     bot = new botConstructor({
+      ...client.game.ai,
       game: client.game,
-      enumerate: client.game.ai.enumerate,
       iterationCallback,
     });
     bot.setOpt('async', true);

--- a/src/client/debug/tests/debug.test.ts
+++ b/src/client/debug/tests/debug.test.ts
@@ -39,6 +39,31 @@ test('switching panels', async () => {
   client.stop();
 });
 
+test('AI panel bot uses the game’s ai options', async () => {
+  const client = Client({
+    game: {
+      moves: { clickCell: () => {} },
+      ai: {
+        enumerate: () => [{ move: 'clickCell', args: [0] }],
+        iterations: 42,
+        playoutDepth: 7,
+      },
+    },
+  });
+  client.start();
+
+  await fireEvent.click(screen.getByText('AI'));
+
+  const iterations = screen.getByLabelText('iterations') as HTMLInputElement;
+  const playoutDepth = screen.getByLabelText(
+    'playoutDepth',
+  ) as HTMLInputElement;
+  expect(iterations.value).toBe('42');
+  expect(playoutDepth.value).toBe('7');
+
+  client.stop();
+});
+
 test('visibility toggle', async () => {
   const client = Client({ game: {} });
   client.start();

--- a/src/client/transport/local.test.ts
+++ b/src/client/transport/local.test.ts
@@ -47,6 +47,33 @@ describe('bots', () => {
     expect(client.getState().ctx.turn).toBe(3);
   });
 
+  test('bots are constructed with the game’s ai options', () => {
+    const botOptions = [];
+    class SpyBot extends RandomBot {
+      constructor(opts) {
+        super(opts);
+        botOptions.push(opts);
+      }
+    }
+    const objectives = () => ({});
+
+    new LocalMaster({
+      game: ProcessGameConfig({
+        ...game,
+        ai: { ...game.ai, iterations: 42, playoutDepth: 7, objectives },
+      }),
+      bots: { '1': SpyBot },
+    });
+
+    expect(botOptions).toHaveLength(1);
+    expect(botOptions[0]).toMatchObject({
+      enumerate: expect.any(Function),
+      iterations: 42,
+      playoutDepth: 7,
+      objectives,
+    });
+  });
+
   test('no bot move', async () => {
     const client = Client({
       numPlayers: 3,

--- a/src/client/transport/local.ts
+++ b/src/client/transport/local.ts
@@ -71,8 +71,8 @@ export class LocalMaster extends Master {
       for (const playerID in bots) {
         const bot = bots[playerID];
         initializedBots[playerID] = new bot({
+          ...game.ai,
           game,
-          enumerate: game.ai.enumerate,
           seed: game.seed,
         });
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -365,6 +365,8 @@ export interface Game<
   plugins?: Array<Plugin<any, any, G>>;
   ai?: {
     enumerate: (G: G, ctx: Ctx, playerID: PlayerID) => AiEnumerate;
+    // bot options forwarded by the Debug Panel, e.g. MCTSBot's iterations/playoutDepth/objectives (#7)
+    [option: string]: unknown;
   };
   processMove?: (
     state: State<G>,


### PR DESCRIPTION
The Debug Panel constructed its bots with only `client.game.ai.enumerate`, dropping any other options defined on `game.ai`, reported for `objectives` in #7 (https://github.com/boardgameio/boardgame.io/issues/7#issuecomment-815012624), and the same applied to `iterations` and `playoutDepth` even though the tutorial says the 1000-iteration default "can be configured". `Local({ bots })` built its bots the same narrow way, on the path where bots actually play.

Changes:
- `AI.svelte` now spreads `client.game.ai` into the bot constructor (both on initial mount and when switching bots), with `game` and `iterationCallback` listed after the spread so they can't be overridden. This is the fix delucis suggested in the thread.
- `LocalMaster` does the same for `Local({ bots })`, with `game` and `seed` after the spread. Without it the two paths disagree silently — a bot tuned in the panel plays differently in the real game, which is harder to spot than the original bug (thanks @devill for catching it).
- `Game['ai']` gains an index signature so TypeScript games can actually declare these extra options. Typing them precisely would mean importing MCTSBot types into `types.ts` (circular), so the extra keys stay `unknown`. Worth being explicit about the cost: this also turns off excess-property checking for `ai`, so a typo like `iteratons: 42` used to be a `TS2353` error and now compiles and is dropped silently by the bot's destructuring. Nothing in the current code catches that; a dev-only check on the MCTSBot side would, and covers third-party bots too — follow-up, not this PR.
- New debug-panel test asserting a game with `ai: { iterations: 42, playoutDepth: 7 }` shows those values in the AI tab's option sliders (previously the 1000/50 defaults), plus a Local transport test asserting the bot constructor receives `iterations`, `playoutDepth` and `objectives`.

## Verification

- Each test fails without its own fix: the panel test reads `1000` instead of `42`; the transport test loses all three keys.
- Full suite: 43 suites, 903 tests passing. `tsc --noEmit`, ESLint and Prettier clean on the changed files.

Related: #7 (stays open — this covers the debug-panel and local-play paths from that thread)