### PR TITLE
chore(ci): correct the ESLint Dependabot holds instead of dropping them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,12 +20,29 @@ updates:
       - "*"
     cooldown:
       default-days: 7
+    # A grouped update is only as mergeable as its worst member, so majors that
+    # are known not to build are parked here instead of being left to redden the
+    # weekly pull request. Every hold says what has to happen before it can go.
     ignore:
-      # ESLint 9 replaces .eslintrc with flat config, so the bump cannot pass CI
-      # until that migration happens. Grouped, it would keep every other update
-      # in the weekly pull request unmergeable. Drop this once we are on flat
-      # config.
+      # Flat config landed in #1325, so .eslintrc is no longer what blocks this
+      # one — ESLint 10 is. eslint-plugin-react's latest release (7.37.5) peers
+      # `^9.7`, and on 10 it does not merely warn, it throws: `react/display-name`
+      # reaches for `contextOrFilename.getFilename`, which ESLint 10 removed.
+      # Drop this once eslint-plugin-react supports ESLint 10.
       - dependency-name: eslint
+        update-types:
+          - version-update:semver-major
+      # @eslint/js has to move with eslint's major. 10.0.1 installs happily
+      # against eslint 9 and quietly enables rules that 9 ships no baseline for,
+      # taking `eslint .` from 0 problems to 7. Drop it with the hold above.
+      - dependency-name: "@eslint/js"
+        update-types:
+          - version-update:semver-major
+      # eslint-plugin-unicorn 57+ is ESM-only and nine majors of recommended
+      # rules further on. 65 is the highest that resolves against ESLint 9, and
+      # it reports 24 problems whose autofixes reach past formatting into test
+      # semantics. That wants its own pass, not a slot in the weekly batch.
+      - dependency-name: eslint-plugin-unicorn
         update-types:
           - version-update:semver-major
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ commit to a separate branch rather than `main`, keep each commit to one concern,
 - `pnpm exec jest path/to/file.test.ts` — run one test file. Add `-t "name"` for one test case.
 - `pnpm run test:coverage` — lint + jest with coverage scoped to `src/**`. This is what `pre-push` runs, so pushes aren't fast.
 - `pnpm run test:integration` — `scripts/integration.js` deletes `dist/`, `npm pack`s the lib, installs the tarball into `integration/`, and runs that project's tests + build. Use to verify the published artifact.
-- `pnpm run lint` / `pnpm run lint:fix` — eslint over the whole repo (`.eslintrc`).
+- `pnpm run lint` / `pnpm run lint:fix` — eslint over the whole repo (`eslint.config.js`).
 - `pnpm run ts` — typecheck only (`tsc --noEmit`).
 - `pnpm run build` — rollup build into `dist/` (silent).
 - `pnpm run build:watch` — rollup in watch mode.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,11 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 const jest = require('eslint-plugin-jest');
-const unicorn = require('eslint-plugin-unicorn');
+// eslint-plugin-unicorn is ESM-only from v57 on, where `require()` hands back
+// the module namespace rather than the plugin and `.configs` is undefined.
+// Unwrap the default export when it is present so the config survives that bump.
+const unicornModule = require('eslint-plugin-unicorn');
+const unicorn = unicornModule.default ?? unicornModule;
 const react = require('eslint-plugin-react');
 const typescriptEslint = require('@typescript-eslint/eslint-plugin');
 const prettierRecommended = require('eslint-plugin-prettier/recommended');


### PR DESCRIPTION
Finishes the last two items on #1324, and supersedes #1302.

#1325 landed flat config and moved `eslint` to `^9.39.5`. #1324's checklist then asks for two more
things: #1302 closed, and the ESLint major hold taken out of `.github/dependabot.yml`. The first is
right. The second turns out to be the wrong move and the hold was never the only gap.

### #1302 is superseded rather than mergeable

It proposes 8.57.1 → 9.8.0 against a `main` that is already on `^9.39.5`, and its branch is
`CONFLICTING`. There is nothing left in it to land, so it wants closing. A pull request can't close
another pull request, so that one is yours to press.

### Dropping the hold would let ESLint 10 in, which is a harder stop than the one it replaces

`eslint-plugin-react@7.37.5` is the plugin's latest release and peers `^3 || … || ^9.7`. That is not
just a declaration — under ESLint 10, lint dies before it reads a source file:

```
TypeError: Error while loading rule 'react/display-name':
  contextOrFilename.getFilename is not a function
    at resolveBasedir (…/eslint-plugin-react/lib/util/version.js:31:100)
    at detectReactVersion (…/eslint-plugin-react/lib/util/version.js:85:19)
```

So the hold stays, and its comment is rewritten to name what actually blocks it and what would
release it, rather than a flat-config migration that has already happened.

### Two neighbours of `eslint` were never covered

Since #1323 grouped everything into one weekly pull request, a group is only as mergeable as its
worst member. Both of these are majors Dependabot is free to propose today, and neither is held:

| state | `eslint .` |
| --- | --- |
| baseline — `main` as it stands | 129 files, **0 problems** |
| `@eslint/js` 9.39.5 → 10.0.1, eslint left at 9 | **7 errors** — `preserve-caught-error` ×4, `no-useless-assignment` ×3 |
| `eslint-plugin-unicorn` 56.0.1 → 65.0.0 | **crash**; 24 errors once the config no longer crashes |
| `eslint` 9.39.5 → 10.8.1 (+ the majors that follow it) | **crash** — the traceback above |

`@eslint/js` is the quiet one. 10.0.1 resolves against eslint 9 without so much as a peer warning,
then switches on rules that 9 ships no baseline for. Nothing announces it; lint just goes red.

unicorn is worse than a rule count, because its autofixes reach past formatting into behaviour:

- `unicorn/prefer-https` rewrites `http://example.com/` to `https://` inside `src/server/cors.test.ts`
  — the fixtures belonging to the tests named *"disallows other origins"* and *"disallows random URL"*.
- `unicorn/prefer-queue-microtask` swaps `process.nextTick` for `queueMicrotask` in that file's mock
  response. Different queue, not a rename.

Nine majors of recommended rules deserve a pass with someone reading each fix, not a slot in a batch
that gets merged on green. So it is held with a stated exit condition instead of left to break the
batch — 65.0.0 is the ceiling anyway, since 66+ peers `eslint >=10.4`.

### The config would have crashed on that bump regardless

unicorn is ESM-only from v57 on, so `require()` hands back the module namespace and
`unicorn.configs` is `undefined`:

```
TypeError: Cannot read properties of undefined (reading 'flat/recommended')
    at Object.<anonymous> (eslint.config.js:37:18)
```

Unwrapping `default` when it is present fixes that independently of when the bump lands. At the
pinned 56.0.1 it changes nothing — 129 files, 0 problems, before and after.

### One leftover from #1325

`AGENTS.md` still told agents that `pnpm run lint` is configured by `.eslintrc`, a file that pull
request deleted.

### Testing

`pnpm run lint` is clean over the same 129 files (20 `.js`, 1 `.cjs`, 99 `.ts`, 9 `.tsx`),
`pnpm test` passes 43 suites / 903 tests (1 todo), and `pnpm run build` succeeds.

Every figure in the tables above is from running the bump locally against this branch and reverting,
not from reading peer ranges.
