### PR TITLE
Select the configured active player

### DIFF
--- a/src/ai/ai.test.ts
+++ b/src/ai/ai.test.ts
@@ -253,6 +253,19 @@ describe('Simulate', () => {
 
     expect(endState.G.movedBy).toBe('2');
   });
+
+  test('stops when no bot is configured for the active player', async () => {
+    const state = InitializeGame({ game: TicTacToe });
+
+    const result = await Simulate({
+      game: TicTacToe,
+      bots: {},
+      state,
+      depth: 1,
+    });
+
+    expect(result).toEqual({ state, metadata: null });
+  });
 });
 
 describe('Bot', () => {

--- a/src/ai/ai.test.ts
+++ b/src/ai/ai.test.ts
@@ -140,6 +140,33 @@ describe('Step', () => {
     await Step(client, bot);
     expect(client.getState().G).toEqual({ moved: true });
   });
+
+  test('uses a requested active player', async () => {
+    const enumerate = jest.fn((_G, _ctx, playerID) => [
+      makeMove('A', undefined, playerID),
+    ]);
+    const client = Client({
+      numPlayers: 3,
+      game: {
+        setup: () => ({ movedBy: null }),
+        moves: {
+          A: ({ G, playerID }) => {
+            G.movedBy = playerID;
+          },
+        },
+        turn: {
+          activePlayers: { all: Stage.NULL },
+        },
+        ai: { enumerate },
+      },
+    });
+
+    const bot = new RandomBot({ enumerate });
+    await Step(client, bot, '2');
+
+    expect(enumerate.mock.calls[0][2]).toBe('2');
+    expect(client.getState().G.movedBy).toBe('2');
+  });
 });
 
 describe('Simulate', () => {
@@ -196,6 +223,35 @@ describe('Simulate', () => {
       depth: 1,
     });
     expect(endState.ctx.gameover).not.toBe(undefined);
+  });
+
+  test('selects an active player with a configured bot', async () => {
+    const game = ProcessGameConfig({
+      setup: () => ({ movedBy: null }),
+      moves: {
+        A: ({ G, playerID }) => {
+          G.movedBy = playerID;
+        },
+      },
+      turn: {
+        activePlayers: { all: Stage.NULL },
+      },
+      endIf: ({ G }) => G.movedBy !== null,
+    });
+    const bot = new RandomBot({
+      seed: 'test',
+      enumerate: (_G, _ctx, playerID) => [makeMove('A', undefined, playerID)],
+    });
+
+    const state = InitializeGame({ game, numPlayers: 3 });
+    const { state: endState } = await Simulate({
+      game,
+      bots: { '2': bot },
+      state,
+      depth: 1,
+    });
+
+    expect(endState.G.movedBy).toBe('2');
   });
 });
 

--- a/src/ai/ai.ts
+++ b/src/ai/ai.ts
@@ -10,20 +10,19 @@ import { CreateGameReducer } from '../core/reducer';
 import { Bot } from './bot';
 import type { Game, PlayerID, State, Store } from '../types';
 
