### PR TITLE
fix(core): take { remove: true } through the same removal path as leaveGame

### DIFF
--- a/docs/documentation/concepts.md
+++ b/docs/documentation/concepts.md
@@ -14,6 +14,8 @@ boardgame.io captures game state in two objects: `G` and `ctx`.
     turn: 0,
     currentPlayer: '0',
     numPlayers: 2,
+    players: ['0', '1'],
+    playOrder: ['0', '1'],
   }
 }
 ```
@@ -26,6 +28,21 @@ state manually in `G` if you so desire.
 ?> `ctx` contains other fields not shown here that games
 can take advantage of, including support for game phases and complex
 turn orders.
+
+`numPlayers`, `players` and `playOrder` all count players, and they answer
+different questions.
+
+`ctx.numPlayers` is how many seats the match was **created** with. It does not
+change, so in a game players can leave it stops matching how many are playing.
+It stays fixed on purpose: games that never lose a player keep reading the value
+they always read.
+
+`ctx.players` is who is in the match now. A player leaving is taken out of it, so
+`ctx.players.length` — not `numPlayers` — is the live count.
+
+`ctx.playOrder` is who takes a turn in the current phase, in the order they take
+them. It is always a subset of `ctx.players`: a phase may deal in fewer players
+than the match holds, but never in someone who has left it.
 
 !> Because state can be sent between client and server,
 `G` must be a JSON-serializable object; in particular, it must

--- a/src/core/flow.test.ts
+++ b/src/core/flow.test.ts
@@ -1373,14 +1373,43 @@ describe('pass args', () => {
     expect(t.ctx.currentPlayer).toBe('1');
   });
 
-  test('removing all players ends phase', () => {
+  test('removing a player takes them out of the match, not just playOrder', () => {
+    let t = state;
+    t = flow.processEvent(t, gameEvent('pass', { remove: true }));
+    expect(t.ctx.players).toEqual(['1', '2']);
+    expect(t.ctx.playOrder).toEqual(['1', '2']);
+  });
+
+  test('a removed player does not come back at the next phase', () => {
+    let t = state;
+    t = flow.processEvent(t, gameEvent('pass', { remove: true }));
+    t = flow.processEvent(t, gameEvent('endPhase'));
+    expect(t.ctx.phase).toBe('B');
+    expect(t.ctx.players).toEqual(['1', '2']);
+    expect(t.ctx.playOrder).toEqual(['1', '2']);
+  });
+
+  test('removing all players empties the match and ends phase', () => {
     let t = state;
     t = flow.processEvent(t, gameEvent('pass', { remove: true }));
     t = flow.processEvent(t, gameEvent('pass', { remove: true }));
     t = flow.processEvent(t, gameEvent('pass', { remove: true }));
+    expect(t.ctx.players).toEqual([]);
+    expect(t.ctx.playOrder).toEqual([]);
     expect(t.ctx.playOrderPos).toBe(0);
-    expect(t.ctx.currentPlayer).toBe('0');
+    expect(t.ctx.currentPlayer).toBe('');
     expect(t.ctx.phase).toBe('B');
+  });
+
+  test('removing the last player is not discarded when there are no phases', () => {
+    const phaseless = Flow({});
+    let t = { ctx: phaseless.ctx(2) } as State;
+    t = phaseless.processEvent(t, gameEvent('pass', { remove: true }));
+    t = phaseless.processEvent(t, gameEvent('pass', { remove: true }));
+    expect(t.ctx.players).toEqual([]);
+    expect(t.ctx.playOrder).toEqual([]);
+    expect(t.ctx.playOrderPos).toBe(0);
+    expect(t.ctx.currentPlayer).toBe('');
   });
 
   test('playOrderPos does not go out of bounds when passing at the end of the list', () => {

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -10,6 +10,7 @@ import {
   SetActivePlayers,
   UpdateActivePlayersOnceEmpty,
   InitTurnOrderState,
+  RemovePlayer,
   UpdateTurnOrderState,
   Stage,
   TurnOrder,
@@ -559,28 +560,31 @@ export function Flow({
     // Run turn-end triggers.
     const G = phaseConfig.turn.wrapped.onEnd(state);
 
-    if (next) {
-      next.push({ fn: UpdateTurn, arg, currentPlayer });
-    }
-
     // Reset activePlayers.
     let ctx = { ...state.ctx, activePlayers: null };
 
-    // Remove player from playerOrder
+    // Remove the player from the match. This goes through RemovePlayer, the
+    // same path leaveGame takes, so the removal reaches ctx.players and
+    // survives the next phase — filtering playOrder alone was undone by the
+    // next InitTurnOrderState, which re-seeds playOrder from the roster.
+    let playOrderEmptied = false;
     if (arg && arg.remove) {
       playerID = playerID || currentPlayer;
+      ctx = RemovePlayer(ctx, playerID);
+      playOrderEmptied = ctx.playOrder.length === 0;
+    }
 
-      const playOrder = ctx.playOrder.filter((i) => i != playerID);
-
-      const playOrderPos =
-        ctx.playOrderPos > playOrder.length - 1 ? 0 : ctx.playOrderPos;
-
-      ctx = { ...ctx, playOrder, playOrderPos };
-
-      if (playOrder.length === 0) {
-        next.push({ fn: EndPhase, turn, phase });
-        return state;
-      }
+    if (next) {
+      // Removing the last player leaves no turn order to advance, so end the
+      // phase rather than run UpdateTurn against an empty playOrder. Deciding
+      // this after the removal is what lets the updated ctx below survive:
+      // this branch used to return the untouched `state`, throwing the
+      // removal away.
+      next.push(
+        playOrderEmptied
+          ? { fn: EndPhase, turn, phase }
+          : { fn: UpdateTurn, arg, currentPlayer },
+      );
     }
 
     // Create log entry.

--- a/src/core/turn-order.ts
+++ b/src/core/turn-order.ts
@@ -402,7 +402,12 @@ export function InitTurnOrderState(state: State, turn: TurnConfig) {
       `invalid value returned by turn.order.first — expected number got ${posType} “${playOrderPos}”.`,
     );
   }
-  if (playOrder.length > 0 && playOrderPos > playOrder.length - 1) {
+  if (playOrder.length === 0) {
+    // Nobody is left to play. TurnOrder.DEFAULT.first divides by
+    // playOrder.length, so playOrderPos would otherwise be NaN — pair it with
+    // the empty currentPlayer set just below.
+    playOrderPos = 0;
+  } else if (playOrderPos > playOrder.length - 1) {
     playOrderPos = 0;
   }
   const currentPlayer =


### PR DESCRIPTION
Two of the three items in #1329. **Stacked on #1326** — based on
`devill/simplify-player-removal`, so it wants merging after that one.

### Not here: the deprecation

#1329 asks for `{ remove: true }` to be deprecated in favour of `events.unseat(id)`.
That does not exist yet — #1327 is still a design issue with two open questions — and
#1326 removes `events.removePlayer`, which leaves `events.pass({ remove: true })` as the
only way game logic can take a player out of a match. Deprecating it today points at
nothing and closes the last door. It seemed better to make it correct now and let the
pull request that lands `unseat` deprecate it.

### The removal never reached `ctx.players`

`{ remove: true }` filtered `ctx.playOrder` by hand and left the roster alone. Since
#1326 has `InitTurnOrderState` re-seed `playOrder` from `ctx.players` at the start of
every phase, the player came back at the next phase boundary:

| | `playOrder` | `players` |
| --- | --- | --- |
| start, 3 players | `0,1,2` | `0,1,2` |
| `pass({ remove: true })` | `1,2` | `0,1,2` |
| `endPhase` | **`0,1,2`** | `0,1,2` |

It now goes through `RemovePlayer` — the path `leaveGame` already takes at
`reducer.ts:597`, and the one #1329 has `unseat` taking later. That drops the player
from `ctx.players` as well, so the removal survives the phase, and `currentPlayer`,
`playOrderPos` and the active-player bookkeeping come along with it.

### Removing the last player did nothing at all

`flow.ts:582` returned the `state` parameter instead of the `ctx` it had just built, so
the removal and the `G` from the turn-end triggers were both discarded — and every
player who had already left reappeared at the phase that followed. Present since #492.

| | before | after |
| --- | --- | --- |
| 3 players, remove all three | `playOrder 0,1,2`, `currentPlayer '0'` | `playOrder []`, `currentPlayer ''` |
| 2 players, no phases, remove both | `playOrder 0,1`, `currentPlayer '0'` | `playOrder []`, `currentPlayer ''` |

That early return was not gratuitous. `EndTurn` queues `UpdateTurn` before it knows
whether anyone is left, and advancing turn order across an empty `playOrder` gives a
`currentPlayer` of the string `"undefined"`. Simply returning the updated state instead
reproduces exactly that. Choosing between `UpdateTurn` and `EndPhase` *after* the removal
rather than before it removes the need to bail out, so the built `ctx` is the one that
survives.

Emptying the match now also reaches `InitTurnOrderState` with an empty `playOrder` for
the first time, where `TurnOrder.DEFAULT.first` — `(playOrderPos + 1) % playOrder.length`
— divides by zero. The `typeof` check just above it passes `NaN` through, because `NaN`
is a number. Pinned to 0, next to the empty `currentPlayer` that function already writes
for this case.

### `concepts.md`

The State section named `numPlayers` and nothing else, which left the field that goes
stale as the obvious one to reach for. It now says that `numPlayers` is the seat count
the match was created with and does not change, that `ctx.players` is who is in the match
now — so `ctx.players.length` is the live count — and that `ctx.playOrder` is who plays
this phase, in order, always a subset of `ctx.players`.

### One existing test changed

`pass args › removing all players ends phase` asserted `currentPlayer === '0'` after
removing all three players. That value was the bug: player `0` had left, and was back
only because the phase re-seeded the roster. It now asserts the emptied match, and the
case is joined by three tests covering the roster, surviving a phase change, and the
phaseless game.

Against the unfixed branch four of the nine `pass args` tests fail; with the change all
nine pass.

### Testing

`pnpm run lint`, `pnpm run ts`, `pnpm test` (43 suites / 914 tests, 1 todo) and
`pnpm run build` all pass.
