### PR TITLE
docs(agents): note that pnpm settings live in pnpm-workspace.yaml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ This file provides guidance to coding agents (e.g. Claude Code) working in this 
 
 `.npmrc` sets `minimum-release-age=2880` (48 hours) as supply-chain protection. The integration script overrides this with `--config.minimum-release-age=0` because it installs a local tarball.
 
+**pnpm settings live in `pnpm-workspace.yaml`, not `package.json`.** `overrides`, dependency pins and other pnpm config were moved there in #1273. If pnpm config also exists in `package.json`, `package.json` wins and the workspace file is ignored entirely — so adding a `pnpm.overrides` block to `package.json` silently disables every existing pin (e.g. `jest`) with no warning.
+
 ## Common commands
 
 - `pnpm test` — runs `lint` (pretest hook) then jest. Lint failures block tests.


### PR DESCRIPTION
`overrides` and dependency pins moved to `pnpm-workspace.yaml` in #1273.

If a `pnpm` block also exists in `package.json`, pnpm reads `package.json` and ignores the workspace file entirely — every existing pin is silently dropped, with no warning. Worth writing down so it isn't rediscovered the hard way.