+function getActivePlayer(state: State): PlayerID {
+  return state.ctx.activePlayers
+    ? Object.keys(state.ctx.activePlayers)[0]
+    : state.ctx.currentPlayer;
+}
+
 function getBotPlayer(
   state: State,
-  bots: Bot | Record<PlayerID, Bot>,
-  playerID?: PlayerID,
-) {
-  if (playerID !== undefined) return playerID;
-
-  if (state.ctx.activePlayers) {
-    const activePlayers = Object.keys(state.ctx.activePlayers);
-    if (bots instanceof Bot) return activePlayers[0];
-    return activePlayers.find((playerID) => playerID in bots);
-  }
-
-  return state.ctx.currentPlayer;
+  bots: Record<PlayerID, Bot>,
+): PlayerID | undefined {
+  return state.ctx.activePlayers
+    ? Object.keys(state.ctx.activePlayers).find((id) => id in bots)
+    : state.ctx.currentPlayer;
 }
 
 /**
@@ -39,7 +38,7 @@ export async function Step(
   playerID?: PlayerID,
 ) {
   const state = client.store.getState();
-  playerID = getBotPlayer(state, bot, playerID);
+  playerID = playerID ?? getActivePlayer(state);
 
   const { action, metadata } = await bot.play(state, playerID);
 
@@ -60,7 +59,7 @@ export async function Step(
  * Simulates the game till the end or a max depth.
  *
  * @param {...object} game - The game object.
- * @param {...object} bots - An array of bots.
+ * @param {...object} bots - A map of player IDs to bots, or one bot for every seat.
  * @param {...object} state - The game state to start from.
  */
 export async function Simulate({
@@ -75,14 +74,18 @@ export async function Simulate({
   depth?: number;
 }) {
   if (depth === undefined) depth = 10_000;
+  const botMap =
+    bots instanceof Bot
+      ? Object.fromEntries(state.ctx.playOrder.map((p) => [p, bots]))
+      : bots;
   const reducer = CreateGameReducer({ game });
 
   let metadata = null;
   let iter = 0;
   while (state.ctx.gameover === undefined && iter < depth) {
-    const playerID = getBotPlayer(state, bots);
+    const playerID = getBotPlayer(state, botMap);
 
-    const bot = bots instanceof Bot ? bots : bots[playerID];
+    const bot = botMap[playerID];
     if (!bot) break;
     const t = await bot.play(state, playerID);
 

--- a/src/ai/ai.ts
+++ b/src/ai/ai.ts
@@ -10,19 +10,36 @@ import { CreateGameReducer } from '../core/reducer';
 import { Bot } from './bot';
 import type { Game, PlayerID, State, Store } from '../types';
 
+function getBotPlayer(
+  state: State,
+  bots: Bot | Record<PlayerID, Bot>,
+  playerID?: PlayerID,
+) {
+  if (playerID !== undefined) return playerID;
+
+  if (state.ctx.activePlayers) {
+    const activePlayers = Object.keys(state.ctx.activePlayers);
+    if (bots instanceof Bot) return activePlayers[0];
+    return activePlayers.find((playerID) => playerID in bots);
+  }
+
+  return state.ctx.currentPlayer;
+}
+
 /**
  * Make a single move on the client with a bot.
  *
  * @param {...object} client - The game client.
  * @param {...object} bot - The bot.
+ * @param {string} [playerID] - The player the bot should play as.
  */
-export async function Step(client: { store: Store }, bot: Bot) {
+export async function Step(
+  client: { store: Store },
+  bot: Bot,
+  playerID?: PlayerID,
+) {
   const state = client.store.getState();
-
-  let playerID = state.ctx.currentPlayer;
-  if (state.ctx.activePlayers) {
-    playerID = Object.keys(state.ctx.activePlayers)[0];
-  }
+  playerID = getBotPlayer(state, bot, playerID);
 
   const { action, metadata } = await bot.play(state, playerID);
 
@@ -63,12 +80,10 @@ export async function Simulate({
   let metadata = null;
   let iter = 0;
   while (state.ctx.gameover === undefined && iter < depth) {
-    let playerID = state.ctx.currentPlayer;
-    if (state.ctx.activePlayers) {
-      playerID = Object.keys(state.ctx.activePlayers)[0];
-    }
+    const playerID = getBotPlayer(state, bots);
 
     const bot = bots instanceof Bot ? bots : bots[playerID];
+    if (!bot) break;
     const t = await bot.play(state, playerID);
 
     if (!t.action) {


### PR DESCRIPTION
Fixes #1038

`Step` now accepts an explicit active player. When `Simulate` receives a map of player controllers, it selects an active player that has a matching configuration and stops cleanly when none is available.

Previously, both paths always selected the first key in `ctx.activePlayers`. That ignored the player requested by the caller and could choose an entry missing from the supplied controller map.

Tests:
- focused regression suite: 23 tests passed
- `pnpm run lint`
- `pnpm test`: 43 suites passed, 904 tests passed, 1 todo
- `pnpm run test:coverage`: 100% statements, branches and lines
- `pnpm run ts`
- `pnpm run build`