### PR TITLE
feat(core): add disableLog option to suppress the game log

### DIFF
--- a/docs/documentation/api/Game.md
+++ b/docs/documentation/api/Game.md
@@ -140,6 +140,10 @@
   // Disable undo feature for all the moves in the game
   disableUndo: true,
 
+  // Disable the game log: no log entries are created or stored.
+  // Note that the Debug Panel's log and time travel need the log.
+  disableLog: true,
+
   // Transfer delta state with JSON Patch in multiplayer
   deltaState: true,
 }

--- a/src/core/flow.test.ts
+++ b/src/core/flow.test.ts
@@ -255,6 +255,16 @@ describe('turn', () => {
     });
   });
 
+  describe('disableLog', () => {
+    test('events do not append log entries', () => {
+      const flow = Flow({ disableLog: true });
+      let state = { G: {}, ctx: flow.ctx(2) } as State;
+      state = flow.processEvent(state, gameEvent('endTurn'));
+      expect(state.ctx.turn).toBe(1);
+      expect(state.deltalog).toEqual([]);
+    });
+  });
+
   describe('minMoves', () => {
     describe('without phases', () => {
       const flow = Flow({

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -47,6 +47,7 @@ export function Flow({
   turn,
   events,
   plugins,
+  disableLog,
 }: Game) {
   // Attach defaults.
   if (moves === undefined) {
@@ -106,6 +107,9 @@ export function Flow({
       });
     };
   };
+
+  const appendLogEntry = (state: State, logEntry: LogEntry): LogEntry[] =>
+    disableLog ? state.deltalog || [] : [...(state.deltalog || []), logEntry];
 
   const wrapped = {
     onEnd: HookWrapper(onEnd, GameMethod.GAME_ON_END),
@@ -520,7 +524,7 @@ export function Flow({
     const logEntry: LogEntry = { action, _stateID, turn, phase };
     if (automatic) logEntry.automatic = true;
 
-    const deltalog = [...(state.deltalog || []), logEntry];
+    const deltalog = appendLogEntry(state, logEntry);
 
     return { ...state, G, ctx, deltalog };
   }
@@ -584,7 +588,7 @@ export function Flow({
     const logEntry: LogEntry = { action, _stateID, turn, phase };
     if (automatic) logEntry.automatic = true;
 
-    const deltalog = [...(state.deltalog || []), logEntry];
+    const deltalog = appendLogEntry(state, logEntry);
 
     return { ...state, G, ctx, deltalog, _undo: [], _redo: [] };
   }
@@ -665,7 +669,7 @@ export function Flow({
     const logEntry: LogEntry = { action, _stateID, turn, phase };
     if (automatic) logEntry.automatic = true;
 
-    const deltalog = [...(state.deltalog || []), logEntry];
+    const deltalog = appendLogEntry(state, logEntry);
 
     return { ...state, ctx, deltalog };
   }

--- a/src/core/reducer.test.ts
+++ b/src/core/reducer.test.ts
@@ -994,6 +994,32 @@ describe('playerLeave', () => {
   });
 });
 
+describe('disableLog', () => {
+  const game: Game = {
+    disableLog: true,
+    moves: { A: ({ G }) => G },
+  };
+  const reducer = CreateGameReducer({ game });
+  const initialState = InitializeGame({ game, numPlayers: 2 });
+
+  test('deltalog stays empty for moves and events', () => {
+    let state = reducer(initialState, makeMove('A', null, '0'));
+    expect(state.deltalog).toEqual([]);
+
+    state = reducer(state, gameEvent('endTurn', null, '0'));
+    expect(state.deltalog).toEqual([]);
+  });
+
+  test('deltalog stays empty for undo and redo', () => {
+    let state = reducer(initialState, makeMove('A', null, '0'));
+    state = reducer(state, undo('0'));
+    expect(state.deltalog).toEqual([]);
+
+    state = reducer(state, redo('0'));
+    expect(state.deltalog).toEqual([]);
+  });
+});
+
 describe('undo / redo with stages', () => {
   const game: Game = {
     setup: () => ({ A: false, B: false, C: false }),

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -140,8 +140,13 @@ function initializeDeltalog(
     | ActionShape.Undo
     | ActionShape.Redo
     | ActionShape.PlayerLeave,
+  game: Game,
   move?: Move,
 ): TransientState {
+  if (game.disableLog) {
+    return { ...state, deltalog: [] };
+  }
+
   // Create a log entry for this action.
   const logEntry: LogEntry = {
     action,
@@ -427,7 +432,7 @@ export function CreateGameReducer({
         }
 
         // On the server, construct the deltalog.
-        state = initializeDeltalog(state, action, move);
+        state = initializeDeltalog(state, action, game, move);
 
         // Allow the flow reducer to process any triggers that happen after moves.
         state = game.flow.processMove(state, action.payload);
@@ -467,7 +472,7 @@ export function CreateGameReducer({
         });
 
         const G = game.processPlayerLeave(state, playerID);
-        state = initializeDeltalog({ ...state, G }, action);
+        state = initializeDeltalog({ ...state, G }, action, game);
 
         let stateWithError: TransientState | undefined;
         [state, stateWithError] = flushAndValidatePlugins(state, oldState, {
@@ -543,7 +548,7 @@ export function CreateGameReducer({
           }
         }
 
-        state = initializeDeltalog(state, action);
+        state = initializeDeltalog(state, action, game);
 
         return {
           ...state,
@@ -582,7 +587,7 @@ export function CreateGameReducer({
           return WithError(state, ActionErrorType.ActionInvalid);
         }
 
-        state = initializeDeltalog(state, action);
+        state = initializeDeltalog(state, action, game);
 
         return {
           ...state,

--- a/src/types.ts
+++ b/src/types.ts
@@ -325,6 +325,7 @@ export interface Game<
   maxPlayers?: number;
   deltaState?: boolean;
   disableUndo?: boolean;
+  disableLog?: boolean;
   seed?: string | number;
   setup?: (
     context: PluginAPIs & DefaultPluginAPIs & { ctx: Ctx },


### PR DESCRIPTION
Games had no way to opt out of the log: every move, event, undo/redo and player-leave appends entries that accumulate in storage and on clients. #1179 documented this, bot simulations overflowed localStorage because the log grows without bound.

Mirroring the existing `disableUndo` option, `disableLog: true` on the game config now suppresses log entries at both creation sites:

- `initializeDeltalog` in the reducer (moves, undo, redo, player-leave)
- the three flow-level entries (`endTurn`, `endPhase`, `endStage`), gated via a shared `appendLogEntry` helper

With the flag set, `deltalog` stays empty, so nothing is persisted by the master, sent to clients, or accumulated in `client.log`. Documented tradeoff (noted in the Game API docs): the Debug Panel's log tab and time travel are empty for such games.

Closes #1179