### PR TITLE
docs: fix stale example and heading levels

### DIFF
--- a/docs/documentation/deployment.md
+++ b/docs/documentation/deployment.md
@@ -1,6 +1,6 @@
 # Deployment
 
-## Serverless Options
+### Serverless Options
 
 For one-player or pass-and-play games, you may not need the boardgame.io game
 server and prefer to serve an app that runs entirely on the client. If you
@@ -79,7 +79,7 @@ production build in `/build`, which you can host just about anywhere.
 
 <!-- tabs:end -->
 
-## Heroku
+### Heroku
 
 ?> The single-port pattern shown here isn’t Heroku-specific: the same setup
 works on any Node.js host, for example [Render](https://render.com/),
@@ -210,7 +210,7 @@ const GameClient = Client({
 });
 ```
 
-## Self-hosting behind nginx
+### Self-hosting behind nginx
 
 If you run the game server on your own machine or VPS behind
 [nginx](https://nginx.org/), the proxy needs to upgrade WebSocket

--- a/docs/documentation/multiplayer.md
+++ b/docs/documentation/multiplayer.md
@@ -28,7 +28,7 @@ accessible to the client (for instance secret state), then optimistic
 updates may need to be disabled for that move. See the
 [secret state documentation](secret-state.md) for more details.
 
-## Local Master
+### Local Master
 
 The game master can run completely on the browser. This is useful to set
 up pass-and-play multiplayer or for prototyping the multiplayer experience
@@ -142,7 +142,7 @@ Local({
 });
 ```
 
-## Remote Master
+### Remote Master
 
 You can also run the game master on a separate server. Any boardgame.io
 client can connect to this master (whether it is a browser, an Android

--- a/docs/documentation/random.md
+++ b/docs/documentation/random.md
@@ -57,7 +57,7 @@ const game = {
 
 ?> `seed` can be either a string or a number.
 
-## API Reference
+### API Reference
 
 ### 1. Die
 

--- a/docs/documentation/tutorial.md
+++ b/docs/documentation/tutorial.md
@@ -14,7 +14,7 @@ This tutorial walks through a simple game of Tic-Tac-Toe.
 
 
 
-## Setup
+### Setup
 
 We’re going to use ES2015 features like module [imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)
 and the [object spread](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_operator)
@@ -119,7 +119,7 @@ and play around with it on CodeSandbox:<br/><br/>
 
 
 
-## Defining a Game
+### Defining a Game
 
 We define a game by creating an object whose contents
 tell boardgame.io how your game works. More or less everything
@@ -162,7 +162,7 @@ but we don't need that for Tic-Tac-Toe.
 
 
 
-## Creating a Client
+### Creating a Client
 
 <!-- tabs:start -->
 
@@ -253,7 +253,7 @@ in the `Client` config.
 
 
 
-## Game Improvements
+### Game Improvements
 
 ### Validating Moves
 
@@ -364,7 +364,7 @@ the return value is available at `ctx.gameover`.
 
 
 
-## Building a Board
+### Building a Board
 
 <!-- tabs:start -->
 
@@ -603,7 +603,7 @@ And there you have it. A basic tic-tac-toe game!
 
 
 
-## Bots
+### Bots
 
 In this section we will show you how to add a bot that is
 capable of playing your game. We need to tell the

--- a/docs/documentation/typescript.md
+++ b/docs/documentation/typescript.md
@@ -19,7 +19,7 @@ export const MyGame: Game<MyGameState> = {
 };
 ```
 
-[Open this snippet in the TypeScript Playground ↗︎](https://www.typescriptlang.org/play?#code/PTAEHEEMFsFMDoAuBnAUAS2gBwPYCdFREBPLWUAbwhlgBpQBZHAN3IF9QAzPHaUAcgBGOSHgAmAcxrx0OfgG5UqWAA9cBUOgB2iWHk6QAxuQbEocAMqJIuyqlCgQoSAGtIA8P3rEcAVzygUnD8yKDI1rqobEqGOFrhoNAssABcjMkAPKbmsFY2sAB8oAC8oAAU4PSGiCoAlCVFFGyKymr4hLHxhNk0aTlZZjR5ukWlFPaOYPDTUUA)
+[Open this snippet in the TypeScript Playground ↗︎](https://www.typescriptlang.org/play/?#code/PTAEHEEMFsFMDoAuBnAsAKAJbQA4HsAnRURATx1lAG8IZYAaUAWTwDdKBfUAMwL2lAAiAEZ5IBACYBzOvEx5BAbgwZYAD3xFQmAHaJYBbpADGlJqShwAyokj7qGUKBChIAa0igA5OC+NSeACuBKAycF7IoMi2+hgcKujGeDrRoNBssABczBkAPOaWsDZ2sAB8oAC8oAAUNOCMxohqoBwAlJXlVBzK6KoahMRJKcQFdNmF+RZ0xfrlVVSOzmDwK3GKQA)
 
 ### React
 


### PR DESCRIPTION
Fixes #1294

## Summary

- update the TypeScript Playground link so its decoded source matches the current `({ G, ctx })` move signature shown in the documentation
- normalize the remaining top-level documentation sections from `##` to the project’s `###` house style
- leave the existing CodeSandbox links unchanged after checking for current-signature usage and active replacements

## Root cause

The embedded Playground payload and several section headings were not updated alongside the documentation’s move-signature and heading-style migrations, so the rendered page linked to contradictory code and used inconsistent hierarchy.

## Tests

- heading-level check across `docs/documentation/*.md`
- TypeScript Playground payload round-trip/decode check
- docs preview (HTTP 200)
- `pnpm run lint`
- `pnpm test` — 43 suites passed, 901 tests passed, 1 todo, 1 snapshot passed

#### Checklist

- [x] Use a separate branch in your local repo (not `main`).
- [x] Test coverage is 100% (documentation-only change; no runtime coverage is affected).