### PR TITLE
build(integration): stop test:integration modifying tracked files

### DIFF
--- a/scripts/integration.js
+++ b/scripts/integration.js
@@ -24,11 +24,16 @@ shell.rm('-rf', 'node_modules');
 // the CLI flag wins. This sealed scaffold uses pinned deps, so the cooldown
 // adds no protection here. Also sidesteps pnpm 10.16's ERR_PNPM_MISSING_TIME
 // on packages whose abbreviated registry metadata lacks the time field.
-shell.exec('pnpm install --config.minimum-release-age=0');
+// --ignore-workspace stops pnpm walking up to the repo root. Without it,
+// `pnpm add` of a local tarball registers integration/ as an importer of the
+// root workspace and writes the tarball into the root pnpm-lock.yaml.
+shell.exec('pnpm install --ignore-workspace --config.minimum-release-age=0');
 // `./` prefix is required so pnpm treats the filename as a local tarball
 // rather than a registry package name (npm install <name>.tgz is forgiving;
 // pnpm add is not).
-shell.exec(`pnpm add --config.minimum-release-age=0 ./${packed}`);
+shell.exec(
+  `pnpm add --ignore-workspace --config.minimum-release-age=0 ./${packed}`,
+);
 
 shell.set('-e');
 

--- a/scripts/integration.js
+++ b/scripts/integration.js
@@ -31,9 +31,17 @@ shell.exec('pnpm install --ignore-workspace --config.minimum-release-age=0');
 // `./` prefix is required so pnpm treats the filename as a local tarball
 // rather than a registry package name (npm install <name>.tgz is forgiving;
 // pnpm add is not).
+//
+// pnpm add always saves to the manifest and has no --no-save, so snapshot it
+// and put it back. The tarball name carries the version and must never be
+// committed. Restoring here rather than at the end means a failing check
+// below cannot leave the file dirty either; the checks resolve the package
+// through node_modules, which is already populated.
+const manifest = shell.cat('package.json').toString();
 shell.exec(
   `pnpm add --ignore-workspace --config.minimum-release-age=0 ./${packed}`,
 );
+shell.ShellString(manifest).to('package.json');
 
 shell.set('-e');
 


### PR DESCRIPTION
`pnpm run test:integration` left two tracked files modified after every run: the root `pnpm-lock.yaml` and `integration/package.json`. Both are easy to commit by accident — the lockfile change is ~830 lines that look plausible next to a genuine dependency bump.

**Root lockfile.** `pnpm add` of the local tarball walks up to the repo root, registers `integration/` as a workspace importer and writes `boardgame.io@file:integration/boardgame.io-<version>.tgz` into the root lockfile. I isolated this by running the script's steps one at a time: `pnpm install` inside the scaffold is fine and uses the scaffold's own gitignored lockfile — only the tarball `add` reaches the root. `--ignore-workspace` on both commands pins them where they were always meant to be.

**Scaffold manifest.** `pnpm add` always saves, and pnpm 10 has no `--no-save`, so each run wrote `"boardgame.io": "file:boardgame.io-<version>.tgz"` into the tracked `integration/package.json` — pinning a tarball that only exists on the machine that built it. The script now snapshots the manifest and writes it back immediately after the install rather than at the end, so a failing check cannot leave it dirty either; the checks resolve through `node_modules`, which is populated by then.

**Origin.** The manifest write predates pnpm — `npm install <tarball>` saved too, so it has been there since #657. The lockfile write is newer: it needs a root `pnpm-workspace.yaml` for pnpm to have a workspace to walk up to, and that file arrived in #1273.

Verified by running `pnpm run test:integration` to completion (typecheck, vitest, `vite build`, CJS + ESM smoke, publint, attw) and confirming `git status` is clean afterwards, then again with a deliberately failing check injected — also clean.
