### PR TITLE
docs: ask for one commit per concern, and route agents to CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,12 @@ This file provides guidance to coding agents (e.g. Claude Code) working in this 
 
 **boardgame.io** is a turn-based game engine library — game logic lives in `src/`, public entry points in `packages/`, and rollup-built bundles in `dist/`. It is published on npm as `boardgame.io`. The toolchain runs on a modern **Node 24/26** baseline and uses **pnpm** as the package manager.
 
+## Contributing
+
+`CONTRIBUTING.md` governs how changes land, and applies to agent-authored work too. In short:
+commit to a separate branch rather than `main`, keep each commit to one concern, make sure
+`pnpm test` and `pnpm run lint` pass, and open a Pull Request. Read it before opening one.
+
 ## Package manager
 
 **pnpm 10.16+ is mandatory** (pinned via `packageManager` in `package.json`). Don't use npm or yarn — `pnpm-lock.yaml` is the only lockfile, and CI installs with `--frozen-lockfile`. Enable via `corepack enable`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,16 @@ is ready to be merged. Name your branch something like
 Once you are ready, you can create a Pull Request for it to be
 merged into the `main` branch in this repo.
 
+#### One commit per concern
+
+Each commit should do one thing. Bundled commits are hard to review, so re-cut the
+branch into single-purpose commits before opening the Pull Request rather than
+leaving the history as it happened to be written.
+
+If a coding agent wrote the branch, ask it to do the re-cut as a separate pass.
+Agents tend to commit several things at once, and the pass doubles as a review —
+it often surfaces problems the implementation missed.
+
 #### Testing
 
 The following commands must pass for a Pull Request to be considered:


### PR DESCRIPTION
Two related gaps in the contributor docs.

**`CONTRIBUTING.md` said nothing about commit structure.** Bundled commits are slow to review, and the request to re-cut a branch into single-purpose commits currently has to be made by hand on each PR. Writing it down makes it the repo's expectation instead of a recurring ask. Re-cutting also works as a review pass in its own right, which matters most on agent-authored branches.

**`AGENTS.md` never referenced `CONTRIBUTING.md`.** It described the toolchain in detail but not how changes are meant to land, so an agent had no reason to look for the branch, testing, or PR rules. It now points at `CONTRIBUTING.md` and summarises it in a sentence.
