### PR TITLE
fix(deps): patch transitive brace-expansion DoS alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,8 @@ overrides:
   jest-runner: 30.4.1
   jest-runtime: 30.4.1
   jest-resolve-dependencies: 30.4.1
+  brace-expansion@<1.1.16: '>=1.1.16 <2'
+  brace-expansion@>=2.0.0 <2.1.2: '>=2.1.2 <3'
 
 importers:
 
@@ -2000,11 +2002,11 @@ packages:
     resolution: {integrity: sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==}
     engines: {node: '>=8'}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
@@ -7143,12 +7145,12 @@ snapshots:
       type-fest: 0.8.1
       widest-line: 3.1.0
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
@@ -9227,15 +9229,15 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.16
 
   minimatch@8.0.7:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.2
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,5 @@ overrides:
   jest-runner: 30.4.1
   jest-runtime: 30.4.1
   jest-resolve-dependencies: 30.4.1
+  brace-expansion@<1.1.16: '>=1.1.16 <2'
+  brace-expansion@>=2.0.0 <2.1.2: '>=2.1.2 <3'


### PR DESCRIPTION
## Why Dependabot can't do this itself

Dependabot's security-update run has been failing on `main` since 2026-07-25 with:

```
security_update_not_possible | brace-expansion
  latest-resolvable-version: 1.1.15
  lowest-non-vulnerable-version: 5.0.8
```

It reports `5.0.8` because it only looks at the `latest` dist-tag. But the maintainers backported the fix to both maintenance lines — `maintenance-v1: 1.1.16` and `maintenance-v2: 2.1.2` — so no major jump is needed.

Because the run fails, **no** security updates land at all. This unblocks the queue.

## Why not a blanket override

`minimatch` is the only consumer, and each of its majors needs a different `brace-expansion` major:

| consumer | brace-expansion |
|---|---|
| `minimatch@3.1.5` | 1.1.15 -> **1.1.16** |
| `minimatch@8.0.7`, `minimatch@9.0.9` | 2.1.1 -> **2.1.2** |
| `minimatch@10.2.5` | 5.0.7 (already clean) |

A single `brace-expansion: ^5` override would break the first three. Range-scoped overrides patch each line in place instead.

## The advisory

GHSA-3jxr-9vmj-r5cp (high) — exponential-time expansion of consecutive non-expanding `{}` groups. Dev-only reachability here: it comes in via `glob`/`minimatch` in the build and test tooling, never through a runtime code path. Worth patching to unblock Dependabot regardless.

## Notes

Overrides go in `pnpm-workspace.yaml`, not `package.json` — this repo moved its pnpm settings there in #1273, and a `pnpm.overrides` block in `package.json` would silently take precedence and drop the existing `jest` pins.

## Verification

`pnpm install`, `pnpm run ts`, `pnpm run lint`, `pnpm test` (900 passed), `pnpm run build`, `pnpm run test:integration` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRtvKfpVqgRdDrcY4x6zVL