### PR TITLE
feat(core): pass move name and args to turn.onMove

### DIFF
--- a/docs/documentation/api/Game.md
+++ b/docs/documentation/api/Game.md
@@ -66,7 +66,8 @@
     ),
 
     // Called after each move.
-    onMove: ({ G, ctx, events, random, ...plugins }) => G,
+    // move describes the move that was made: { name, args }.
+    onMove: ({ G, ctx, move, events, random, ...plugins }) => G,
 
     // Prevents ending the turn before a minimum number of moves.
     minMoves: 1,

--- a/src/core/flow.test.ts
+++ b/src/core/flow.test.ts
@@ -253,6 +253,15 @@ describe('turn', () => {
       );
       expect(state.G.playerID).toEqual(playerID);
     });
+
+    test('ctx with move name and args', () => {
+      const flow = Flow({
+        turn: { onMove: ({ move }) => ({ move }) },
+      });
+      let state = { G: {}, ctx: flow.ctx(2) } as State;
+      state = flow.processMove(state, makeMove('A', [1, 2], '0').payload);
+      expect(state.G.move).toEqual({ name: 'A', args: [1, 2] });
+    });
   });
 
   describe('disableLog', () => {

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -27,6 +27,7 @@ import type {
   FnContext,
   LogEntry,
   Game,
+  MoveInfo,
   PhaseConfig,
   PlayerID,
   Move,
@@ -86,13 +87,14 @@ export function Flow({
     hookType: GameMethod,
   ) => {
     const withPlugins = plugin.FnWrap(hook, hookType, plugins);
-    return (state: State & { playerID?: PlayerID }) => {
+    return (state: State & { playerID?: PlayerID; move?: MoveInfo }) => {
       const pluginAPIs = plugin.GetAPIs(state);
       return withPlugins({
         ...pluginAPIs,
         G: state.G,
         ctx: state.ctx,
         playerID: state.playerID,
+        ...(state.move !== undefined && { move: state.move }),
       });
     };
   };
@@ -723,7 +725,7 @@ export function Flow({
   }
 
   function ProcessMove(state: State, action: ActionPayload.MakeMove): State {
-    const { playerID, type } = action;
+    const { playerID, type, args } = action;
     const { currentPlayer, activePlayers, _activePlayersMaxMoves } = state.ctx;
     const move = GetMove(state.ctx, type, playerID);
     const shouldCount =
@@ -752,7 +754,11 @@ export function Flow({
     }
 
     const phaseConfig = GetPhase(state.ctx);
-    const G = phaseConfig.turn.wrapped.onMove({ ...state, playerID });
+    const G = phaseConfig.turn.wrapped.onMove({
+      ...state,
+      playerID,
+      move: { name: type, args },
+    });
     state = { ...state, G };
 
     const events = [{ fn: OnMove }];

--- a/src/types.ts
+++ b/src/types.ts
@@ -274,6 +274,12 @@ export interface TurnOrderConfig<
   playOrder?: (context: FnContext<G, PluginAPIs>) => PlayerID[];
 }
 
+/** Details of the move that invoked the `turn.onMove` hook. */
+export interface MoveInfo {
+  name: string;
+  args?: any;
+}
+
 export interface TurnConfig<
   G extends any = any,
   PluginAPIs extends Record<string, unknown> = Record<string, unknown>,
@@ -289,7 +295,7 @@ export interface TurnConfig<
     context: FnContext<G, PluginAPIs>,
   ) => boolean | void | { next: PlayerID };
   onMove?: (
-    context: FnContext<G, PluginAPIs> & { playerID: PlayerID },
+    context: FnContext<G, PluginAPIs> & { playerID: PlayerID; move: MoveInfo },
   ) => void | G;
   stages?: StageMap<G, PluginAPIs>;
   order?: TurnOrderConfig<G, PluginAPIs>;
@@ -297,7 +303,9 @@ export interface TurnConfig<
     endIf?: (state: State<G>) => boolean | void | { next: PlayerID };
     onBegin?: (state: State<G>) => void | G;
     onEnd?: (state: State<G>) => void | G;
-    onMove?: (state: State<G> & { playerID: PlayerID }) => void | G;
+    onMove?: (
+      state: State<G> & { playerID: PlayerID; move?: MoveInfo },
+    ) => void | G;
   };
 }
 


### PR DESCRIPTION
`turn.onMove` previously received only the standard hook context plus `playerID`, so games reacting to moves (side effects, derived state, logging) had no way to know *which* move was made without duplicating that information into `G` from every move — the ask in #861.

The hook context now includes `move: { name, args }`, taken from the action payload at the existing `ProcessMove` call site. `HookWrapper` only forwards the field when set, so other hooks' contexts are unchanged, and the addition is fully backwards-compatible.

Includes a flow test and the Game API doc update.

Closes #861