### PR TITLE
Rework leave-game around an explicit player roster in ctx

### DIFF
--- a/docs/documentation/api/Lobby.md
+++ b/docs/documentation/api/Lobby.md
@@ -231,8 +231,15 @@ await lobbyClient.leaveSlot('tic-tac-toe', 'matchID', {
 
 Permanently remove the player from the game through the normal game-state
 lifecycle, then clear their lobby slot. This runs the game’s
-`onPlayerLeave` hook and removes the player from turn order and active-player
-state. If the match is already over, this only clears the lobby slot.
+`onPlayerLeave` hook and removes the player from `ctx.players`, from turn
+order and from active-player state. If the match is already over, this only
+clears the lobby slot.
+
+!> A game that names a player ID explicitly owns that ID. `endTurn({ next })`
+and the array form of `setActivePlayers` set the players you name without
+checking whether they are still in the match, so they can hand a turn to
+someone who has left. Read `ctx.players` if you need to know who is still
+playing.
 
 Accepts two JSON body parameters, all required:
 

--- a/docs/documentation/events.md
+++ b/docs/documentation/events.md
@@ -78,12 +78,6 @@ Allows adding additional players to the set of "active players", and
 also any stages that you want to put them in. See the guide on [Stages](stages.md)
 for more details.
 
-#### removePlayer
-
-Permanently removes a player from turn order and active-player state.
-This is available to game logic through `events.removePlayer(playerID)`.
-It is not directly callable by clients.
-
 ### Triggering an event from game logic.
 
 You can trigger events from a move or code inside
@@ -160,9 +154,6 @@ const game = {
 
 !> This doesn't apply to events in moves or hooks, but just the
 ability to call an event directly from a client.
-
-!> `removePlayer` is always server-side game logic only. It is not exposed
-on client `events`, even though it is available inside moves and hooks.
 
 ### Calling events from hooks
 

--- a/src/core/flow.test.ts
+++ b/src/core/flow.test.ts
@@ -1400,64 +1400,6 @@ describe('pass args', () => {
   });
 });
 
-test('removePlayer persists across phase starts', () => {
-  const flow = Flow({
-    phases: {
-      A: {
-        start: true,
-        next: 'B',
-        turn: {
-          order: {
-            first: () => 0,
-            next: ({ ctx }) => (ctx.playOrderPos + 1) % ctx.playOrder.length,
-            playOrder: () => ['0', '1', '2'],
-          },
-        },
-      },
-      B: {
-        turn: {
-          order: {
-            first: () => 0,
-            next: ({ ctx }) => (ctx.playOrderPos + 1) % ctx.playOrder.length,
-            playOrder: () => ['0', '1', '2'],
-          },
-        },
-      },
-    },
-  });
-
-  let t = { ctx: flow.ctx(3) } as State;
-  t = flow.init(t);
-  t = flow.processEvent(t, gameEvent('removePlayer', '1'));
-  t = flow.processEvent(t, gameEvent('endPhase'));
-
-  expect(t.ctx.phase).toBe('B');
-  expect(t.ctx.playOrder).toEqual(['0', '2']);
-  expect(t.ctx._removedPlayers).toEqual(['1']);
-});
-
-test('removePlayer ignores non-string playerID', () => {
-  const flow = Flow({});
-  let t = { ctx: flow.ctx(3) } as State;
-  t = flow.init(t);
-
-  t = flow.processEvent(t, gameEvent('removePlayer', 1));
-
-  expect(t.ctx.playOrder).toEqual(['0', '1', '2']);
-  expect(t.ctx._removedPlayers).toBeUndefined();
-});
-
-test('removed players are never active', () => {
-  const flow = Flow({});
-  let t = { ctx: flow.ctx(2) } as State;
-  t = flow.init(t);
-
-  expect(flow.isPlayerActive({}, t.ctx, '0')).toBe(true);
-
-  const staleCtx = { ...t.ctx, currentPlayer: '1', _removedPlayers: ['1'] };
-  expect(flow.isPlayerActive({}, staleCtx, '1')).toBe(false);
-});
-
 test('undoable moves', () => {
   const game: Game = {
     moves: {

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -11,7 +11,6 @@ import {
   UpdateActivePlayersOnceEmpty,
   InitTurnOrderState,
   UpdateTurnOrderState,
-  RemovePlayer,
   Stage,
   TurnOrder,
 } from './turn-order';
@@ -782,15 +781,6 @@ export function Flow({
     return Process(state, [{ fn: UpdateActivePlayers, arg }]);
   }
 
-  function RemovePlayerEvent(
-    state: State,
-    _playerID: PlayerID,
-    playerID: PlayerID,
-  ): State {
-    if (typeof playerID !== 'string') return state;
-    return { ...state, ctx: RemovePlayer(state.ctx, playerID) };
-  }
-
   function SetPhaseEvent(
     state: State,
     _playerID: PlayerID,
@@ -845,7 +835,6 @@ export function Flow({
     setPhase: SetPhaseEvent,
     endGame: EndGameEvent,
     setActivePlayers: SetActivePlayersEvent,
-    removePlayer: RemovePlayerEvent,
   };
 
   const enabledEventNames = [];
@@ -886,9 +875,6 @@ export function Flow({
   }
 
   function IsPlayerActive(_G: any, ctx: Ctx, playerID: PlayerID): boolean {
-    if ((ctx._removedPlayers || []).includes(playerID)) {
-      return false;
-    }
     if (ctx.activePlayers) {
       return playerID in ctx.activePlayers;
     }

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -882,15 +882,19 @@ export function Flow({
   }
 
   return {
-    ctx: (numPlayers: number): Ctx => ({
-      numPlayers,
-      turn: 0,
-      currentPlayer: '0',
-      playOrder: Array.from({ length: numPlayers }).map((_, i) => i + ''),
-      playOrderPos: 0,
-      phase: startingPhase,
-      activePlayers: null,
-    }),
+    ctx: (numPlayers: number): Ctx => {
+      const players = Array.from({ length: numPlayers }).map((_, i) => i + '');
+      return {
+        numPlayers,
+        turn: 0,
+        currentPlayer: '0',
+        players,
+        playOrder: [...players],
+        playOrderPos: 0,
+        phase: startingPhase,
+        activePlayers: null,
+      };
+    },
     init: (state: State): State => {
       return Process(state, [{ fn: StartGame }]);
     },

--- a/src/core/reducer.test.ts
+++ b/src/core/reducer.test.ts
@@ -10,6 +10,7 @@ import { INVALID_MOVE } from './constants';
 import { applyMiddleware, createStore } from 'redux';
 import { CreateGameReducer, TransientHandlingMiddleware } from './reducer';
 import { InitializeGame } from './initialize';
+import { TurnOrder } from './turn-order';
 import {
   makeMove,
   gameEvent,
@@ -781,7 +782,7 @@ describe('redo stack', () => {
 });
 
 describe('playerLeave', () => {
-  test('runs onPlayerLeave and updates G', () => {
+  test('runs onPlayerLeave, keeps its returned G, and removes the player from the match', () => {
     const game: Game = {
       onPlayerLeave: ({ G, playerID }) => ({ ...G, left: playerID }),
     };
@@ -791,6 +792,9 @@ describe('playerLeave', () => {
     const state = reducer(initialState, playerLeave('1'));
 
     expect(state.G).toEqual({ left: '1' });
+    expect(state.ctx.players).toEqual(['0', '2']);
+    expect(state.ctx.playOrder).toEqual(['0', '2']);
+    expect(state.ctx.numPlayers).toBe(3);
     expect(state.ctx.activePlayers).toBeNull();
     expect(state.deltalog).toEqual([
       {
@@ -858,6 +862,139 @@ describe('playerLeave', () => {
         },
       },
     });
+  });
+
+  test('rejects removing the final player before game end', () => {
+    const game: Game = {};
+    const reducer = CreateGameReducer({ game });
+    const initialState = InitializeGame({ game, numPlayers: 1 });
+
+    const state = reducer(initialState, playerLeave('0'));
+
+    expect(state).toMatchObject({
+      ...initialState,
+      transients: {
+        error: {
+          type: 'action/action_invalid',
+        },
+      },
+    });
+  });
+
+  test('allows removing the final player once the hook has ended the game', () => {
+    const game: Game = {
+      onPlayerLeave: ({ G, events }) => {
+        events.endGame('left');
+        return G;
+      },
+    };
+    const reducer = CreateGameReducer({ game });
+    const initialState = InitializeGame({ game, numPlayers: 1 });
+
+    const state = reducer(initialState, playerLeave('0'));
+
+    expect(state.ctx.gameover).toBe('left');
+    expect(state.ctx.players).toEqual([]);
+    expect(state.ctx.playOrder).toEqual([]);
+    expect(state.ctx.currentPlayer).toBe('');
+  });
+
+  test('rejects removing a player when it would empty playOrder, even though players remains non-empty', () => {
+    const game: Game = {
+      turn: { order: TurnOrder.CUSTOM(['1']) },
+    };
+    const reducer = CreateGameReducer({ game });
+    const initialState = InitializeGame({ game, numPlayers: 2 });
+
+    const state = reducer(initialState, playerLeave('1'));
+
+    expect(state).toMatchObject({
+      ...initialState,
+      transients: {
+        error: {
+          type: 'action/action_invalid',
+        },
+      },
+    });
+  });
+
+  test('a departed player named in turn.activePlayers.value is not resurrected at the next StartTurn', () => {
+    const game: Game = {
+      turn: { activePlayers: { value: { '0': 's', '1': 's', '2': 's' } } },
+    };
+    const reducer = CreateGameReducer({ game });
+    let state = InitializeGame({ game, numPlayers: 3 });
+
+    state = reducer(state, playerLeave('1'));
+    expect(state.ctx.activePlayers).toEqual({ '0': 's', '2': 's' });
+
+    state = reducer(state, gameEvent('endTurn'));
+
+    expect(state.ctx.activePlayers).toEqual({ '0': 's', '2': 's' });
+  });
+
+  test('a player removed while queued in _prevActivePlayers is not resurrected by a later revert', () => {
+    const game: Game = {
+      moves: {
+        focus0: ({ events }) => {
+          events.setActivePlayers({ value: { '0': 'A' } });
+        },
+        focus1: ({ events }) => {
+          events.setActivePlayers({
+            value: { '1': 'B' },
+            revert: true,
+            minMoves: 1,
+            maxMoves: 1,
+          });
+        },
+        act: () => {},
+      },
+    };
+    const reducer = CreateGameReducer({ game });
+    let state = InitializeGame({ game, numPlayers: 3 });
+
+    // Player 0 is active, then a revert-queuing move snapshots that state
+    // (naming player 0) before switching control to player 1.
+    state = reducer(state, makeMove('focus0', null, '0'));
+    state = reducer(state, makeMove('focus1', null, '0'));
+    expect(state.ctx.activePlayers).toEqual({ '1': 'B' });
+
+    state = reducer(state, playerLeave('0'));
+
+    // Player 1 finishes their move, emptying activePlayers and triggering
+    // the revert to the stale snapshot naming player 0.
+    state = reducer(state, makeMove('act', null, '1'));
+
+    expect(state.ctx.activePlayers).toBeNull();
+  });
+
+  test('a player removed while named in a queued _nextActivePlayers spec is not resurrected', () => {
+    const game: Game = {
+      moves: {
+        focus1: ({ events }) => {
+          events.setActivePlayers({
+            value: { '1': 'A' },
+            minMoves: 1,
+            maxMoves: 1,
+            next: { value: { '0': 'B', '2': 'B' } },
+          });
+        },
+        act: () => {},
+      },
+    };
+    const reducer = CreateGameReducer({ game });
+    let state = InitializeGame({ game, numPlayers: 3 });
+
+    state = reducer(state, makeMove('focus1', null, '0'));
+    expect(state.ctx.activePlayers).toEqual({ '1': 'A' });
+
+    state = reducer(state, playerLeave('0'));
+
+    // Player 1 finishes their move, emptying activePlayers and applying the
+    // queued spec, which still names the now-departed player 0.
+    state = reducer(state, makeMove('act', null, '1'));
+
+    expect(state.ctx.activePlayers).toEqual({ '2': 'B' });
   });
 
   test('leave is cancelled if plugin declares it invalid', () => {

--- a/src/core/reducer.test.ts
+++ b/src/core/reducer.test.ts
@@ -781,7 +781,7 @@ describe('redo stack', () => {
 });
 
 describe('playerLeave', () => {
-  test('runs onPlayerLeave and removes player from ctx', () => {
+  test('runs onPlayerLeave and updates G', () => {
     const game: Game = {
       onPlayerLeave: ({ G, playerID }) => ({ ...G, left: playerID }),
     };
@@ -791,8 +791,6 @@ describe('playerLeave', () => {
     const state = reducer(initialState, playerLeave('1'));
 
     expect(state.G).toEqual({ left: '1' });
-    expect(state.ctx.playOrder).toEqual(['0', '2']);
-    expect(state.ctx._removedPlayers).toEqual(['1']);
     expect(state.ctx.activePlayers).toBeNull();
     expect(state.deltalog).toEqual([
       {
@@ -802,31 +800,6 @@ describe('playerLeave', () => {
         turn: 1,
       },
     ]);
-  });
-
-  test('keeps playOrderPos aligned when removing player before current player', () => {
-    const game: Game = {};
-    const reducer = CreateGameReducer({ game });
-    const initialState = InitializeGame({ game, numPlayers: 3 });
-    let state = {
-      ...initialState,
-      ctx: {
-        ...initialState.ctx,
-        currentPlayer: '2',
-        playOrderPos: 2,
-      },
-    };
-
-    state = reducer(state, playerLeave('0'));
-
-    expect(state.ctx.playOrder).toEqual(['1', '2']);
-    expect(state.ctx.currentPlayer).toBe('2');
-    expect(state.ctx.playOrderPos).toBe(1);
-
-    state = reducer(state, gameEvent('endTurn', undefined, '2'));
-
-    expect(state.ctx.currentPlayer).toBe('1');
-    expect(state.ctx.playOrderPos).toBe(0);
   });
 
   test('rebases undo and clears redo', () => {
@@ -847,73 +820,6 @@ describe('playerLeave', () => {
     expect(state._undo).toHaveLength(1);
     expect(state._undo[0].ctx).toEqual(state.ctx);
     expect(state._redo).toEqual([]);
-  });
-
-  test('cleans active player history and queued active players', () => {
-    const game: Game = {
-      moves: {
-        active: ({ events }) => {
-          events.setActivePlayers({ value: { '1': 'A', '2': 'A' } });
-          events.setActivePlayers({
-            all: 'A',
-            revert: true,
-            next: { value: { '1': 'B', '2': 'B' } },
-          });
-        },
-      },
-    };
-    const reducer = CreateGameReducer({ game });
-    let state = InitializeGame({ game, numPlayers: 3 });
-
-    state = reducer(state, makeMove('active', null, '0'));
-    state = reducer(state, playerLeave('1'));
-
-    expect(state.ctx.activePlayers).toEqual({ '0': 'A', '2': 'A' });
-    expect(state.ctx._activePlayersNumMoves).toEqual({ '0': 0, '2': 0 });
-    expect(state.ctx._nextActivePlayers).toEqual({ value: { '2': 'B' } });
-    expect(state.ctx._prevActivePlayers).toEqual([
-      {
-        activePlayers: { '2': 'A' },
-        _activePlayersMinMoves: null,
-        _activePlayersMaxMoves: null,
-        _activePlayersNumMoves: { '2': 0 },
-      },
-    ]);
-  });
-
-  test('does not remove final player before gameover', () => {
-    const game: Game = {};
-    const reducer = CreateGameReducer({ game });
-    const initialState = InitializeGame({ game, numPlayers: 1 });
-
-    const state = reducer(initialState, playerLeave('0'));
-
-    expect(state).toMatchObject({
-      ...initialState,
-      transients: {
-        error: {
-          type: 'action/action_invalid',
-        },
-      },
-    });
-  });
-
-  test('allows hook to end game before final player is removed', () => {
-    const game: Game = {
-      onPlayerLeave: ({ G, events }) => {
-        events.endGame('left');
-        return G;
-      },
-    };
-    const reducer = CreateGameReducer({ game });
-    const initialState = InitializeGame({ game, numPlayers: 1 });
-
-    const state = reducer(initialState, playerLeave('0'));
-
-    expect(state.ctx.gameover).toBe('left');
-    expect(state.ctx.playOrder).toEqual([]);
-    expect(state.ctx.currentPlayer).toBe('');
-    expect(state.ctx._removedPlayers).toEqual(['0']);
   });
 
   test('rejects non-string playerID', () => {
@@ -988,7 +894,6 @@ describe('playerLeave', () => {
 
     const state = reducer(initialState, playerLeave('1'));
 
-    expect(state.ctx.playOrder).toEqual(['0', '2']);
     expect(state._undo).toEqual([]);
     expect(state._redo).toEqual([]);
   });

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -29,7 +29,6 @@ import type {
 import { gameEvent, stripTransients } from './action-creators';
 import { ActionErrorType, UpdateErrorType } from './errors';
 import { applyPatch } from 'rfc6902';
-import { RemovePlayer } from './turn-order';
 
 /**
  * Check if the payload for the passed action contains a playerID.
@@ -591,19 +590,6 @@ export function CreateGameReducer({
           isClient: false,
         });
         if (stateWithError) return stateWithError;
-
-        state = {
-          ...state,
-          ctx: RemovePlayer(state.ctx, playerID),
-        };
-
-        if (
-          state.ctx.gameover === undefined &&
-          state.ctx.playOrder.length === 0
-        ) {
-          error(`cannot remove final player before game end`);
-          return WithError(oldState, ActionErrorType.ActionInvalid);
-        }
 
         state = rebaseUndoRedoState(state, { game, playerID });
 

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -9,6 +9,7 @@
 import * as Actions from './action-types';
 import * as plugins from '../plugins/main';
 import { ProcessGameConfig } from './game';
+import { RemovePlayer } from './turn-order';
 import { error } from './logger';
 import { INVALID_MOVE } from './constants';
 import type { Dispatch } from 'redux';
@@ -590,6 +591,19 @@ export function CreateGameReducer({
           isClient: false,
         });
         if (stateWithError) return stateWithError;
+
+        state = {
+          ...state,
+          ctx: RemovePlayer(state.ctx, playerID),
+        };
+
+        if (
+          state.ctx.gameover === undefined &&
+          (state.ctx.players.length === 0 || state.ctx.playOrder.length === 0)
+        ) {
+          error(`cannot remove final player before game end`);
+          return WithError(oldState, ActionErrorType.ActionInvalid);
+        }
 
         state = rebaseUndoRedoState(state, { game, playerID });
 

--- a/src/core/turn-order.test.ts
+++ b/src/core/turn-order.test.ts
@@ -10,9 +10,6 @@ import { Flow } from './flow';
 import { Client } from '../client/client';
 import {
   UpdateTurnOrderState,
-  InitTurnOrderState,
-  RemovePlayer,
-  SetActivePlayers,
   Stage,
   TurnOrder,
   ActivePlayers,
@@ -21,7 +18,7 @@ import { makeMove, gameEvent } from './action-creators';
 import { CreateGameReducer } from './reducer';
 import { InitializeGame } from './initialize';
 import { error } from '../core/logger';
-import type { Ctx, Game, State } from '../types';
+import type { Game, State } from '../types';
 
 jest.mock('../core/logger', () => ({
   info: jest.fn(),
@@ -1125,176 +1122,6 @@ describe('Random API is available', () => {
   });
 });
 
-describe('RemovePlayer', () => {
-  const baseCtx = () =>
-    ({
-      numPlayers: 3,
-      turn: 1,
-      currentPlayer: '0',
-      playOrder: ['0', '1', '2'],
-      playOrderPos: 0,
-      phase: null,
-      activePlayers: null,
-    }) as unknown as Ctx;
-
-  test('filters array-form queued active players', () => {
-    const ctx = {
-      ...baseCtx(),
-      _nextActivePlayers: ['1', '2'] as any,
-    };
-
-    const next = RemovePlayer(ctx, '1');
-
-    expect(next._nextActivePlayers).toEqual(['2']);
-  });
-
-  test('drops emptied value from queued active players recursively', () => {
-    const ctx = {
-      ...baseCtx(),
-      _nextActivePlayers: {
-        value: { '1': 'A' },
-        next: { value: { '1': 'B' }, currentPlayer: 'C' },
-      } as any,
-    };
-
-    const next = RemovePlayer(ctx, '1');
-
-    expect(next._nextActivePlayers).toEqual({
-      next: { currentPlayer: 'C' },
-    });
-  });
-
-  test('resets position when current player is missing from play order', () => {
-    const ctx = {
-      ...baseCtx(),
-      currentPlayer: '3',
-      playOrderPos: 2,
-    };
-
-    const next = RemovePlayer(ctx, '1');
-
-    expect(next.playOrder).toEqual(['0', '2']);
-    expect(next.playOrderPos).toBe(0);
-    expect(next.currentPlayer).toBe('0');
-  });
-
-  test('keeps position when a stale current player leaves room in the order', () => {
-    const ctx = {
-      ...baseCtx(),
-      currentPlayer: '9',
-      playOrderPos: 1,
-    };
-
-    const next = RemovePlayer(ctx, '2');
-
-    expect(next.playOrder).toEqual(['0', '1']);
-    expect(next.playOrderPos).toBe(1);
-    expect(next.currentPlayer).toBe('1');
-  });
-
-  test('wraps position when the current player leaves from the end of the order', () => {
-    const ctx = {
-      ...baseCtx(),
-      numPlayers: 2,
-      playOrder: ['0', '1'],
-      playOrderPos: 1,
-      currentPlayer: '1',
-    };
-
-    const next = RemovePlayer(ctx, '1');
-
-    expect(next.playOrder).toEqual(['0']);
-    expect(next.playOrderPos).toBe(0);
-    expect(next.currentPlayer).toBe('0');
-  });
-
-  test('clears current player when the last player is removed', () => {
-    const ctx = {
-      ...baseCtx(),
-      numPlayers: 1,
-      playOrder: ['0'],
-      currentPlayer: '0',
-    };
-
-    const next = RemovePlayer(ctx, '0');
-
-    expect(next.playOrder).toEqual([]);
-    expect(next.currentPlayer).toBe('');
-    expect(next.playOrderPos).toBe(0);
-  });
-
-  test('is idempotent for an already removed player', () => {
-    const ctx = {
-      ...baseCtx(),
-      playOrder: ['0', '2'],
-      _removedPlayers: ['1'],
-    };
-
-    const next = RemovePlayer(ctx, '1');
-
-    expect(next._removedPlayers).toEqual(['1']);
-    expect(next.playOrder).toEqual(['0', '2']);
-  });
-
-  test('keeps queued active players without a value untouched', () => {
-    const ctx = {
-      ...baseCtx(),
-      _nextActivePlayers: { all: 'A' } as any,
-    };
-
-    const next = RemovePlayer(ctx, '1');
-
-    expect(next._nextActivePlayers).toEqual({ all: 'A' });
-  });
-});
-
-describe('SetActivePlayers with removed players', () => {
-  const ctx = {
-    numPlayers: 3,
-    turn: 1,
-    currentPlayer: '0',
-    playOrder: ['0', '1', '2'],
-    playOrderPos: 0,
-    phase: null,
-    activePlayers: null,
-    _removedPlayers: ['1'],
-  } as unknown as Ctx;
-
-  test('skips removed players in all', () => {
-    const next = SetActivePlayers(ctx, { all: 'A' });
-    expect(next.activePlayers).toEqual({ '0': 'A', '2': 'A' });
-  });
-
-  test('skips removed players in value', () => {
-    const next = SetActivePlayers(ctx, { value: { '0': 'B', '1': 'B' } });
-    expect(next.activePlayers).toEqual({ '0': 'B' });
-  });
-});
-
-test('current player is empty when every player has been removed', () => {
-  const state = {
-    G: {},
-    plugins: {},
-    ctx: {
-      numPlayers: 1,
-      turn: 1,
-      currentPlayer: '0',
-      playOrder: ['0'],
-      playOrderPos: 0,
-      phase: null,
-      activePlayers: null,
-      _removedPlayers: ['0'],
-    },
-  } as unknown as State;
-
-  const ctx = InitTurnOrderState(state, {
-    order: { first: () => 0, next: () => 0 },
-  });
-
-  expect(ctx.playOrder).toEqual([]);
-  expect(ctx.currentPlayer).toBe('');
-});
-
 test('out-of-range first player position falls back to start of play order', () => {
   const flow = Flow({
     turn: {
@@ -1310,4 +1137,16 @@ test('out-of-range first player position falls back to start of play order', () 
 
   expect(state.ctx.playOrderPos).toBe(0);
   expect(state.ctx.currentPlayer).toBe('0');
+});
+
+test('current player is empty when play order is empty', () => {
+  const flow = Flow({
+    turn: { order: TurnOrder.CUSTOM([]) },
+  });
+
+  let state = { ctx: flow.ctx(2) } as State;
+  state = flow.init(state);
+
+  expect(state.ctx.playOrder).toEqual([]);
+  expect(state.ctx.currentPlayer).toBe('');
 });

--- a/src/core/turn-order.test.ts
+++ b/src/core/turn-order.test.ts
@@ -10,6 +10,9 @@ import { Flow } from './flow';
 import { Client } from '../client/client';
 import {
   UpdateTurnOrderState,
+  RemovePlayer,
+  SetActivePlayers,
+  GetPlayers,
   Stage,
   TurnOrder,
   ActivePlayers,
@@ -18,7 +21,7 @@ import { makeMove, gameEvent } from './action-creators';
 import { CreateGameReducer } from './reducer';
 import { InitializeGame } from './initialize';
 import { error } from '../core/logger';
-import type { Game, State } from '../types';
+import type { Ctx, Game, State } from '../types';
 
 jest.mock('../core/logger', () => ({
   info: jest.fn(),
@@ -382,13 +385,13 @@ test('ctx.players is populated at match creation and playOrder defaults to it', 
   expect(state.ctx.playOrder).toEqual(state.ctx.players);
 });
 
-test('a phase-scoped CUSTOM order does not shrink playOrder for a later phase', () => {
+test('a phase-scoped custom order does not leak into the next phase', () => {
   const flow = Flow({
     phases: {
       A: {
         start: true,
         next: 'B',
-        turn: { order: TurnOrder.CUSTOM(['1', '3']) },
+        turn: { order: TurnOrder.CUSTOM(['3', '1']) },
       },
       B: {},
     },
@@ -396,32 +399,207 @@ test('a phase-scoped CUSTOM order does not shrink playOrder for a later phase', 
 
   let state = { ctx: flow.ctx(4) } as State;
   state = flow.init(state);
-  expect(state.ctx.playOrder).toEqual(['1', '3']);
+  expect(state.ctx.playOrder).toEqual(['3', '1']);
 
   state = flow.processEvent(state, gameEvent('endPhase'));
   expect(state.ctx.phase).toBe('B');
   expect(state.ctx.playOrder).toEqual(['0', '1', '2', '3']);
 });
 
-test('a phase-specific custom order does not leak into the next phase', () => {
+test('a removed player stays out of playOrder across a phase boundary', () => {
   const flow = Flow({
-    phases: {
-      A: {
-        start: true,
-        next: 'B',
-        turn: { order: TurnOrder.CUSTOM(['2', '0', '1']) },
-      },
-      B: {},
-    },
+    phases: { A: { start: true, next: 'B' }, B: {} },
   });
 
   let state = { ctx: flow.ctx(3) } as State;
   state = flow.init(state);
-  expect(state.ctx.playOrder).toEqual(['2', '0', '1']);
+  state = { ...state, ctx: RemovePlayer(state.ctx, '1') };
+  expect(state.ctx.playOrder).toEqual(['0', '2']);
 
   state = flow.processEvent(state, gameEvent('endPhase'));
+
+  expect(state.ctx.phase).toBe('B');
+  expect(state.ctx.playOrder).toEqual(['0', '2']);
+});
+
+test('a custom play order does not resurrect a player who left during the previous phase', () => {
+  const flow = Flow({
+    turn: { order: TurnOrder.CUSTOM(['0', '1', '2']) },
+    phases: { one: { start: true, next: 'two' }, two: {} },
+  });
+
+  let state = { ctx: flow.ctx(3) } as State;
+  state = flow.init(state);
+  state = { ...state, ctx: RemovePlayer(state.ctx, '1') };
+  expect(state.ctx.players).toEqual(['0', '2']);
+  expect(state.ctx.playOrder).toEqual(['0', '2']);
+
+  state = flow.processEvent(state, gameEvent('endPhase'));
+
+  // turn.order.playOrder is static game config, so it has no way to know
+  // player '1' has since left — InitTurnOrderState must filter its result
+  // against ctx.players itself. ctx.playOrder is always a subset of
+  // ctx.players.
+  expect(state.ctx.phase).toBe('two');
+  expect(state.ctx.playOrder).toEqual(['0', '2']);
+});
+
+test('characterisation: endTurn({ next }) sets currentPlayer to an explicitly named departed player', () => {
+  const flow = Flow({});
+  let state = { ctx: flow.ctx(3) } as State;
+  state = flow.init(state);
+  state = { ...state, ctx: RemovePlayer(state.ctx, '1') };
+
+  state = flow.processEvent(state, gameEvent('endTurn', { next: '1' }));
+
+  // Outside the leave-game contract: a game that names a player ID
+  // explicitly still owns that ID, departed or not.
+  expect(state.ctx.currentPlayer).toBe('1');
+});
+
+test('a phase transition tolerates a legacy ctx that predates ctx.players', () => {
+  const flow = Flow({
+    phases: { A: { start: true, next: 'B' }, B: {} },
+  });
+
+  let state = { ctx: flow.ctx(3) } as State;
+  state = flow.init(state);
+  const { players: _players, ...legacyCtx } = state.ctx;
+  state = { ...state, ctx: legacyCtx as Ctx };
+
+  state = flow.processEvent(state, gameEvent('endPhase'));
+
   expect(state.ctx.phase).toBe('B');
   expect(state.ctx.playOrder).toEqual(['0', '1', '2']);
+});
+
+describe('GetPlayers', () => {
+  test('returns ctx.players when present', () => {
+    expect(GetPlayers({ players: ['0', '2'], numPlayers: 3 } as Ctx)).toEqual([
+      '0',
+      '2',
+    ]);
+  });
+
+  test('derives the roster from numPlayers when ctx.players is absent (a state persisted before ctx.players existed)', () => {
+    expect(GetPlayers({ numPlayers: 3 } as Ctx)).toEqual(['0', '1', '2']);
+  });
+});
+
+describe('RemovePlayer', () => {
+  test('3-player match: removing a middle player keeps players, playOrder, currentPlayer and playOrderPos consistent', () => {
+    const flow = Flow({});
+    let ctx = flow.ctx(3);
+    ctx = { ...ctx, currentPlayer: '2', playOrderPos: 2 };
+
+    const next = RemovePlayer(ctx, '1');
+
+    expect(next.players).toEqual(['0', '2']);
+    expect(next.playOrder).toEqual(['0', '2']);
+    expect(next.currentPlayer).toBe('2');
+    expect(next.playOrderPos).toBe(1);
+  });
+
+  test('removing the current player advances the turn to the next player', () => {
+    const flow = Flow({});
+    const ctx = flow.ctx(3);
+
+    const next = RemovePlayer(ctx, '0');
+
+    expect(next.playOrder).toEqual(['1', '2']);
+    expect(next.playOrderPos).toBe(0);
+    expect(next.currentPlayer).toBe('1');
+  });
+
+  test('removing the current player wraps to the first player when they were last in playOrder', () => {
+    const flow = Flow({});
+    let ctx = flow.ctx(3);
+    ctx = { ...ctx, currentPlayer: '2', playOrderPos: 2 };
+
+    const next = RemovePlayer(ctx, '2');
+
+    expect(next.playOrder).toEqual(['0', '1']);
+    expect(next.playOrderPos).toBe(0);
+    expect(next.currentPlayer).toBe('0');
+  });
+
+  test('removing the current player from the middle of a longer playOrder shifts to the player who takes its slot', () => {
+    const flow = Flow({});
+    let ctx = flow.ctx(5);
+    ctx = { ...ctx, currentPlayer: '2', playOrderPos: 2 };
+
+    const next = RemovePlayer(ctx, '2');
+
+    expect(next.playOrder).toEqual(['0', '1', '3', '4']);
+    expect(next.playOrderPos).toBe(2);
+    expect(next.currentPlayer).toBe('3');
+  });
+
+  test('tolerates a legacy ctx that predates ctx.players, deriving the roster from numPlayers', () => {
+    const flow = Flow({});
+    const ctx = flow.ctx(3);
+    const { players: _players, ...legacyCtx } = ctx;
+
+    const next = RemovePlayer(legacyCtx as Ctx, '1');
+
+    expect(next.players).toEqual(['0', '2']);
+    expect(next.playOrder).toEqual(['0', '2']);
+  });
+
+  test('removing the last player empties playOrder and clears currentPlayer', () => {
+    const flow = Flow({});
+    const ctx = flow.ctx(1);
+
+    const next = RemovePlayer(ctx, '0');
+
+    expect(next.players).toEqual([]);
+    expect(next.playOrder).toEqual([]);
+    expect(next.currentPlayer).toBe('');
+    expect(next.playOrderPos).toBe(0);
+  });
+
+  test('leaves ctx.numPlayers unchanged', () => {
+    const flow = Flow({});
+    const ctx = flow.ctx(3);
+
+    const next = RemovePlayer(ctx, '1');
+
+    expect(next.numPlayers).toBe(3);
+  });
+
+  test('removes an active player from activePlayers and the move-count maps, leaving the others alone', () => {
+    const flow = Flow({});
+    let ctx = flow.ctx(3);
+    ctx = SetActivePlayers(ctx, {
+      value: { '1': 'stage', '2': 'stage' },
+      minMoves: 1,
+      maxMoves: 2,
+    });
+
+    const next = RemovePlayer(ctx, '1');
+
+    expect(next.activePlayers).toEqual({ '2': 'stage' });
+    expect(next._activePlayersMinMoves).toEqual({ '2': 1 });
+    expect(next._activePlayersMaxMoves).toEqual({ '2': 2 });
+    expect(next._activePlayersNumMoves).toEqual({ '2': 0 });
+  });
+
+  test('removing the sole active player clears activePlayers and the move-count maps entirely', () => {
+    const flow = Flow({});
+    let ctx = flow.ctx(3);
+    ctx = SetActivePlayers(ctx, {
+      value: { '1': 'stage' },
+      minMoves: 1,
+      maxMoves: 1,
+    });
+
+    const next = RemovePlayer(ctx, '1');
+
+    expect(next.activePlayers).toBeNull();
+    expect(next._activePlayersMinMoves).toBeNull();
+    expect(next._activePlayersMaxMoves).toBeNull();
+    expect(next._activePlayersNumMoves).toBeNull();
+  });
 });
 
 describe('setActivePlayers', () => {
@@ -445,6 +623,19 @@ describe('setActivePlayers', () => {
       '1': Stage.NULL,
       '2': Stage.NULL,
     });
+  });
+
+  test('characterisation: short form still activates a departed player named explicitly', () => {
+    const departedState = { ...state, ctx: RemovePlayer(state.ctx, '1') };
+
+    const newState = flow.processEvent(
+      departedState,
+      gameEvent('setActivePlayers', [['1']]),
+    );
+
+    // Outside the leave-game contract: the array short form is not
+    // reconciled against who's still in the match.
+    expect(newState.ctx.activePlayers).toMatchObject({ '1': Stage.NULL });
   });
 
   test('undefined stage leaves player inactive', () => {

--- a/src/core/turn-order.test.ts
+++ b/src/core/turn-order.test.ts
@@ -283,6 +283,17 @@ describe('turn orders', () => {
     expect(state.ctx.currentPlayer).toBe('0');
   });
 
+  test('CUSTOM_FROM stringifies a numeric play order', () => {
+    const flow = Flow({
+      turn: { order: TurnOrder.CUSTOM_FROM('order') },
+    });
+
+    let state = { G: { order: [2, 1, 0] }, ctx: flow.ctx(3) } as State;
+    state = flow.init(state);
+
+    expect(state.ctx.playOrder).toEqual(['2', '1', '0']);
+  });
+
   test('manual', () => {
     const flow = Flow({
       phases: {
@@ -360,6 +371,57 @@ test('playOrder', () => {
   expect(state.ctx.currentPlayer).toBe('1');
   state = reducer(state, gameEvent('endTurn'));
   expect(state.ctx.currentPlayer).toBe('2');
+});
+
+test('ctx.players is populated at match creation and playOrder defaults to it', () => {
+  const flow = Flow({});
+
+  const state = { ctx: flow.ctx(3) } as State;
+
+  expect(state.ctx.players).toEqual(['0', '1', '2']);
+  expect(state.ctx.playOrder).toEqual(state.ctx.players);
+});
+
+test('a phase-scoped CUSTOM order does not shrink playOrder for a later phase', () => {
+  const flow = Flow({
+    phases: {
+      A: {
+        start: true,
+        next: 'B',
+        turn: { order: TurnOrder.CUSTOM(['1', '3']) },
+      },
+      B: {},
+    },
+  });
+
+  let state = { ctx: flow.ctx(4) } as State;
+  state = flow.init(state);
+  expect(state.ctx.playOrder).toEqual(['1', '3']);
+
+  state = flow.processEvent(state, gameEvent('endPhase'));
+  expect(state.ctx.phase).toBe('B');
+  expect(state.ctx.playOrder).toEqual(['0', '1', '2', '3']);
+});
+
+test('a phase-specific custom order does not leak into the next phase', () => {
+  const flow = Flow({
+    phases: {
+      A: {
+        start: true,
+        next: 'B',
+        turn: { order: TurnOrder.CUSTOM(['2', '0', '1']) },
+      },
+      B: {},
+    },
+  });
+
+  let state = { ctx: flow.ctx(3) } as State;
+  state = flow.init(state);
+  expect(state.ctx.playOrder).toEqual(['2', '0', '1']);
+
+  state = flow.processEvent(state, gameEvent('endPhase'));
+  expect(state.ctx.phase).toBe('B');
+  expect(state.ctx.playOrder).toEqual(['0', '1', '2']);
 });
 
 describe('setActivePlayers', () => {

--- a/src/core/turn-order.ts
+++ b/src/core/turn-order.ts
@@ -19,127 +19,17 @@ import type {
 } from '../types';
 import { supportDeprecatedMoveLimit } from './backwards-compatibility';
 
-function IsPlayerRemoved(ctx: Ctx, playerID: PlayerID): boolean {
-  return (ctx._removedPlayers || []).includes(playerID);
-}
-
-function RemovePlayerFromRecord<T>(
-  record: Record<PlayerID, T> | null | undefined,
-  playerID: PlayerID,
-) {
-  if (!record) return record;
-  const next = { ...record };
-  delete next[playerID];
-  return Object.keys(next).length > 0 ? next : null;
-}
-
-function RemovePlayerFromActivePlayersArg(
-  arg: ActivePlayersArg | null | undefined,
-  playerID: PlayerID,
-): ActivePlayersArg | null | undefined {
-  if (!arg) return arg;
-
-  if (Array.isArray(arg)) {
-    return arg.filter((id) => id !== playerID);
-  }
-
-  const next = { ...arg };
-
-  if (next.value) {
-    next.value = { ...next.value };
-    delete next.value[playerID];
-    if (Object.keys(next.value).length === 0) {
-      delete next.value;
-    }
-  }
-
-  if (next.next) {
-    next.next = RemovePlayerFromActivePlayersArg(next.next, playerID);
-  }
-
-  return next;
-}
-
-export function RemovePlayer(ctx: Ctx, playerID: PlayerID): Ctx {
-  const removedPlayers = (ctx._removedPlayers || []).includes(playerID)
-    ? ctx._removedPlayers
-    : [...(ctx._removedPlayers || []), playerID];
-  const playOrder = ctx.playOrder.filter((id) => id !== playerID);
-  let playOrderPos = 0;
-  let currentPlayer = ctx.currentPlayer;
-
-  if (playOrder.length === 0) {
-    currentPlayer = '';
-  } else if (ctx.currentPlayer === playerID) {
-    playOrderPos =
-      ctx.playOrderPos > playOrder.length - 1 ? 0 : ctx.playOrderPos;
-    currentPlayer = playOrder[playOrderPos];
-  } else {
-    const currentPlayerPos = playOrder.indexOf(ctx.currentPlayer);
-    if (currentPlayerPos === -1) {
-      playOrderPos =
-        ctx.playOrderPos > playOrder.length - 1 ? 0 : ctx.playOrderPos;
-      currentPlayer = playOrder[playOrderPos];
-    } else {
-      playOrderPos = currentPlayerPos;
-    }
-  }
-
-  return {
-    ...ctx,
-    currentPlayer,
-    playOrder,
-    playOrderPos,
-    activePlayers: RemovePlayerFromRecord(ctx.activePlayers, playerID),
-    _activePlayersMinMoves: RemovePlayerFromRecord(
-      ctx._activePlayersMinMoves,
-      playerID,
-    ),
-    _activePlayersMaxMoves: RemovePlayerFromRecord(
-      ctx._activePlayersMaxMoves,
-      playerID,
-    ),
-    _activePlayersNumMoves: RemovePlayerFromRecord(
-      ctx._activePlayersNumMoves,
-      playerID,
-    ),
-    _prevActivePlayers: (ctx._prevActivePlayers || []).map((entry) => ({
-      activePlayers: RemovePlayerFromRecord(entry.activePlayers, playerID),
-      _activePlayersMinMoves: RemovePlayerFromRecord(
-        entry._activePlayersMinMoves,
-        playerID,
-      ),
-      _activePlayersMaxMoves: RemovePlayerFromRecord(
-        entry._activePlayersMaxMoves,
-        playerID,
-      ),
-      _activePlayersNumMoves: RemovePlayerFromRecord(
-        entry._activePlayersNumMoves,
-        playerID,
-      ),
-    })),
-    _nextActivePlayers: RemovePlayerFromActivePlayersArg(
-      ctx._nextActivePlayers,
-      playerID,
-    ),
-    _removedPlayers: removedPlayers,
-  };
-}
-
 export function SetActivePlayers(ctx: Ctx, arg: ActivePlayersArg): Ctx {
   let activePlayers: typeof ctx.activePlayers = {};
   let _prevActivePlayers: typeof ctx._prevActivePlayers = [];
   let _nextActivePlayers: ActivePlayersArg | null = null;
   let _activePlayersMinMoves = {};
   let _activePlayersMaxMoves = {};
-  const removedPlayers = new Set(ctx._removedPlayers || []);
 
   if (Array.isArray(arg)) {
     // support a simple array of player IDs as active players
     const value = {};
-    arg
-      .filter((v) => !removedPlayers.has(v))
-      .forEach((v) => (value[v] = Stage.NULL));
+    arg.forEach((v) => (value[v] = Stage.NULL));
     activePlayers = value;
   } else {
     // process active players argument object
@@ -163,10 +53,7 @@ export function SetActivePlayers(ctx: Ctx, arg: ActivePlayersArg): Ctx {
       ];
     }
 
-    if (
-      arg.currentPlayer !== undefined &&
-      !removedPlayers.has(ctx.currentPlayer)
-    ) {
+    if (arg.currentPlayer !== undefined) {
       ApplyActivePlayerArgument(
         activePlayers,
         _activePlayersMinMoves,
@@ -179,7 +66,7 @@ export function SetActivePlayers(ctx: Ctx, arg: ActivePlayersArg): Ctx {
     if (arg.others !== undefined) {
       for (let i = 0; i < ctx.playOrder.length; i++) {
         const id = ctx.playOrder[i];
-        if (id !== ctx.currentPlayer && !removedPlayers.has(id)) {
+        if (id !== ctx.currentPlayer) {
           ApplyActivePlayerArgument(
             activePlayers,
             _activePlayersMinMoves,
@@ -194,7 +81,6 @@ export function SetActivePlayers(ctx: Ctx, arg: ActivePlayersArg): Ctx {
     if (arg.all !== undefined) {
       for (let i = 0; i < ctx.playOrder.length; i++) {
         const id = ctx.playOrder[i];
-        if (removedPlayers.has(id)) continue;
         ApplyActivePlayerArgument(
           activePlayers,
           _activePlayersMinMoves,
@@ -207,7 +93,6 @@ export function SetActivePlayers(ctx: Ctx, arg: ActivePlayersArg): Ctx {
 
     if (arg.value) {
       for (const id in arg.value) {
-        if (removedPlayers.has(id)) continue;
         ApplyActivePlayerArgument(
           activePlayers,
           _activePlayersMinMoves,
@@ -375,9 +260,7 @@ export function InitTurnOrderState(state: State, turn: TurnConfig) {
   if (order.playOrder !== undefined) {
     playOrder = order.playOrder(context);
   }
-  playOrder = playOrder
-    .map((playerID) => playerID + '')
-    .filter((playerID) => !IsPlayerRemoved(ctx, playerID));
+  playOrder = playOrder.map((playerID) => playerID + '');
 
   let playOrderPos = order.first(context);
   const posType = typeof playOrderPos;

--- a/src/core/turn-order.ts
+++ b/src/core/turn-order.ts
@@ -19,15 +19,30 @@ import type {
 } from '../types';
 import { supportDeprecatedMoveLimit } from './backwards-compatibility';
 
+/**
+ * The players in this match. Falls back to deriving the roster from
+ * numPlayers for states persisted before ctx.players existed.
+ */
+export function GetPlayers(ctx: Ctx): PlayerID[] {
+  return (
+    ctx.players ?? Array.from({ length: ctx.numPlayers }).map((_, i) => i + '')
+  );
+}
+
 export function SetActivePlayers(ctx: Ctx, arg: ActivePlayersArg): Ctx {
   let activePlayers: typeof ctx.activePlayers = {};
   let _prevActivePlayers: typeof ctx._prevActivePlayers = [];
   let _nextActivePlayers: ActivePlayersArg | null = null;
   let _activePlayersMinMoves = {};
   let _activePlayersMaxMoves = {};
+  const players = GetPlayers(ctx);
 
   if (Array.isArray(arg)) {
     // support a simple array of player IDs as active players
+    //
+    // Deliberately not filtered against ctx.players: a game naming a player
+    // ID here owns that ID, in or out of the match (see the "short form"
+    // characterisation test).
     const value = {};
     arg.forEach((v) => (value[v] = Stage.NULL));
     activePlayers = value;
@@ -53,7 +68,13 @@ export function SetActivePlayers(ctx: Ctx, arg: ActivePlayersArg): Ctx {
       ];
     }
 
-    if (arg.currentPlayer !== undefined) {
+    // turn.activePlayers is static game config, reapplied at every
+    // StartTurn — filter it against the roster so it can't resurrect a
+    // player who has since left the match.
+    if (
+      arg.currentPlayer !== undefined &&
+      players.includes(ctx.currentPlayer)
+    ) {
       ApplyActivePlayerArgument(
         activePlayers,
         _activePlayersMinMoves,
@@ -93,6 +114,7 @@ export function SetActivePlayers(ctx: Ctx, arg: ActivePlayersArg): Ctx {
 
     if (arg.value) {
       for (const id in arg.value) {
+        if (!players.includes(id)) continue;
         ApplyActivePlayerArgument(
           activePlayers,
           _activePlayersMinMoves,
@@ -166,21 +188,25 @@ export function UpdateActivePlayersOnceEmpty(ctx: Ctx) {
   if (activePlayers && Object.keys(activePlayers).length === 0) {
     if (_nextActivePlayers) {
       ctx = SetActivePlayers(ctx, _nextActivePlayers);
+      _prevActivePlayers = ctx._prevActivePlayers;
+      // A player named in this queued spec may have left the match since it
+      // was recorded; drop them here instead of reviving them as active.
       ({
         activePlayers,
         _activePlayersMinMoves,
         _activePlayersMaxMoves,
         _activePlayersNumMoves,
-        _prevActivePlayers,
-      } = ctx);
+      } = withoutLeftPlayers(ctx, GetPlayers(ctx)));
     } else if (_prevActivePlayers.length > 0) {
       const lastIndex = _prevActivePlayers.length - 1;
+      // A player named in this snapshot may have left the match since it
+      // was recorded; drop them here instead of reviving them as active.
       ({
         activePlayers,
         _activePlayersMinMoves,
         _activePlayersMaxMoves,
         _activePlayersNumMoves,
-      } = _prevActivePlayers[lastIndex]);
+      } = withoutLeftPlayers(_prevActivePlayers[lastIndex], GetPlayers(ctx)));
       _prevActivePlayers = _prevActivePlayers.slice(0, lastIndex);
     } else {
       activePlayers = null;
@@ -196,6 +222,105 @@ export function UpdateActivePlayersOnceEmpty(ctx: Ctx) {
     _activePlayersMaxMoves,
     _activePlayersNumMoves,
     _prevActivePlayers,
+  };
+}
+
+type ActivePlayersSnapshot = Pick<
+  Ctx,
+  | 'activePlayers'
+  | '_activePlayersMinMoves'
+  | '_activePlayersMaxMoves'
+  | '_activePlayersNumMoves'
+>;
+
+/**
+ * Keep only the entries in an activePlayers snapshot (activePlayers plus its
+ * move-count bookkeeping) whose player is still in the match. Used both when
+ * applying a queued ctx._nextActivePlayers spec and when restoring a
+ * ctx._prevActivePlayers snapshot, either of which may name a player who has
+ * since left.
+ */
+function withoutLeftPlayers(
+  snapshot: ActivePlayersSnapshot,
+  players: PlayerID[],
+): ActivePlayersSnapshot {
+  function keep<T>(record: Record<PlayerID, T> | null | undefined) {
+    if (!record) return null;
+    const next: Record<PlayerID, T> = {};
+    for (const id of Object.keys(record).filter((id) => players.includes(id))) {
+      next[id] = record[id];
+    }
+    return Object.keys(next).length > 0 ? next : null;
+  }
+
+  return {
+    activePlayers: keep(snapshot.activePlayers),
+    _activePlayersMinMoves: keep(snapshot._activePlayersMinMoves),
+    _activePlayersMaxMoves: keep(snapshot._activePlayersMaxMoves),
+    _activePlayersNumMoves: keep(snapshot._activePlayersNumMoves),
+  };
+}
+
+/**
+ * Remove one player's entry from an activePlayers-shaped record, returning
+ * null if that empties it (matching the null-when-empty convention
+ * SetActivePlayers already uses).
+ */
+function withoutPlayer<T>(
+  record: Record<PlayerID, T> | null | undefined,
+  playerID: PlayerID,
+): Record<PlayerID, T> | null {
+  if (!record) return null;
+  const next = { ...record };
+  delete next[playerID];
+  return Object.keys(next).length > 0 ? next : null;
+}
+
+/**
+ * Removes a player from the match: from ctx.players (the fixed roster the
+ * match was created with) and from playOrder. Because InitTurnOrderState
+ * re-seeds playOrder from ctx.players at the start of every phase, removing
+ * from ctx.players is what makes the removal persist across phases.
+ *
+ * ctx.numPlayers is deliberately left untouched — it always reflects the
+ * seat count the match was created with, not how many players remain in it.
+ *
+ * Stale references to this player in ctx._prevActivePlayers and
+ * ctx._nextActivePlayers are left as-is rather than scrubbed; they are made
+ * inert where they're consumed instead (see withoutLeftPlayers, used above
+ * in UpdateActivePlayersOnceEmpty).
+ *
+ * Reads the roster through GetPlayers so a match persisted before
+ * ctx.players existed can still process a leave.
+ */
+export function RemovePlayer(ctx: Ctx, playerID: PlayerID): Ctx {
+  const players = GetPlayers(ctx).filter((id) => id !== playerID);
+  const playOrder = ctx.playOrder.filter((id) => id !== playerID);
+
+  let { currentPlayer, playOrderPos } = ctx;
+
+  if (playOrder.length === 0) {
+    currentPlayer = '';
+    playOrderPos = 0;
+  } else if (currentPlayer === playerID) {
+    // The player at the same numeric position shifts down to fill the
+    // removed player's slot, which is exactly the next player in turn order.
+    playOrderPos = playOrderPos > playOrder.length - 1 ? 0 : playOrderPos;
+    currentPlayer = playOrder[playOrderPos];
+  } else {
+    playOrderPos = playOrder.indexOf(currentPlayer);
+  }
+
+  return {
+    ...ctx,
+    players,
+    playOrder,
+    playOrderPos,
+    currentPlayer,
+    activePlayers: withoutPlayer(ctx.activePlayers, playerID),
+    _activePlayersMinMoves: withoutPlayer(ctx._activePlayersMinMoves, playerID),
+    _activePlayersMaxMoves: withoutPlayer(ctx._activePlayersMaxMoves, playerID),
+    _activePlayersNumMoves: withoutPlayer(ctx._activePlayersNumMoves, playerID),
   };
 }
 
@@ -254,12 +379,21 @@ export function InitTurnOrderState(state: State, turn: TurnConfig) {
   const pluginAPIs = plugin.GetAPIs(state);
   const context = { ...pluginAPIs, G, ctx };
   const order = turn.order;
+  const players = GetPlayers(ctx);
 
-  let playOrder = [...ctx.players];
+  let playOrder = [...players];
   if (order.playOrder !== undefined) {
     playOrder = order.playOrder(context);
   }
-  playOrder = playOrder.map((playerID) => playerID + '');
+  // Invariant: ctx.playOrder is always a subset of ctx.players.
+  // turn.order.playOrder is static game config, so a CUSTOM/CUSTOM_FROM
+  // order has no way to know a player has since left the match — filter the
+  // result against the roster here instead. This also narrows an
+  // undocumented tolerance: a custom play order naming a player ID that was
+  // never in the roster is now dropped instead of passed through.
+  playOrder = playOrder
+    .map((playerID) => playerID + '')
+    .filter((playerID) => players.includes(playerID));
 
   let playOrderPos = order.first(context);
   const posType = typeof playOrderPos;

--- a/src/core/turn-order.ts
+++ b/src/core/turn-order.ts
@@ -251,12 +251,11 @@ function getCurrentPlayer(
  */
 export function InitTurnOrderState(state: State, turn: TurnConfig) {
   let { G, ctx } = state;
-  const { numPlayers } = ctx;
   const pluginAPIs = plugin.GetAPIs(state);
   const context = { ...pluginAPIs, G, ctx };
   const order = turn.order;
 
-  let playOrder = Array.from({ length: numPlayers }).map((_, i) => i + '');
+  let playOrder = [...ctx.players];
   if (order.playOrder !== undefined) {
     playOrder = order.playOrder(context);
   }

--- a/src/master/master.test.ts
+++ b/src/master/master.test.ts
@@ -267,7 +267,7 @@ describe('update', () => {
     expect(updateError).toBe('unauthorized action');
   });
 
-  test('rejects disabled and private game events', async () => {
+  test('rejects disabled and unknown game events', async () => {
     const gameWithDisabledEvent: Game = {
       events: {
         setActivePlayers: false,
@@ -285,8 +285,8 @@ describe('update', () => {
       'matchID',
       '0',
     );
-    const { error: privateError } = await master.onUpdate(
-      ActionCreators.gameEvent('removePlayer', '1', '0'),
+    const { error: unknownError } = await master.onUpdate(
+      ActionCreators.gameEvent('notAnEvent', '1', '0'),
       0,
       'matchID',
       '0',
@@ -294,7 +294,7 @@ describe('update', () => {
 
     expect(sendAll).not.toHaveBeenCalled();
     expect(disabledResult).toEqual({ error: 'unauthorized action' });
-    expect(privateError).toBe('unauthorized action');
+    expect(unknownError).toBe('unauthorized action');
   });
 
   test('invalid matchID', async () => {
@@ -630,8 +630,6 @@ describe('player leave', () => {
 
     expect(result).toBeUndefined();
     expect(state.G).toEqual({ left: '1' });
-    expect(state.ctx.playOrder).toEqual(['0', '2']);
-    expect(state.ctx._removedPlayers).toEqual(['1']);
     expect(log.at(-1).action).toEqual(ActionCreators.playerLeave('1'));
     expect(sendAll).toHaveBeenCalledWith({
       type: 'update',
@@ -690,14 +688,27 @@ describe('player leave', () => {
   });
 
   test('does not persist or broadcast when reducer rejects leave', async () => {
-    const game: Game = { name: 'leave' };
+    const game: Game<{ value: number }> = {
+      name: 'leave',
+      setup: () => ({ value: 5 }),
+      plugins: [
+        {
+          name: 'validator',
+          isInvalid: ({ G }) => {
+            if (G.value % 5 !== 0) return 'G.value must divide by 5';
+            return false;
+          },
+        },
+      ],
+      onPlayerLeave: ({ G }) => ({ ...G, value: 6 }),
+    };
     const db = new InMemory();
-    const initialState = InitializeGame({ game, numPlayers: 1 });
+    const initialState = InitializeGame({ game, numPlayers: 2 });
     db.createMatch('matchID', {
       initialState,
       metadata: {
         gameName: 'leave',
-        players: { '0': { id: 0 } },
+        players: { '0': { id: 0 }, '1': { id: 1 } },
         createdAt: 0,
         updatedAt: 0,
       },
@@ -707,8 +718,8 @@ describe('player leave', () => {
     const result = await master.onPlayerLeave('matchID', '0');
     const { state, log } = db.fetch('matchID', { state: true, log: true });
 
-    expect(result).toEqual({ error: 'action/action_invalid' });
-    expect(state.ctx.playOrder).toEqual(['0']);
+    expect(result).toEqual({ error: 'action/plugin_invalid' });
+    expect(state.G).toEqual({ value: 5 });
     expect(log).toEqual([]);
     expect(sendAll).not.toHaveBeenCalled();
   });

--- a/src/plugins/events/events.ts
+++ b/src/plugins/events/events.ts
@@ -40,7 +40,6 @@ export interface EventsAPI {
   endStage(): void;
   endTurn(arg?: { next: PlayerID }): void;
   pass(arg?: { remove: true }): void;
-  removePlayer(playerID: PlayerID): void;
   setActivePlayers(arg: ActivePlayersArg): void;
   setPhase(newPhase: string): void;
   setStage(newStage: string): void;

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -1397,8 +1397,6 @@ describe('.configureRouter', () => {
         });
         expect(response.status).toEqual(200);
         expect(state.G).toEqual({ left: '0' });
-        expect(state.ctx.playOrder).toEqual(['1']);
-        expect(state.ctx._removedPlayers).toEqual(['0']);
         expect(metadata.players['0']).toEqual({ id: 0 });
         expect(metadata.players['1']).toEqual({
           id: 1,
@@ -1440,27 +1438,33 @@ describe('.configureRouter', () => {
       });
 
       test('does not clear the lobby slot when game leave is rejected', async () => {
-        const game = ProcessGameConfig({ name: 'foo' });
-        const memory = createMemoryMatch(game, {
-          numPlayers: 1,
-          metadata: createLeaveMetadata('foo', {
-            '0': { id: 0, name: 'alice', credentials: 'SECRET1' },
-          }),
+        const game = ProcessGameConfig({
+          name: 'foo',
+          setup: () => ({ value: 5 }),
+          plugins: [
+            {
+              name: 'validator',
+              isInvalid: ({ G }) => {
+                if (G.value % 5 !== 0) return 'G.value must divide by 5';
+                return false;
+              },
+            },
+          ],
+          onPlayerLeave: ({ G }) => ({ ...G, value: 6 }),
         });
+        const memory = createMemoryMatch(game);
         const app = createApiServer({ db: memory, auth, games: [game] });
 
         response = await apiCall(app)
           .post('/games/foo/1/leaveGame')
           .send('playerID=0&credentials=SECRET1');
 
-        const { state, metadata, log } = memory.fetch('1', {
-          state: true,
+        const { metadata, log } = memory.fetch('1', {
           metadata: true,
           log: true,
         });
         expect(response.status).toEqual(400);
-        expect(response.text).toEqual('action/action_invalid');
-        expect(state.ctx.playOrder).toEqual(['0']);
+        expect(response.text).toEqual('action/plugin_invalid');
         expect(metadata.players['0']).toEqual({
           id: 0,
           name: 'alice',

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,8 @@ export interface ActivePlayers {
 
 export interface Ctx {
   numPlayers: number;
+  /** The players in this match, in seat order. `playOrder` defaults to this. */
+  players: Array<PlayerID>;
   playOrder: Array<PlayerID>;
   playOrderPos: number;
   activePlayers: null | ActivePlayers;

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,7 +104,6 @@ export interface Ctx {
     _activePlayersNumMoves?: Record<PlayerID, number>;
   }>;
   _nextActivePlayers?: ActivePlayersArg;
-  _removedPlayers?: PlayerID[];
   _random?: {
     seed: string | number;
   };


### PR DESCRIPTION
Draft, and deliberately so — this changes public API, so I'd like to agree the shape
before polishing it. It also reworks part of #1258, which only just landed, so I'd
very much like @Rupesh-ark's read on it.

## The filtering mechanism doesn't sit well with the existing design

`ctx` has never held a list of players. It holds `numPlayers`, and `playOrder` is
rebuilt from `numPlayers` at the start of **every phase**:

```js
// InitTurnOrderState
let playOrder = Array.from({ length: numPlayers }).map((_, i) => i + '');
```

So a player taken out of `playOrder` is back at the next phase change. #1258 handles
that with a `ctx._removedPlayers` tombstone that every consumer subtracts again:

```mermaid
flowchart LR
  N["ctx.numPlayers<br/>frozen at create"] -->|rebuilt every phase| P["ctx.playOrder"]
  R["ctx._removedPlayers"] -.->|subtract| P
  R -.->|subtract| A["SetActivePlayers<br/>4 branches"]
  R -.->|subtract| I["IsPlayerActive"]
  R -.->|deep scrub| H["_prevActivePlayers<br/>_nextActivePlayers"]
```

A tombstone is a negative list, so it is only correct while every reader remembers to
subtract it. Nothing in the type system says a new reader of `playOrder` must.

## It also blocks things we might want next

Each of these needs to **change who is playing**:

- handing a seat over to another player mid-match
- adding a seat during a match, in a game that supports it
- creating a match before you know how many people will join

With a tombstone there is nothing to change — only a list of who has been struck out.

## The alternative

The first commit reverts the turn-order half of #1258. The rest replaces it with one
new field, `ctx.players` — the players in this match, in seat order:

| layer | field | changed |
|---|---|---|
| who is admitted to the lobby | `metadata.players` | no |
| **who is in the match** | **`ctx.players`** | **new** |
| who plays this phase | `ctx.playOrder` | no |

`playOrder` is seeded from the roster instead of from a count, and constrained to it:

```js
// InitTurnOrderState
const players = GetPlayers(ctx);
let playOrder = [...players];
if (order.playOrder !== undefined) {
  playOrder = order.playOrder(context);
}
// invariant: ctx.playOrder is always a subset of ctx.players
playOrder = playOrder
  .map((playerID) => playerID + '')
  .filter((playerID) => players.includes(playerID));
```

```mermaid
flowchart LR
  N["ctx.numPlayers<br/>seats created"] -->|at setup| PL["ctx.players<br/>who is in the match"]
  PL -->|seeds, every phase| PO["ctx.playOrder<br/>who plays this phase"]
  L["leaveGame"] -->|removes from| PL
```

Removing a player is then a removal rather than a filter, and `RemovePlayer` drops from
65 lines to 30 — the deep scrub of `_prevActivePlayers` / `_nextActivePlayers` goes away,
because both are made inert where they are read instead.

`GetPlayers()` falls back to deriving the roster from `numPlayers`, so matches persisted
by 0.50.x keep working.

## Commits

| commit | diff |
|---|---|
| `revert(core)` drop the turn-order half of the leave-game feature | +56 −511 |
| `refactor(core)` give `ctx` an explicit player list | +78 −11 |
| `feat(core)` remove a leaving player from the match | +506 −23 |

The middle commit is pure structure: I diffed its behaviour against `main` across six
scenarios and the resulting states are identical.

## Two things I left alone on purpose

- `endTurn({ next })` and the array form of `setActivePlayers` still set whatever player
  ID you name, including one who has left. Without a tombstone the framework can't tell
  "has left" from "was never in the roster", and boardgame.io tolerates the latter today.
  Documented rather than changed.
- `flow.ts` `EndTurn` returns the wrong `state` in the `arg.remove` branch, so removing
  the last player silently does nothing. Pre-existing since #492 (2018), out of scope here.

## Where this goes next

This PR stands on its own — it adds no features and `leaveGame` ends up behaving exactly
as it does today. What the roster makes possible afterwards is written up separately, so
none of it has to be bought into here: #1327 (seating), #1328 (lobby lifecycle),
#1329 (tidy-up).

`pnpm test` and `pnpm run lint` are green — 43 suites, 911 tests, 100% statements and
branches.
