### PR TITLE
feat(lobby): give MatchData a status instead of inferring it from seat occupancy

### DIFF
--- a/docs/documentation/api/Lobby.md
+++ b/docs/documentation/api/Lobby.md
@@ -145,6 +145,12 @@ const { matchID } = await lobbyClient.createMatch('tic-tac-toe', {
 
 Allows a player to join a particular match instance `id` of a game named `name`.
 
+The first player to join becomes the match’s `creator`, the only player allowed
+to start it. Once every seat is taken the match’s `status` becomes `running` on
+its own. Freeing a seat again — see [leaving a lobby slot](#leaving-a-lobby-slot)
+— puts it back to `open`, and hands `creator` to a player who is still seated if
+the creator was the one who left.
+
 Accepts three JSON body parameters:
 
 - `playerName` (required): the display name of the player joining the match.
@@ -167,6 +173,37 @@ const { playerCredentials } = await lobbyClient.joinMatch(
     playerName: 'Alice',
   }
 );
+```
+
+### Starting a match
+
+#### POST `/games/{name}/{id}/start`
+
+Settles the seats of match `id` so play can begin, moving its `status` from
+`open` to `running`.
+
+A match with a fixed number of seats does this by itself the moment the last
+seat is taken, and never needs this endpoint. It is for matches that can begin
+before every seat is filled, where only the player who created the match — the
+first one to sit down, reported as `creator` — decides when that is.
+
+Accepts two JSON body parameters, both required:
+
+- `playerID`: the ID of the player starting the match, which must be the match’s
+  `creator`.
+
+- `credentials`: that player’s authentication token.
+
+Responds `403` if the player is not the creator or the credentials do not match,
+and `409` if the match is already running.
+
+#### Using a LobbyClient instance
+
+```js
+await lobbyClient.startMatch('tic-tac-toe', 'matchID', {
+  playerID: '0',
+  credentials: 'playerCredentials',
+});
 ```
 
 ### Updating a player’s metadata

--- a/docs/documentation/plugins.md
+++ b/docs/documentation/plugins.md
@@ -145,9 +145,15 @@ players: {
 The initial values of these states are determined by the `setup` function in its options object, which creates the state for a particular `playerID`.
 
 The record associated with the current player can be accessed
-via `ctx.player.get()`. If this is a 2 player game,
-then the opponent's record is available using `ctx.player.opponent.get()`. These fields can be modified using their corresponding
-`set()` versions.
+via `ctx.player.get()`. If the game declares itself to be for exactly two
+players — `minPlayers: 2` and `maxPlayers: 2` — then the opponent's record is
+available using `ctx.player.opponent.get()`. These fields can be modified using
+their corresponding `set()` versions.
+
+?> `opponent` follows what the game declares rather than how many players are in
+the match, because the declaration holds for the life of the match and the live
+count does not. A two-player game that declares neither bound does not get
+`opponent`.
 
 ```js
 ctx.player.get() // Get the current player's record.

--- a/src/lobby/client.test.ts
+++ b/src/lobby/client.test.ts
@@ -337,6 +337,30 @@ describe('LobbyClient', () => {
     test('validates body', testBasicBody(client.leaveMatch));
   });
 
+  describe('startMatch', () => {
+    test('calls `/games/:name/:id/start`', async () => {
+      await client.startMatch('tic-tac-toe', 'xyz', {
+        playerID: '0',
+        credentials: 'pwd',
+      });
+      expect(fetch).toHaveBeenCalledWith(`/games/tic-tac-toe/xyz/start`, {
+        method: 'post',
+        body: '{"playerID":"0","credentials":"pwd"}',
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    test('validates gameName', throwsWithInvalidGameName(client.startMatch));
+    test('validates matchID', throwsWithInvalidMatchID(client.startMatch));
+
+    test(
+      'throws without body',
+      throwsWithoutBody(() => client.startMatch('chess', 'id', undefined)),
+    );
+
+    test('validates body', testBasicBody(client.startMatch));
+  });
+
   describe('leaveSlot', () => {
     test('calls `/games/:name/:id/leaveSlot`', async () => {
       await client.leaveSlot('tic-tac-toe', 'xyz', {

--- a/src/lobby/client.ts
+++ b/src/lobby/client.ts
@@ -284,6 +284,42 @@ export class LobbyClient {
   }
 
   /**
+   * Start a match, settling its seats so play can begin.
+   *
+   * A match with a fixed number of seats starts itself once the last one is
+   * taken. This is for matches that can begin before every seat is filled,
+   * where only the player who created the match decides when that is.
+   * @param  gameName The match’s game type, e.g. 'tic-tac-toe'.
+   * @param  matchID  Match ID for the match to start.
+   * @param  body     Options required to start the match.
+   * @param  init     Optional RequestInit interface to override defaults.
+   * @return Promise resolves if successful.
+   *
+   * @example
+   * lobbyClient.startMatch('tic-tac-toe', 'xyz', {
+   *   playerID: '0',
+   *   credentials: 'credentials-returned-when-joining',
+   * })
+   *   .then(() => console.log('Match started.'))
+   *   .catch(error => console.error('Error starting match', error));
+   */
+  async startMatch(
+    gameName: string,
+    matchID: string,
+    body: {
+      playerID: string;
+      credentials: string;
+      [key: string]: any;
+    },
+    init?: RequestInit,
+  ): Promise<void> {
+    assertGameName(gameName);
+    assertMatchID(matchID);
+    validateBody(body, { playerID: 'string', credentials: 'string' });
+    await this.post(`/games/${gameName}/${matchID}/start`, { body, init });
+  }
+
+  /**
    * Leave a previously joined lobby slot.
    * @param  gameName The match’s game type, e.g. 'tic-tac-toe'.
    * @param  matchID  Match ID for the match to leave.

--- a/src/lobby/connection.test.ts
+++ b/src/lobby/connection.test.ts
@@ -19,6 +19,7 @@ describe('lobby', () => {
     match1 = {
       gameName: 'game1',
       matchID: 'matchID_1',
+      status: 'open',
       players: [{ id: 0 }],
       createdAt: 1,
       updatedAt: 4,
@@ -26,6 +27,7 @@ describe('lobby', () => {
     match2 = {
       gameName: 'game2',
       matchID: 'matchID_2',
+      status: 'open',
       players: [{ id: 1 }],
       createdAt: 2,
       updatedAt: 3,

--- a/src/lobby/match-instance.tsx
+++ b/src/lobby/match-instance.tsx
@@ -19,6 +19,7 @@ type Match = {
   gameName: string;
   matchID: string;
   players: LobbyAPI.Match['players'];
+  status: LobbyAPI.Match['status'];
 };
 
 type MatchInstanceProps = {
@@ -88,16 +89,11 @@ class LobbyMatchInstance extends React.Component<MatchInstanceProps> {
       (player) => player.name === this.props.playerName,
     );
     const freeSeat = inst.players.find((player) => !player.name);
-    if (playerSeat && freeSeat) {
-      // already seated: waiting for match to start
-      return this._createButtonLeave(inst);
-    }
-    if (freeSeat) {
-      // at least 1 seat is available
-      return this._createButtonJoin(inst, freeSeat.id);
-    }
-    // match is full
+    // Already seated: wait while the match is open, play once it is running.
     if (playerSeat) {
+      if (inst.status === 'open') {
+        return this._createButtonLeave(inst);
+      }
       return (
         <div>
           {[
@@ -107,16 +103,17 @@ class LobbyMatchInstance extends React.Component<MatchInstanceProps> {
         </div>
       );
     }
+    // at least 1 seat is available
+    if (freeSeat) {
+      return this._createButtonJoin(inst, freeSeat.id);
+    }
     // allow spectating
     return this._createButtonSpectate(inst);
   };
 
   render() {
     const match = this.props.match;
-    let status = 'OPEN';
-    if (!match.players.some((player) => !player.name)) {
-      status = 'RUNNING';
-    }
+    const status = match.status === 'running' ? 'RUNNING' : 'OPEN';
     return (
       <tr key={'line-' + match.matchID}>
         <td key={'cell-name-' + match.matchID}>{match.gameName}</td>

--- a/src/lobby/react.test.tsx
+++ b/src/lobby/react.test.tsx
@@ -191,6 +191,7 @@ describe('lobby', () => {
               '1': { id: 1 },
             },
             gameName: 'GameName1',
+            status: 'open' as const,
           },
         ];
         act(() => {
@@ -395,6 +396,7 @@ describe('lobby', () => {
             matchID: 'matchID1',
             players: { '0': { id: 0 } },
             gameName: 'GameName1',
+            status: 'open' as const,
           },
         ];
         forceLobbyUpdate();
@@ -459,11 +461,13 @@ describe('lobby', () => {
             matchID: 'matchID1',
             players: { '0': { id: 0 } },
             gameName: 'GameName1',
+            status: 'open' as const,
           },
           {
             matchID: 'matchID2',
             players: { '0': { id: 0, name: 'Bob' } },
             gameName: 'GameName1',
+            status: 'running' as const,
           },
         ];
         forceLobbyUpdate();
@@ -521,6 +525,7 @@ describe('lobby', () => {
               '1': { id: 1 },
             },
             gameName: 'GameName1',
+            status: 'open' as const,
           },
         ];
         forceLobbyUpdate();
@@ -560,21 +565,25 @@ describe('lobby', () => {
               '1': { id: 1, name: 'Charly', credentials: 'SECRET2' },
             },
             gameName: 'GameName1',
+            status: 'running' as const,
           },
           {
             matchID: 'matchID2',
             players: { '0': { id: 0, name: 'Alice' } },
             gameName: 'GameName2',
+            status: 'running' as const,
           },
           {
             matchID: 'matchID3',
             players: { '0': { id: 0, name: 'Bob' } },
             gameName: 'GameName3',
+            status: 'running' as const,
           },
           {
             matchID: 'matchID4',
             players: { '0': { id: 0, name: 'Zoe' } },
             gameName: 'GameNameUnknown',
+            status: 'running' as const,
           },
         ];
         forceLobbyUpdate();
@@ -643,6 +652,7 @@ describe('lobby', () => {
               '1': { id: 1, name: 'Charly', credentials: 'SECRET2' },
             },
             gameName: 'GameName1',
+            status: 'running' as const,
           },
         ];
         forceLobbyUpdate();

--- a/src/lobby/react.tsx
+++ b/src/lobby/react.tsx
@@ -312,11 +312,11 @@ class Lobby extends React.Component<LobbyProps, LobbyState> {
     playerName: string,
   ) => {
     return matches.map((match) => {
-      const { matchID, gameName, players } = match;
+      const { matchID, gameName, players, status } = match;
       return (
         <LobbyMatchInstance
           key={'instance-' + matchID}
-          match={{ matchID, gameName, players: Object.values(players) }}
+          match={{ matchID, gameName, status, players: Object.values(players) }}
           playerName={playerName}
           onClickJoin={this._joinMatch}
           onClickLeave={this._leaveMatch}

--- a/src/plugins/plugin-player.test.ts
+++ b/src/plugins/plugin-player.test.ts
@@ -40,6 +40,11 @@ describe('2 player game', () => {
 
   beforeAll(() => {
     const game: Game<any, { player: PlayerAPI }> = {
+      // `player.opponent` follows what the game declares, so a game that uses
+      // it has to say it is for exactly two players.
+      minPlayers: 2,
+      maxPlayers: 2,
+
       moves: {
         A: ({ player }) => {
           player.set({ field: 'A1' });

--- a/src/plugins/plugin-player.ts
+++ b/src/plugins/plugin-player.ts
@@ -54,7 +54,7 @@ const PlayerPlugin = <PlayerState extends any = any>({
     return { players: api.state };
   },
 
-  api: ({ ctx, data }): PlayerAPI => {
+  api: ({ ctx, game, data }): PlayerAPI => {
     const state = data.players;
 
     const get = () => {
@@ -67,7 +67,9 @@ const PlayerPlugin = <PlayerState extends any = any>({
 
     const result: PlayerAPI = { state, get, set };
 
-    if (ctx.numPlayers === 2) {
+    // What the game declared holds for the life of the match; the number of
+    // players in it right now does not.
+    if (game.minPlayers === 2 && game.maxPlayers === 2) {
       const other = ctx.currentPlayer === '0' ? '1' : '0';
       const get = () => {
         return data.players[other];

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -523,6 +523,20 @@ describe('.configureRouter', () => {
             });
           });
 
+          test('records the first player to sit down as the creator', async () => {
+            expect(db.mocks.setMetadata).toHaveBeenCalledWith(
+              '1',
+              expect.objectContaining({ creator: 0 }),
+            );
+          });
+
+          test('starts the match once the last seat is taken', async () => {
+            expect(db.mocks.setMetadata).toHaveBeenCalledWith(
+              '1',
+              expect.objectContaining({ status: 'running' }),
+            );
+          });
+
           describe('when custom data is provided', () => {
             beforeEach(async () => {
               const app = createApiServer({ db, auth, games });
@@ -622,6 +636,75 @@ describe('.configureRouter', () => {
           });
         });
 
+        describe('when a seat is left free', () => {
+          beforeEach(async () => {
+            db = new AsyncStorage({
+              fetch: async () => ({
+                metadata: {
+                  gameName: 'foo',
+                  players: { '0': { id: 0 }, '1': { id: 1 } },
+                  status: 'open',
+                  createdAt: 0,
+                  updatedAt: 0,
+                } as Server.MatchData,
+              }),
+            });
+            const app = createApiServer({ db, auth, games });
+            response = await apiCall(app)
+              .post('/games/foo/1/join')
+              .send({ playerID: 0, playerName: 'alice' });
+          });
+
+          test('is successful', async () => {
+            expect(response.status).toEqual(200);
+          });
+
+          test('leaves the match open', async () => {
+            expect(db.mocks.setMetadata).toHaveBeenCalledWith(
+              '1',
+              expect.objectContaining({ status: 'open' }),
+            );
+          });
+        });
+
+        describe('when the last free seat is taken', () => {
+          beforeEach(async () => {
+            db = new AsyncStorage({
+              fetch: async () => ({
+                metadata: {
+                  gameName: 'foo',
+                  players: {
+                    '0': { id: 0, name: 'alice', credentials: 'SECRET' },
+                    '1': { id: 1 },
+                  },
+                  status: 'open',
+                  creator: '0',
+                  createdAt: 0,
+                  updatedAt: 0,
+                } as Server.MatchData,
+              }),
+            });
+            const app = createApiServer({ db, auth, games });
+            response = await apiCall(app)
+              .post('/games/foo/1/join')
+              .send({ playerID: 1, playerName: 'bob' });
+          });
+
+          test('starts the match', async () => {
+            expect(db.mocks.setMetadata).toHaveBeenCalledWith(
+              '1',
+              expect.objectContaining({ status: 'running' }),
+            );
+          });
+
+          test('leaves the original creator in place', async () => {
+            expect(db.mocks.setMetadata).toHaveBeenCalledWith(
+              '1',
+              expect.objectContaining({ creator: '0' }),
+            );
+          });
+        });
+
         describe('when playerName is omitted', () => {
           beforeEach(async () => {
             const app = createApiServer({ db, auth, games });
@@ -662,6 +745,167 @@ describe('.configureRouter', () => {
             expect(response.status).toEqual(409);
           });
         });
+      });
+    });
+  });
+
+  describe('starting a match', () => {
+    const auth = new Auth();
+    const games: Game[] = [ProcessGameConfig({ name: 'foo' })];
+    let db: AsyncStorage;
+    let response;
+
+    const storageHolding = (metadata: Partial<Server.MatchData> | null) =>
+      new AsyncStorage({
+        fetch: async () => ({
+          metadata:
+            metadata === null
+              ? null
+              : ({
+                  gameName: 'foo',
+                  players: {
+                    '0': { id: 0, name: 'alice', credentials: 'SECRET' },
+                    '1': { id: 1 },
+                  },
+                  status: 'open',
+                  creator: '0',
+                  createdAt: 0,
+                  updatedAt: 0,
+                  ...metadata,
+                } as Server.MatchData),
+        }),
+      });
+
+    const start = async (
+      body: Record<string, unknown>,
+      storage: AsyncStorage,
+      transport?: ReturnType<typeof createMatchTransport>['transport'],
+    ) => {
+      db = storage;
+      const app = createApiServer({ db, auth, games, transport });
+      return apiCall(app).post('/games/foo/1/start').send(body);
+    };
+
+    beforeEach(() => {
+      delete process.env.API_SECRET;
+    });
+
+    describe('when the creator starts it', () => {
+      let transportAPI: ReturnType<typeof createMatchTransport>['transportAPI'];
+
+      beforeEach(async () => {
+        const matchTransport = createMatchTransport();
+        transportAPI = matchTransport.transportAPI;
+        response = await start(
+          { playerID: '0', credentials: 'SECRET' },
+          storageHolding({}),
+          matchTransport.transport,
+        );
+      });
+
+      test('is successful', () => {
+        expect(response.status).toEqual(200);
+      });
+
+      test('marks the match as running', () => {
+        expect(db.mocks.setMetadata).toHaveBeenCalledWith(
+          '1',
+          expect.objectContaining({ status: 'running' }),
+        );
+      });
+
+      test('broadcasts the match data', () => {
+        expect(transportAPI.sendAll).toHaveBeenCalled();
+      });
+    });
+
+    describe('when a player who did not create it starts it', () => {
+      beforeEach(async () => {
+        response = await start(
+          { playerID: '1', credentials: 'OTHER' },
+          storageHolding({
+            players: {
+              '0': { id: 0, name: 'alice', credentials: 'SECRET' },
+              '1': { id: 1, name: 'bob', credentials: 'OTHER' },
+            },
+          }),
+        );
+      });
+
+      test('is forbidden', () => {
+        expect(response.status).toEqual(403);
+      });
+
+      test('leaves the match open', () => {
+        expect(db.mocks.setMetadata).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when the credentials are invalid', () => {
+      beforeEach(async () => {
+        response = await start(
+          { playerID: '0', credentials: 'WRONG' },
+          storageHolding({}),
+        );
+      });
+
+      test('is forbidden', () => {
+        expect(response.status).toEqual(403);
+      });
+    });
+
+    describe('when playerID is omitted', () => {
+      beforeEach(async () => {
+        response = await start({ credentials: 'SECRET' }, storageHolding({}));
+      });
+
+      test('is forbidden', () => {
+        expect(response.status).toEqual(403);
+      });
+    });
+
+    describe('when the match is already running', () => {
+      beforeEach(async () => {
+        response = await start(
+          { playerID: '0', credentials: 'SECRET' },
+          storageHolding({ status: 'running' }),
+        );
+      });
+
+      test('is a conflict', () => {
+        expect(response.status).toEqual(409);
+      });
+    });
+
+    describe('when the match was stored before status existed', () => {
+      beforeEach(async () => {
+        response = await start(
+          { playerID: '0', credentials: 'SECRET' },
+          storageHolding({
+            status: undefined,
+            players: {
+              '0': { id: 0, name: 'alice', credentials: 'SECRET' },
+              '1': { id: 1, name: 'bob', credentials: 'OTHER' },
+            },
+          }),
+        );
+      });
+
+      test('reads every seat being taken as already running', () => {
+        expect(response.status).toEqual(409);
+      });
+    });
+
+    describe('when the match does not exist', () => {
+      beforeEach(async () => {
+        response = await start(
+          { playerID: '0', credentials: 'SECRET' },
+          storageHolding(null),
+        );
+      });
+
+      test('is not found', () => {
+        expect(response.status).toEqual(404);
       });
     });
   });
@@ -1149,6 +1393,42 @@ describe('.configureRouter', () => {
             .post('/games/foo/1/leave')
             .send('playerID=0&playerName=alice');
           expect(response.status).toEqual(404);
+        });
+      });
+
+      describe('when a player leaves a running match', () => {
+        beforeEach(async () => {
+          db = new AsyncStorage({
+            fetch: async () => ({
+              metadata: {
+                ...createLeaveMetadata(),
+                status: 'running',
+                creator: '0',
+              } as Server.MatchData,
+            }),
+          });
+          const app = createApiServer({ db, auth, games });
+          response = await apiCall(app)
+            .post('/games/foo/1/leaveSlot')
+            .send('playerID=0&credentials=SECRET1');
+        });
+
+        test('is successful', async () => {
+          expect(response.status).toEqual(200);
+        });
+
+        test('opens the match again, since a seat is free', async () => {
+          expect(db.mocks.setMetadata).toHaveBeenCalledWith(
+            '1',
+            expect.objectContaining({ status: 'open' }),
+          );
+        });
+
+        test('hands the match to someone still seated', async () => {
+          expect(db.mocks.setMetadata).toHaveBeenCalledWith(
+            '1',
+            expect.objectContaining({ creator: '1' }),
+          );
         });
       });
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -12,7 +12,13 @@ import type Router from '@koa/router';
 import { bodyParser as koaBodyParser } from '@koa/bodyparser';
 import { nanoid } from 'nanoid';
 import cors from '@koa/cors';
-import { createMatch, getFirstAvailablePlayerID, getNumPlayers } from './util';
+import {
+  createMatch,
+  getFirstAvailablePlayerID,
+  getMatchStatus,
+  getNumPlayers,
+  isFull,
+} from './util';
 import type { Auth } from './auth';
 import type { Server, LobbyAPI, Game, StorageAPI } from '../types';
 import { Master } from '../master/master';
@@ -73,6 +79,7 @@ const createClientMatchData = (
   return {
     ...metadata,
     matchID,
+    status: getMatchStatus(metadata),
     players: Object.values(metadata.players).map((player) => {
       // strip away credentials
       const { credentials, ...strippedInfo } = player;
@@ -194,13 +201,27 @@ export const configureRouter = ({
 
     delete metadata.players[playerID].name;
     delete metadata.players[playerID].credentials;
-    const hasPlayers = Object.values(metadata.players).some(({ name }) => name);
-    if (hasPlayers) {
-      await db.setMetadata(matchID, metadata);
-      broadcastMatchData(matchID, metadata);
-    } else {
+
+    const remaining = Object.values(metadata.players).filter(
+      ({ name }) => name,
+    );
+    if (remaining.length === 0) {
       await db.wipe(matchID);
+      return;
     }
+
+    // This seat is free again, so the match is open whatever it was before.
+    // Leaving it running with an empty seat would change what the lobby shows
+    // for fixed-seat matches, which previously read occupancy directly.
+    metadata.status = 'open';
+
+    // The creator has left, so hand the match to whoever is still sitting.
+    if (metadata.creator === playerID) {
+      metadata.creator = String(remaining[0].id);
+    }
+
+    await db.setMetadata(matchID, metadata);
+    broadcastMatchData(matchID, metadata);
   };
 
   const clearPlayerSlotFromRequest = async (ctx: Koa.Context) => {
@@ -400,11 +421,64 @@ export const configureRouter = ({
     const playerCredentials = await auth.generateCredentials(ctx);
     metadata.players[playerID].credentials = playerCredentials;
 
+    // Whoever sits down first owns the match and may start it.
+    if (metadata.creator === undefined) {
+      metadata.creator = playerID;
+    }
+
+    // A match with a fixed number of seats starts itself once they are all
+    // taken, which is what the lobby used to infer from occupancy alone.
+    if (isFull(metadata.players)) {
+      metadata.status = 'running';
+    }
+
     await db.setMetadata(matchID, metadata);
     broadcastMatchData(matchID, metadata);
 
     const body: LobbyAPI.JoinedMatch = { playerID, playerCredentials };
     ctx.body = body;
+  });
+
+  /**
+   * Start a given match, settling its seats so play can begin.
+   *
+   * A match with a fixed number of seats starts itself when the last one is
+   * taken and never needs this. It exists for matches that can begin before
+   * every seat is filled, where only the creator decides when that is.
+   *
+   * @param {string} name - The name of the game.
+   * @param {string} id - The ID of the match.
+   * @param {string} playerID - The ID of the player starting the match.
+   * @param {string} credentials - The credentials of that player.
+   * @return - Nothing.
+   */
+  router.post('/games/:name/:id/start', bodyParser, async (ctx) => {
+    const matchID = ctx.params.id;
+    const gameName = ctx.params.name;
+    const playerID = (ctx.request.body as any)?.playerID;
+    const credentials = (ctx.request.body as any)?.credentials;
+
+    if (typeof playerID !== 'string') {
+      ctx.throw(403, 'playerID is required');
+    }
+
+    const metadata = await fetchMetadataForGame(ctx, matchID, gameName);
+    await authenticatePlayer(ctx, metadata, playerID, credentials);
+
+    if (metadata.creator !== undefined && metadata.creator !== playerID) {
+      ctx.throw(403, 'Player ' + playerID + ' did not create match ' + matchID);
+    }
+
+    if (getMatchStatus(metadata) === 'running') {
+      ctx.throw(409, 'Match ' + matchID + ' has already started');
+    }
+
+    metadata.status = 'running';
+
+    await db.setMetadata(matchID, metadata);
+    broadcastMatchData(matchID, metadata);
+
+    ctx.body = {};
   });
 
   /**

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -19,6 +19,7 @@ export const createMetadata = ({
     gameName: game.name,
     unlisted: !!unlisted,
     players: {},
+    status: 'open',
     createdAt: Date.now(),
     updatedAt: Date.now(),
   };
@@ -67,6 +68,25 @@ export const createMatch = ({
  */
 export const getNumPlayers = (players: Server.MatchData['players']): number =>
   Object.keys(players).length;
+
+/**
+ * Whether every seat in a match has been taken.
+ */
+export const isFull = (players: Server.MatchData['players']): boolean =>
+  Object.values(players).every((player) => !!player.name);
+
+/**
+ * The lobby lifecycle status of a match.
+ *
+ * Matches stored before `status` existed do not carry one, so fall back to the
+ * rule the lobby used to infer it with: a match is running once every seat has
+ * a name. That is only ever right for fixed-seat matches, which is exactly
+ * what every match predating this field is.
+ */
+export const getMatchStatus = (
+  metadata: Server.MatchData,
+): Server.MatchStatus =>
+  metadata.status ?? (isFull(metadata.players) ? 'running' : 'open');
 
 /**
  * Given players, tries to find the ID of the first player that can be joined.

--- a/src/types.ts
+++ b/src/types.ts
@@ -404,9 +404,23 @@ export namespace Server {
     isConnected?: boolean;
   };
 
+  /**
+   * Where a match is in the lobby's own lifecycle, which is not the game's:
+   * `running` means the seats are settled and play can begin, and says
+   * nothing about whether the game is over.
+   */
+  export type MatchStatus = 'open' | 'running';
+
   export interface MatchData {
     gameName: string;
     players: { [id: number]: PlayerMetadata };
+    /**
+     * Absent on matches stored before this field existed; read it through
+     * `getMatchStatus`, which falls back to seat occupancy for those.
+     */
+    status?: MatchStatus;
+    /** The player who may start the match: whoever joined it first. */
+    creator?: PlayerID;
     setupData?: any;
     gameover?: any;
     nextMatchID?: string;
@@ -426,9 +440,11 @@ export namespace Server {
 export namespace LobbyAPI {
   export type GameList = string[];
   type PublicPlayerMetadata = Omit<Server.PlayerMetadata, 'credentials'>;
-  export type Match = Omit<Server.MatchData, 'players'> & {
+  export type Match = Omit<Server.MatchData, 'players' | 'status'> & {
     matchID: string;
     players: PublicPlayerMetadata[];
+    /** Always present here: the server resolves it before responding. */
+    status: Server.MatchStatus;
   };
   export interface MatchList {
     matches: Match[];


### PR DESCRIPTION
Closes #1328.

`Server.MatchData` now carries `status: 'open' | 'running'` and `creator`, plus
`POST /games/{name}/{id}/start` and `LobbyClient.startMatch`. The seat-occupancy rule
is kept wherever it still applies, so a match with a fixed number of seats behaves
exactly as before.

### The lifecycle

| | `status` |
| --- | --- |
| created | `open` |
| last free seat taken | `running`, on its own |
| a seat freed again | `open`, and `creator` passes to a player still seated |
| creator calls `/start` | `running` |

`creator` is the first player to sit down, and starting the match is theirs alone —
`403` for anyone else or for bad credentials, `409` if it is already running.

### Two decisions worth flagging

**`status` is optional in storage, not required as the issue sketched it.** Matches
written before this field existed do not have one, so a required field would be a
claim about stored data that isn't true. Everything reads it through `getMatchStatus`,
which falls back to the old occupancy rule for those rows — always the right answer,
since every match predating the field has fixed seats. What goes over the wire is not
optional: `createClientMatchData` resolves it, so `LobbyAPI.Match['status']` is
required and the React lobby can rely on it.

**Freeing a seat reopens the match.** Otherwise a fixed-seat match that filled up and
then lost a player would sit at `running` with an empty seat, where the lobby used to
show it as open again. This is the piece #1327 will want to revisit: once a match can
be started deliberately, a leave should probably not undo that.

### plugin-player

`opponent` came from `ctx.numPlayers === 2`, which reads the seat count the match was
created with — it stops describing the match as soon as players can come and go, and
leaves `opponent` pointing at a fixed `'0'` or `'1'` that may be nobody. It now follows
`minPlayers` and `maxPlayers` both being 2, as the issue asks.

> [!WARNING]
> This is a breaking change. A two-player game that declares neither bound no longer
> gets `opponent`, and `player.opponent.set(...)` throws `Cannot read properties of
> undefined`. Declaring `minPlayers: 2` and `maxPlayers: 2` restores it. The plugin's
> own test game needed exactly that change, which is a fair sign real games will too —
> say the word if you would rather it fell back to `ctx.numPlayers` when a game
> declares neither, and I will add that.

### Not included

**The plugin-player hook.** `G.players` is still built from `ctx.numPlayers` at setup,
so a player seated after setup gets no entry. Fixing that needs a hook *and* a way to
be seated in the first place, and neither exists yet — that is #1327's to do.

**Creating at `minPlayers`.** The React create form already defaults `numPlayers` to
`minPlayers`, and re-defaults it when the selected game changes, so there was nothing
to change. It still lets you pick a larger number, which seemed worth keeping.

### Testing

`pnpm run lint`, `pnpm run ts`, `pnpm test` (43 suites / 923 tests, 1 todo) and
`pnpm run build` all pass. Twenty new tests cover the start endpoint (creator, wrong
player, bad credentials, missing playerID, already running, unknown match, and a match
stored before `status` existed), the creator and auto-start on join, the reopen and
creator handover on leave, and `LobbyClient.startMatch`.
