### PR TITLE
chore(ci): group every Dependabot update into one weekly pull request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,14 @@ updates:
       - "*"
     cooldown:
       default-days: 7
+    ignore:
+      # ESLint 9 replaces .eslintrc with flat config, so the bump cannot pass CI
+      # until that migration happens. Grouped, it would keep every other update
+      # in the weekly pull request unmergeable. Drop this once we are on flat
+      # config.
+      - dependency-name: eslint
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,33 +1,28 @@
 version: 2
-updates:
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 10
-    groups:
-      npm-minor-patch:
-        update-types:
-          - minor
-          - patch
 
-  # The integration scaffold has its own manifest and no lockfile, so the
-  # root entry above never sees it.
-  - package-ecosystem: npm
-    directory: /integration
+# Everything Dependabot finds lands in a single weekly pull request, across both
+# npm manifests and GitHub Actions. Only version updates are grouped: a security
+# fix still gets its own pull request rather than waiting behind the weekly batch.
+multi-ecosystem-groups:
+  all-dependencies:
     schedule:
       interval: weekly
+
+updates:
+  # The integration scaffold has its own manifest and no lockfile, so it has to
+  # be listed explicitly — a root-only entry never sees it.
+  - package-ecosystem: npm
+    directories:
+      - /
+      - /integration
+    multi-ecosystem-group: all-dependencies
+    patterns:
+      - "*"
     cooldown:
       default-days: 7
-    groups:
-      integration-minor-patch:
-        update-types:
-          - minor
-          - patch
 
   - package-ecosystem: github-actions
     directory: /
-    schedule:
-      interval: weekly
+    multi-ecosystem-group: all-dependencies
+    patterns:
+      - "*"


### PR DESCRIPTION
Dependabot currently opens one pull request per major update, because the existing groups only cover `minor` and `patch`. Six landed in a single morning (#1317, #1318, #1319, #1320, #1321, #1322), and since `main` requires branches to be up to date, each merge forced a rebase and a full CI run on all the others — they had to go in strictly one at a time.

This replaces the per-ecosystem groups with a [multi-ecosystem group](https://docs.github.com/en/code-security/concepts/supply-chain-security/multi-ecosystem-updates) (generally available since July 2025), so everything Dependabot finds arrives in **one weekly pull request** covering both npm manifests and GitHub Actions.

Two other things fall out of it:

* `patterns: ["*"]` with no `update-types` filter means majors are grouped too — that is the part that was generating the extra pull requests.
* `directories: [/, /integration]` folds the duplicate npm block into the root entry. The scaffold still has to be named explicitly, because it has its own manifest and no lockfile.

Only version updates are grouped, so a security fix still gets its own pull request rather than waiting behind the weekly batch.

### The trade-off, and why ESLint is ignored

Grouping means a single unmergeable bump blocks everything else in the batch. There is one right now: ESLint 9 fails with `ESLint couldn't find an eslint.config.(js|mjs|cjs)` because the repo is still on `.eslintrc` plus `.eslintignore`. That is a flat-config migration, not a bump — see #1302.

Left alone it is one stuck pull request; inside the group it would block every other update, every week. So the second commit ignores ESLint majors, with a comment saying to drop the rule once the migration lands. Happy to drop that commit if you would rather keep the bump visible and merge around it.

### Notes for review

* Dependabot's own "config file validation" check does not fire reliably on pull requests here — #1311 changed this same file and never got one — so it cannot be relied on as the gate before merge. Instead the file validates clean against [SchemaStore's `dependabot-2.0` schema](https://json.schemastore.org/dependabot-2.0.json), which models `multi-ecosystem-groups`, `multi-ecosystem-group`, `patterns` and `directories` with `additionalProperties: false`. The shape also matches [Dependabot's own configuration](https://github.com/dependabot/dependabot-core/blob/main/.github/dependabot.yml).
* `pnpm test` (43 suites / 903 passed) and `pnpm run lint` are green, though neither exercises this file.
