### PR TITLE
Prioritize explicit turn endings

### DIFF
--- a/src/core/flow.test.ts
+++ b/src/core/flow.test.ts
@@ -427,6 +427,21 @@ describe('turn', () => {
         expect(state.ctx.turn).toBe(2);
         expect(state.ctx.currentPlayer).toBe('1');
       });
+
+      test('explicit endTurn takes precedence over the automatic turn end', () => {
+        const game: Game = {
+          moves: {
+            endTurn: ({ events }) => events.endTurn({ next: '2' }),
+          },
+          turn: { maxMoves: 1 },
+        };
+        const client = Client({ game, numPlayers: 3 });
+
+        client.moves.endTurn();
+
+        expect(client.getState().ctx.turn).toBe(2);
+        expect(client.getState().ctx.currentPlayer).toBe('2');
+      });
     });
 
     describe('with phases', () => {

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -276,7 +276,12 @@ export function Flow({
       }
 
       // Check if we should end the turn.
-      if ([OnMove, UpdateStage, UpdateActivePlayers].includes(fn)) {
+      const turnEndPending =
+        state.plugins?.events?.api?._private?.isTurnEndPending() ?? false;
+      if (
+        [OnMove, UpdateStage, UpdateActivePlayers].includes(fn) &&
+        !turnEndPending
+      ) {
         const shouldEndTurn = ShouldEndTurn(state);
         if (shouldEndTurn) {
           events.push({

--- a/src/plugins/events/events.test.ts
+++ b/src/plugins/events/events.test.ts
@@ -57,6 +57,18 @@ test('dispatch', () => {
   ]);
 });
 
+test('detects pending turn-ending events', () => {
+  const flow = { eventNames: ['setPhase', 'pass'] } as Game['flow'];
+  const e = new Events(flow, { phase: '', turn: 0 } as Ctx);
+  const events = e.api();
+
+  expect(e.isTurnEndPending()).toBe(false);
+  events.setPhase('B');
+  expect(e.isTurnEndPending()).toBe(false);
+  events.pass({ remove: true });
+  expect(e.isTurnEndPending()).toBe(true);
+});
+
 test('update ctx', () => {
   const game: Game = {
     moves: {

--- a/src/plugins/events/events.ts
+++ b/src/plugins/events/events.ts
@@ -49,6 +49,7 @@ export interface EventsAPI {
 export interface PrivateEventsAPI {
   _private: {
     isUsed(): boolean;
+    isTurnEndPending(): boolean;
     updateTurnContext(ctx: Ctx, methodType: GameMethod | undefined): void;
     unsetCurrentMethod(): void;
     update(state: State): State;
@@ -109,6 +110,12 @@ export class Events {
 
   isUsed() {
     return this.dispatch.length > 0;
+  }
+
+  isTurnEndPending() {
+    return this.dispatch.some(
+      ({ type }) => type === 'endTurn' || type === 'pass',
+    );
   }
 
   updateTurnContext(ctx: Ctx, methodType: GameMethod | undefined) {


### PR DESCRIPTION
Fixes #924

An explicit `endTurn` or `pass` queued by a move now takes precedence over the automatic `maxMoves` / legacy `moveLimit` turn end. This preserves arguments such as `endTurn({ next: '2' })` instead of advancing through the default play order.

The automatic turn end previously ran before the queued event was flushed. By the time that event was processed, its captured turn no longer matched and its `next` argument was discarded.

Tests:
- focused regression suites: 142 tests passed
- `pnpm run lint`
- `pnpm test`: 43 suites passed, 903 tests passed, 1 todo
- `pnpm run test:coverage`
- `pnpm run ts`
- `pnpm run build`